### PR TITLE
Allow version in info.yml files

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -20,7 +20,9 @@
   <arg value="p"/>
 
   <!-- Include existing standards. -->
-  <rule ref="Drupal"/>
+  <rule ref="Drupal">
+    <exclude name="Drupal.InfoFiles.AutoAddedKeys"/>
+  </rule>
   <rule ref="DrupalPractice">
     <!-- Ignore specific sniffs. -->
     <exclude name="DrupalPractice.InfoFiles.NamespacedDependency"/>


### PR DESCRIPTION
We're never going to push our code out into the wild, so we'll be adding our own `version` attributes to the modules, thank you very much. This commit suppresses the sniff which blocks commits of `.info.yml` files including that attribute.