### PR TITLE
Persist database via a named volume. (Possible fix for #15)

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -33,6 +33,7 @@ services:
     ## TODO: Map mysql data file directory to persit db compose down commands.
     volumes:
       - ./db/overrides/backups:/var/mysql/backups:delegated
+      - db:/var/lib/mysql
     env_file:
       - ./docker.env
     ports:
@@ -42,3 +43,6 @@ services:
 
 networks:
   drupalvm:
+
+volumes:
+  db:


### PR DESCRIPTION
The Docker Library project documents a problem with some versions of MariaDB
not starting correctly when a host system directory is mounted to /var/lib/mysql.
https://github.com/docker-library/mariadb/issues/38

It appears to work correctly when a named volume is used; at least,
it works on Windows.  This should be tested on OS/X as well
before being merged.