### PR TITLE
Enables the core block_content module.

### DIFF
--- a/docroot/profiles/custom/cgov_site/cgov_site.info.yml
+++ b/docroot/profiles/custom/cgov_site/cgov_site.info.yml
@@ -13,6 +13,7 @@ install:
   - dynamic_page_cache
   # from Standard
   - toolbar
+  - block_content
   - config
   - ckeditor
   - help


### PR DESCRIPTION

## Description 
Closes #148 

* Enables the block_content module for the the creation of custom content blocks. 