### PR TITLE
Issue #233 - Default web container to /var/www

### DIFF
--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -132,3 +132,6 @@ ENTRYPOINT ["docker-entrypoint.sh"]
 
 # If no command is passed to the container, start Apache by default.
 CMD ["apachectl", "-D", "FOREGROUND"]
+
+# Default to /var/www so we don't need to do it by hand.
+WORKDIR /var/www


### PR DESCRIPTION
Changes the `web` container's Dockerfile so login to the container defaults to `/var/www`.