### PR TITLE
Let the debugging IDE listen on port 9000 (#35)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,6 +126,9 @@ nbproject/*
 # PHPStorm
 atlassian-ide-plugin.xml
 
+# VS Code
+.vscode
+
 #NPM
 npm-debug.log
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -21,7 +21,6 @@ services:
       - ./docker.env
     ports:
       - "80:80"
-      - "9000:9000"
     networks:
       drupalvm:
     depends_on:


### PR DESCRIPTION
The way xdebug works, the debugging program listens on port 9000
and the xdebug service connects to that program over that port.
So we have to prevent docker from binding to the port so the
debugging program (e.g., PHPStorm) can listen on it. Removed
the mapping for port 9000 from docker/docker-compose.yml.

Also added .vscode to the .gitignore file.