### PR TITLE
Bug/48 chrome missing

### DIFF
--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -54,6 +54,7 @@ RUN curl https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
   && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 # Install the chrome webdriver.
+# Using 'latest' in download URL no longer works, apparently.
 RUN CD_VERSION=2.44 && echo "Using chromedriver version: "$CD_VERSION \
   && curl -o /tmp/chromedriver_linux64.zip https://chromedriver.storage.googleapis.com/$CD_VERSION/chromedriver_linux64.zip \
   && rm -rf /opt/selenium/chromedriver \


### PR DESCRIPTION
See comment on ticket #48 describing a patch to `blt` needed to make the `behat` tests work. We may want to open a separate ticket for that, or you may prefer to have me fold that into this PR.

Fixes #48.