### PR TITLE
Fixes #130 - Add common dates to Home_Landing

### DIFF
--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/modules/cgov_home_landing/config/install/core.entity_form_display.node.cgov_home_landing.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/modules/cgov_home_landing/config/install/core.entity_form_display.node.cgov_home_landing.default.yml
@@ -5,12 +5,16 @@ dependencies:
     - field.field.node.cgov_home_landing.field_browser_title
     - field.field.node.cgov_home_landing.field_card_description
     - field.field.node.cgov_home_landing.field_card_title
+    - field.field.node.cgov_home_landing.field_date_display_mode
+    - field.field.node.cgov_home_landing.field_date_posted
+    - field.field.node.cgov_home_landing.field_date_reviewed
+    - field.field.node.cgov_home_landing.field_date_updated
     - field.field.node.cgov_home_landing.field_list_description
     - field.field.node.cgov_home_landing.field_page_description
     - field.field.node.cgov_home_landing.field_short_title
     - node.type.cgov_home_landing
   module:
-    - content_moderation
+    - datetime
     - path
 id: node.cgov_home_landing.default
 targetEntityType: node
@@ -46,6 +50,30 @@ content:
       placeholder: ''
     third_party_settings: {  }
     type: string_textfield
+    region: content
+  field_date_display_mode:
+    weight: 29
+    settings: {  }
+    third_party_settings: {  }
+    type: options_buttons
+    region: content
+  field_date_posted:
+    weight: 26
+    settings: {  }
+    third_party_settings: {  }
+    type: datetime_default
+    region: content
+  field_date_reviewed:
+    weight: 27
+    settings: {  }
+    third_party_settings: {  }
+    type: datetime_default
+    region: content
+  field_date_updated:
+    weight: 28
+    settings: {  }
+    third_party_settings: {  }
+    type: datetime_default
     region: content
   field_list_description:
     weight: 7

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/modules/cgov_home_landing/config/install/core.entity_view_display.node.cgov_home_landing.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/modules/cgov_home_landing/config/install/core.entity_view_display.node.cgov_home_landing.default.yml
@@ -5,11 +5,17 @@ dependencies:
     - field.field.node.cgov_home_landing.field_browser_title
     - field.field.node.cgov_home_landing.field_card_description
     - field.field.node.cgov_home_landing.field_card_title
+    - field.field.node.cgov_home_landing.field_date_display_mode
+    - field.field.node.cgov_home_landing.field_date_posted
+    - field.field.node.cgov_home_landing.field_date_reviewed
+    - field.field.node.cgov_home_landing.field_date_updated
     - field.field.node.cgov_home_landing.field_list_description
     - field.field.node.cgov_home_landing.field_page_description
     - field.field.node.cgov_home_landing.field_short_title
     - node.type.cgov_home_landing
   module:
+    - datetime
+    - options
     - user
 id: node.cgov_home_landing.default
 targetEntityType: node
@@ -39,6 +45,40 @@ content:
       link_to_entity: false
     third_party_settings: {  }
     type: string
+    region: content
+  field_date_display_mode:
+    weight: 111
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: list_default
+    region: content
+  field_date_posted:
+    weight: 108
+    label: above
+    settings:
+      format_type: medium
+      timezone_override: ''
+    third_party_settings: {  }
+    type: datetime_default
+    region: content
+  field_date_reviewed:
+    weight: 109
+    label: above
+    settings:
+      format_type: medium
+      timezone_override: ''
+    third_party_settings: {  }
+    type: datetime_default
+    region: content
+  field_date_updated:
+    weight: 110
+    label: above
+    settings:
+      format_type: medium
+      timezone_override: ''
+    third_party_settings: {  }
+    type: datetime_default
     region: content
   field_list_description:
     weight: 107

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/modules/cgov_home_landing/config/install/field.field.node.cgov_home_landing.field_date_display_mode.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/modules/cgov_home_landing/config/install/field.field.node.cgov_home_landing.field_date_display_mode.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_date_display_mode
+    - node.type.cgov_home_landing
+  module:
+    - options
+id: node.cgov_home_landing.field_date_display_mode
+field_name: field_date_display_mode
+entity_type: node
+bundle: cgov_home_landing
+label: 'Date Display Mode'
+description: 'Select which date to display. [Displays on page, beneath the body text. On lists, most recent date is displayed.]'
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/modules/cgov_home_landing/config/install/field.field.node.cgov_home_landing.field_date_posted.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/modules/cgov_home_landing/config/install/field.field.node.cgov_home_landing.field_date_posted.yml
@@ -1,0 +1,23 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_date_posted
+    - node.type.cgov_home_landing
+  module:
+    - datetime
+id: node.cgov_home_landing.field_date_posted
+field_name: field_date_posted
+entity_type: node
+bundle: cgov_home_landing
+label: 'Posted Date'
+description: 'Select which date to display. [Displays on page, beneath the body text. On lists, most recent date is displayed.]'
+required: true
+translatable: true
+default_value:
+  -
+    default_date_type: now
+    default_date: now
+default_value_callback: ''
+settings: {  }
+field_type: datetime

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/modules/cgov_home_landing/config/install/field.field.node.cgov_home_landing.field_date_reviewed.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/modules/cgov_home_landing/config/install/field.field.node.cgov_home_landing.field_date_reviewed.yml
@@ -1,0 +1,23 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_date_reviewed
+    - node.type.cgov_home_landing
+  module:
+    - datetime
+id: node.cgov_home_landing.field_date_reviewed
+field_name: field_date_reviewed
+entity_type: node
+bundle: cgov_home_landing
+label: 'Reviewed Date'
+description: 'Select which date to display. [Displays on page, beneath the body text. On lists, most recent date is displayed.]'
+required: true
+translatable: true
+default_value:
+  -
+    default_date_type: now
+    default_date: now
+default_value_callback: ''
+settings: {  }
+field_type: datetime

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/modules/cgov_home_landing/config/install/field.field.node.cgov_home_landing.field_date_updated.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/modules/cgov_home_landing/config/install/field.field.node.cgov_home_landing.field_date_updated.yml
@@ -1,0 +1,23 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_date_updated
+    - node.type.cgov_home_landing
+  module:
+    - datetime
+id: node.cgov_home_landing.field_date_updated
+field_name: field_date_updated
+entity_type: node
+bundle: cgov_home_landing
+label: 'Updated Date'
+description: 'Select which date to display. [Displays on page, beneath the body text. On lists, most recent date is displayed.]'
+required: true
+translatable: true
+default_value:
+  -
+    default_date_type: now
+    default_date: now
+default_value_callback: ''
+settings: {  }
+field_type: datetime


### PR DESCRIPTION
I'm not certain why content_moderation was there in `core.entity_form_display.node.cgov_home_landing.default.yml` , but it's being removed by the export process, so I left the removal there.