### PR TITLE
Feature/141  page options block plugin

### DIFF
--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.services.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.services.yml
@@ -1,0 +1,3 @@
+services:
+  cgov_core.page_options_manager:
+    class: Drupal\cgov_core\Services\PageOptionsManager

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.services.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.services.yml
@@ -1,3 +1,4 @@
 services:
   cgov_core.page_options_manager:
     class: Drupal\cgov_core\Services\PageOptionsManager
+    arguments: ['@current_route_match']

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Plugin/Block/PageOptions.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Plugin/Block/PageOptions.php
@@ -4,7 +4,7 @@ namespace Drupal\cgov_core\Plugin\Block;
 
 use Drupal\Core\Block\BlockBase;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
-use Drupal\cgov_core\Services\PageOptionsManager;
+use Drupal\cgov_core\Services\PageOptionsManagerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Access\AccessResult;
@@ -36,7 +36,7 @@ class PageOptions extends BlockBase implements ContainerFactoryPluginInterface {
   /**
    * {@inheritdoc}
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, PageOptionsManager $po_manager) {
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, PageOptionsManagerInterface $po_manager) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->pageOptionsConfigs = $po_manager->getConfig();
   }

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Plugin/Block/PageOptions.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Plugin/Block/PageOptions.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Drupal\cgov_core\Plugin\Block;
+
+use Drupal\Core\Block\BlockBase;
+
+/**
+ * Cgov page options block.
+ *
+ * @Block(
+ *  id = "page_options",
+ *  admin_label = "Page Options Block for Cgov",
+ * )
+ */
+class PageOptionsBlock extends BlockBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build() {
+    return [
+      'example' => 'example',
+    ];
+  }
+
+}

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Plugin/Block/PageOptions.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Plugin/Block/PageOptions.php
@@ -19,6 +19,24 @@ class PageOptions extends BlockBase implements ContainerFactoryPluginInterface {
 
   public $currentNodeType = '';
 
+  private static $nodeOptions = [
+    'cgov_home_landing' => [
+      'print',
+      'email',
+      'facebook',
+      'twitter',
+      'pinterest',
+    ],
+    'cgov_article' => [
+      'resize',
+      'print',
+      'email',
+      'facebook',
+      'twitter',
+      'pinterest',
+    ],
+  ];
+
   private static $optionConfigs = [
     'facebook' => 'true',
     'twitter' => 'true',
@@ -63,34 +81,11 @@ class PageOptions extends BlockBase implements ContainerFactoryPluginInterface {
    * {@inheritdoc}
    */
   public function getPageOptionsForPageType($nodeType) {
-    $options = [];
-    switch ($nodeType) {
-      case 'cgov_article':
-        $options = [
-          'resize',
-          'print',
-          'email',
-          'facebook',
-          'twitter',
-          'pinterest',
-        ];
-        break;
-
-      case 'cgov_home_landing':
-        $options = [
-          'print',
-          'email',
-          'facebook',
-          'twitter',
-          'pinterest',
-        ];
-        break;
-
+    if (array_key_exists($nodeType, self::$nodeOptions)) {
+      $nodeOptions = self::$nodeOptions[$nodeType];
+      return self::getOptionsConfigMap($nodeOptions);
     }
-    if (count($options) > 0) {
-      $options = self::getOptionsConfigMap($options);
-    }
-    return $options;
+    return [];
   }
 
   /**

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Plugin/Block/PageOptions.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Plugin/Block/PageOptions.php
@@ -17,7 +17,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class PageOptions extends BlockBase implements ContainerFactoryPluginInterface {
 
-  public $poResult = [];
+  public $pageOptionsConfigs = [];
 
   /**
    * {@inheritdoc}
@@ -36,7 +36,7 @@ class PageOptions extends BlockBase implements ContainerFactoryPluginInterface {
    */
   public function __construct(array $configuration, $plugin_id, $plugin_definition, PageOptionsManager $po_manager) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
-    $this->poResult = $po_manager->getConfig();
+    $this->pageOptionsConfigs = $po_manager->getConfig();
   }
 
   /**
@@ -45,7 +45,7 @@ class PageOptions extends BlockBase implements ContainerFactoryPluginInterface {
   public function build() {
     return [
       '#type' => 'block',
-      'options' => $this->poResult,
+      'options' => $this->pageOptionsConfigs,
     ];
   }
 

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Plugin/Block/PageOptions.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Plugin/Block/PageOptions.php
@@ -19,6 +19,26 @@ class PageOptions extends BlockBase implements ContainerFactoryPluginInterface {
 
   public $currentNodeType = '';
 
+  private static $optionConfigs = [
+    'facebook' => 'true',
+    'twitter' => 'true',
+    'email' => 'true',
+    'resize' => 'true',
+    'print' => 'true',
+    'pinterest' => 'true',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  private static function getOptionsConfigMap($options) {
+    $optionConfigs = self::$optionConfigs;
+    $configMap = array_combine($options, array_map(function ($option) use ($optionConfigs) {
+      return $optionConfigs[$option];
+    }, $options));
+    return $configMap;
+  }
+
   /**
    * {@inheritdoc}
    */
@@ -43,15 +63,21 @@ class PageOptions extends BlockBase implements ContainerFactoryPluginInterface {
    * {@inheritdoc}
    */
   public function getPageOptionsForPageType($nodeType) {
+    $options = [];
     switch ($nodeType) {
       case 'cgov_article':
-        return ['article', 'page'];
+        $options = ['facebook', 'resize'];
+        break;
 
       case 'cgov_home_landing':
-        return ['home', 'landing'];
+        $options = ['email', 'twitter'];
+        break;
 
     }
-    return [];
+    if (count($options) > 0) {
+      $options = self::getOptionsConfigMap($options);
+    }
+    return $options;
   }
 
   /**
@@ -59,7 +85,8 @@ class PageOptions extends BlockBase implements ContainerFactoryPluginInterface {
    */
   public function build() {
     return [
-      '#options' => $this->getPageOptionsForPageType($this->currentNodeType),
+      '#type' => 'block',
+      'options' => $this->getPageOptionsForPageType($this->currentNodeType),
     ];
   }
 

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Plugin/Block/PageOptions.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Plugin/Block/PageOptions.php
@@ -66,11 +66,24 @@ class PageOptions extends BlockBase implements ContainerFactoryPluginInterface {
     $options = [];
     switch ($nodeType) {
       case 'cgov_article':
-        $options = ['facebook', 'resize'];
+        $options = [
+          'resize',
+          'print',
+          'email',
+          'facebook',
+          'twitter',
+          'pinterest',
+        ];
         break;
 
       case 'cgov_home_landing':
-        $options = ['email', 'twitter'];
+        $options = [
+          'print',
+          'email',
+          'facebook',
+          'twitter',
+          'pinterest',
+        ];
         break;
 
     }

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Plugin/Block/PageOptions.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Plugin/Block/PageOptions.php
@@ -17,9 +17,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class PageOptions extends BlockBase implements ContainerFactoryPluginInterface {
 
-  protected $routeMatch;
-
-  public $currentNodeType = 'test';
+  public $currentNodeType = '';
 
   /**
    * {@inheritdoc}
@@ -38,26 +36,22 @@ class PageOptions extends BlockBase implements ContainerFactoryPluginInterface {
    */
   public function __construct(array $configuration, $plugin_id, $plugin_definition, CurrentRouteMatch $route_match) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
-    $this->routeMatch = $route_match;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function getNodeType() {
-    $nid = '';
-    // $node = $this->routeMatch()->getParameter('node');
-    // if ($node instanceof NodeInterface) {
-    // $nid = $node->getType();
-    // }
-    return $nid;
+    $this->currentNodeType = $route_match->getParameter('node')->getType();
   }
 
   /**
    * {@inheritdoc}
    */
   public function getPageOptionsForPageType($nodeType) {
-    return $nodeType;
+    switch ($nodeType) {
+      case 'cgov_article':
+        return ['article', 'page'];
+
+      case 'cgov_home_landing':
+        return ['home', 'landing'];
+
+    }
+    return [];
   }
 
   /**

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Plugin/Block/PageOptions.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Plugin/Block/PageOptions.php
@@ -3,8 +3,6 @@
 namespace Drupal\cgov_core\Plugin\Block;
 
 use Drupal\Core\Block\BlockBase;
-use Drupal\Core\Routing\CurrentRouteMatch;
-use Drupal\node\NodeInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\cgov_core\Services\PageOptionsManager;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -19,52 +17,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class PageOptions extends BlockBase implements ContainerFactoryPluginInterface {
 
-  public $currentNodeType = '';
-  public $poResult = '';
-
-  private static $nodeOptions = [
-    'cgov_home_landing' => [
-      'print',
-      'email',
-      'facebook',
-      'twitter',
-      'pinterest',
-    ],
-    'cgov_article' => [
-      'resize',
-      'print',
-      'email',
-      'facebook',
-      'twitter',
-      'pinterest',
-    ],
-  ];
-
-  private static $optionConfigs = [
-    'facebook' => 'true',
-    'twitter' => 'true',
-    'email' => 'true',
-    'resize' => 'true',
-    'print' => 'true',
-    'pinterest' => 'true',
-  ];
-
-  /**
-   * Build array of page options configurations.
-   *
-   * @param array $options
-   *   Page options used on current node.
-   *
-   * @return array
-   *   An associative array of configurations
-   */
-  private static function getOptionsConfigMap(array $options) {
-    $optionConfigs = self::$optionConfigs;
-    $configMap = array_combine($options, array_map(function ($option) use ($optionConfigs) {
-      return $optionConfigs[$option];
-    }, $options));
-    return $configMap;
-  }
+  public $poResult = [];
 
   /**
    * {@inheritdoc}
@@ -74,7 +27,6 @@ class PageOptions extends BlockBase implements ContainerFactoryPluginInterface {
       $configuration,
       $plugin_id,
       $plugin_definition,
-      $container->get('current_route_match'),
       $container->get('cgov_core.page_options_manager')
     );
   }
@@ -82,36 +34,9 @@ class PageOptions extends BlockBase implements ContainerFactoryPluginInterface {
   /**
    * {@inheritdoc}
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, CurrentRouteMatch $route_match, PageOptionsManager $po_manager) {
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, PageOptionsManager $po_manager) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
-    $node = $route_match->getParameter('node');
-    if ($node instanceof NodeInterface) {
-      $this->currentNodeType = $node->getType();
-    }
     $this->poResult = $po_manager->getConfig();
-  }
-
-  /**
-   * Get page options config array for valid node types.
-   *
-   * If a given node type does not have registered page options
-   * configurations return an empty array. Otherwise return an
-   * associative array mapping the page option types to their
-   * individual configuration specifics.
-   *
-   * @param string $nodeType
-   *   The current node/page/view type:
-   *   - examples: cgov_article, cgov_home_landing, etc.
-   *
-   * @return array
-   *   An associative array of configuration specifics.
-   */
-  public function getPageOptionsForPageType(string $nodeType) {
-    if (array_key_exists($nodeType, self::$nodeOptions)) {
-      $nodeOptions = self::$nodeOptions[$nodeType];
-      return self::getOptionsConfigMap($nodeOptions);
-    }
-    return [];
   }
 
   /**
@@ -120,10 +45,7 @@ class PageOptions extends BlockBase implements ContainerFactoryPluginInterface {
   public function build() {
     return [
       '#type' => 'block',
-      'options' => $this->getPageOptionsForPageType($this->currentNodeType),
-      // This is a hack to replicate the behavior currently on the site for
-      // home and landing pages, which are exceptional.
-      'hasColumnsLayout' => $this->currentNodeType === 'cgov_home_landing' ? TRUE : FALSE,
+      'options' => $this->poResult,
     ];
   }
 

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Plugin/Block/PageOptions.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Plugin/Block/PageOptions.php
@@ -4,7 +4,9 @@ namespace Drupal\cgov_core\Plugin\Block;
 
 use Drupal\Core\Block\BlockBase;
 use Drupal\Core\Routing\CurrentRouteMatch;
+use Drupal\node\NodeInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\cgov_core\Services\PageOptionsManager;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -18,6 +20,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class PageOptions extends BlockBase implements ContainerFactoryPluginInterface {
 
   public $currentNodeType = '';
+  public $poResult = '';
 
   private static $nodeOptions = [
     'cgov_home_landing' => [
@@ -71,16 +74,21 @@ class PageOptions extends BlockBase implements ContainerFactoryPluginInterface {
       $configuration,
       $plugin_id,
       $plugin_definition,
-      $container->get('current_route_match')
+      $container->get('current_route_match'),
+      $container->get('cgov_core.page_options_manager')
     );
   }
 
   /**
    * {@inheritdoc}
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, CurrentRouteMatch $route_match) {
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, CurrentRouteMatch $route_match, PageOptionsManager $po_manager) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
-    $this->currentNodeType = $route_match->getParameter('node')->getType();
+    $node = $route_match->getParameter('node');
+    if ($node instanceof NodeInterface) {
+      $this->currentNodeType = $node->getType();
+    }
+    $this->poResult = $po_manager->getConfig();
   }
 
   /**

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Plugin/Block/PageOptions.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Plugin/Block/PageOptions.php
@@ -3,23 +3,69 @@
 namespace Drupal\cgov_core\Plugin\Block;
 
 use Drupal\Core\Block\BlockBase;
+use Drupal\Core\Routing\CurrentRouteMatch;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * Cgov page options block.
+ * Provides a block with page options.
  *
  * @Block(
  *  id = "page_options",
- *  admin_label = "Page Options Block for Cgov",
+ *  admin_label = "Page Options",
  * )
  */
-class PageOptionsBlock extends BlockBase {
+class PageOptions extends BlockBase implements ContainerFactoryPluginInterface {
+
+  protected $routeMatch;
+
+  public $currentNodeType = 'test';
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('current_route_match')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, CurrentRouteMatch $route_match) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->routeMatch = $route_match;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getNodeType() {
+    $nid = '';
+    // $node = $this->routeMatch()->getParameter('node');
+    // if ($node instanceof NodeInterface) {
+    // $nid = $node->getType();
+    // }
+    return $nid;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getPageOptionsForPageType($nodeType) {
+    return $nodeType;
+  }
 
   /**
    * {@inheritdoc}
    */
   public function build() {
     return [
-      'example' => 'example',
+      '#options' => $this->getPageOptionsForPageType($this->currentNodeType),
     ];
   }
 

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Plugin/Block/PageOptions.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Plugin/Block/PageOptions.php
@@ -6,6 +6,8 @@ use Drupal\Core\Block\BlockBase;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\cgov_core\Services\PageOptionsManager;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\Access\AccessResult;
 
 /**
  * Provides a block with page options.
@@ -37,6 +39,19 @@ class PageOptions extends BlockBase implements ContainerFactoryPluginInterface {
   public function __construct(array $configuration, $plugin_id, $plugin_definition, PageOptionsManager $po_manager) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->pageOptionsConfigs = $po_manager->getConfig();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function blockAccess(AccountInterface $account) {
+    if ($this->pageOptionsConfigs) {
+      // By default, the block is visible.
+      return AccessResult::allowed();
+    }
+    // Do not render block if page options config is empty
+    // (not a node or unrecognized node type)
+    return AccessResult::forbidden();
   }
 
   /**

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Plugin/Block/PageOptions.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Plugin/Block/PageOptions.php
@@ -47,9 +47,15 @@ class PageOptions extends BlockBase implements ContainerFactoryPluginInterface {
   ];
 
   /**
-   * {@inheritdoc}
+   * Build array of page options configurations.
+   *
+   * @param array $options
+   *   Page options used on current node.
+   *
+   * @return array
+   *   An associative array of configurations
    */
-  private static function getOptionsConfigMap($options) {
+  private static function getOptionsConfigMap(array $options) {
     $optionConfigs = self::$optionConfigs;
     $configMap = array_combine($options, array_map(function ($option) use ($optionConfigs) {
       return $optionConfigs[$option];
@@ -78,9 +84,21 @@ class PageOptions extends BlockBase implements ContainerFactoryPluginInterface {
   }
 
   /**
-   * {@inheritdoc}
+   * Get page options config array for valid node types.
+   *
+   * If a given node type does not have registered page options
+   * configurations return an empty array. Otherwise return an
+   * associative array mapping the page option types to their
+   * individual configuration specifics.
+   *
+   * @param string $nodeType
+   *   The current node/page/view type:
+   *   - examples: cgov_article, cgov_home_landing, etc.
+   *
+   * @return array
+   *   An associative array of configuration specifics.
    */
-  public function getPageOptionsForPageType($nodeType) {
+  public function getPageOptionsForPageType(string $nodeType) {
     if (array_key_exists($nodeType, self::$nodeOptions)) {
       $nodeOptions = self::$nodeOptions[$nodeType];
       return self::getOptionsConfigMap($nodeOptions);

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Plugin/Block/PageOptions.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Plugin/Block/PageOptions.php
@@ -113,6 +113,9 @@ class PageOptions extends BlockBase implements ContainerFactoryPluginInterface {
     return [
       '#type' => 'block',
       'options' => $this->getPageOptionsForPageType($this->currentNodeType),
+      // This is a hack to replicate the behavior currently on the site for
+      // home and landing pages, which are exceptional.
+      'hasColumnsLayout' => $this->currentNodeType === 'cgov_home_landing' ? TRUE : FALSE,
     ];
   }
 

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Services/PageOptionsManager.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Services/PageOptionsManager.php
@@ -39,12 +39,12 @@ class PageOptionsManager {
   ];
 
   private static $optionConfigs = [
-    'facebook' => 'true',
-    'twitter' => 'true',
-    'email' => 'true',
-    'resize' => 'true',
-    'print' => 'true',
-    'pinterest' => 'true',
+    'facebook' => TRUE,
+    'twitter' => TRUE,
+    'email' => TRUE,
+    'resize' => TRUE,
+    'print' => TRUE,
+    'pinterest' => TRUE,
   ];
 
   /**

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Services/PageOptionsManager.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Services/PageOptionsManager.php
@@ -3,20 +3,41 @@
 namespace Drupal\cgov_core\Services;
 
 use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\node\NodeInterface;
 
 /**
  * Page Options Manager Service.
  */
 class PageOptionsManager {
 
-  /**
-   * The route match.
-   *
-   * @var \Drupal\Core\Routing\RouteMatchInterface
-   */
-  protected $routeMatch;
+  protected $pageOptionsConfig = [];
 
-  protected $nodeType = '';
+  private static $nodeOptions = [
+    'cgov_home_landing' => [
+      'print',
+      'email',
+      'facebook',
+      'twitter',
+      'pinterest',
+    ],
+    'cgov_article' => [
+      'resize',
+      'print',
+      'email',
+      'facebook',
+      'twitter',
+      'pinterest',
+    ],
+  ];
+
+  private static $optionConfigs = [
+    'facebook' => 'true',
+    'twitter' => 'true',
+    'email' => 'true',
+    'resize' => 'true',
+    'print' => 'true',
+    'pinterest' => 'true',
+  ];
 
   /**
    * Constructs a new Page Options Manager Service class.
@@ -25,15 +46,59 @@ class PageOptionsManager {
    *   The route match.
    */
   public function __construct(RouteMatchInterface $route_match) {
-    $this->routeMatch = $route_match;
-    $this->nodeType = 'Test';
+    $currentNode = $route_match->getParameter('node');
+    if ($currentNode instanceof NodeInterface) {
+      $currentNodeType = $currentNode->getType();
+      $this->pageOptionsConfig = self::getPageOptionsForPageType($currentNodeType);
+    }
+
+  }
+
+  /**
+   * Build array of page options configurations.
+   *
+   * @param array $options
+   *   Page options used on current node.
+   *
+   * @return array
+   *   An associative array of configurations
+   */
+  private static function getOptionsConfigMap(array $options) {
+    $optionConfigs = self::$optionConfigs;
+    $configMap = array_combine($options, array_map(function ($option) use ($optionConfigs) {
+      return $optionConfigs[$option];
+    }, $options));
+    return $configMap;
+  }
+
+  /**
+   * Get page options config array for valid node types.
+   *
+   * If a given node type does not have registered page options
+   * configurations return an empty array. Otherwise return an
+   * associative array mapping the page option types to their
+   * individual configuration specifics.
+   *
+   * @param string $nodeType
+   *   The current node/page/view type:
+   *   - examples: cgov_article, cgov_home_landing, etc.
+   *
+   * @return array
+   *   An associative array of configuration specifics.
+   */
+  private static function getPageOptionsForPageType(string $nodeType) {
+    if (array_key_exists($nodeType, self::$nodeOptions)) {
+      $nodeOptions = self::$nodeOptions[$nodeType];
+      return self::getOptionsConfigMap($nodeOptions);
+    }
+    return [];
   }
 
   /**
    * {@inheritdoc}
    */
   public function getConfig() {
-    return $this->nodeType;
+    return $this->pageOptionsConfig;
   }
 
 }

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Services/PageOptionsManager.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Services/PageOptionsManager.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Drupal\cgov_core\Services;
+
+/**
+ * Page Options Manager Service.
+ */
+class PageOptionsManager {
+
+  protected $nodeType = '';
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct() {
+    $this->nodeType = 'Test';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getConfig() {
+    return $this->nodeType;
+  }
+
+}

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Services/PageOptionsManager.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Services/PageOptionsManager.php
@@ -8,7 +8,7 @@ use Drupal\node\NodeInterface;
 /**
  * Page Options Manager Service.
  */
-class PageOptionsManager {
+class PageOptionsManager implements PageOptionsManagerInterface {
 
   protected $pageOptionsConfig = [];
 

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Services/PageOptionsManager.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Services/PageOptionsManager.php
@@ -2,17 +2,30 @@
 
 namespace Drupal\cgov_core\Services;
 
+use Drupal\Core\Routing\RouteMatchInterface;
+
 /**
  * Page Options Manager Service.
  */
 class PageOptionsManager {
 
+  /**
+   * The route match.
+   *
+   * @var \Drupal\Core\Routing\RouteMatchInterface
+   */
+  protected $routeMatch;
+
   protected $nodeType = '';
 
   /**
-   * {@inheritdoc}
+   * Constructs a new Page Options Manager Service class.
+   *
+   * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
+   *   The route match.
    */
-  public function __construct() {
+  public function __construct(RouteMatchInterface $route_match) {
+    $this->routeMatch = $route_match;
     $this->nodeType = 'Test';
   }
 

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Services/PageOptionsManager.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Services/PageOptionsManager.php
@@ -12,6 +12,14 @@ class PageOptionsManager {
 
   protected $pageOptionsConfig = [];
 
+  /**
+   * TODO:.
+   *
+   * In future revisions, available options will be moved to the nodes
+   * themselves, rather than be hardcoded here.
+   *
+   * @var array
+   */
   private static $nodeOptions = [
     'cgov_home_landing' => [
       'print',

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Services/PageOptionsManagerInterface.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Services/PageOptionsManagerInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Drupal\cgov_core\Services;
+
+/**
+ * Undocumented interface.
+ */
+interface PageOptionsManagerInterface {
+
+  /**
+   * Get page options configuration array.
+   */
+  public function getConfig();
+
+}

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/tests/src/Unit/Plugin/Block/PageOptionsTest.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/tests/src/Unit/Plugin/Block/PageOptionsTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Drupal\Tests\cgov_core\Unit\Plugin\Block;
+
+use Drupal\Tests\UnitTestCase;
+use Drupal\cgov_core\Plugin\Block\PageOptions;
+use Drupal\cgov_core\Services\PageOptionsManager;
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+
+/**
+ * Tests Page Options Block Plugin.
+ *
+ * @group cgov_core
+ */
+class PageOptionsTest extends UnitTestCase {
+
+  protected $container;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+    $this->container = new ContainerBuilder();
+    \Drupal::setContainer($this->container);
+  }
+
+  /**
+   * Page Options block should make single call to service on setup.
+   */
+  public function testServiceCall() {
+    $mockService = $this->getMockBuilder(PageOptionsManager::class)
+      ->disableOriginalConstructor()
+      ->getMock();
+    $mockService->expects($this->once())
+      ->method('getConfig')
+      ->willReturn([]);
+    new PageOptions([], 'page_options', ['provider' => 'dummy_provider'], $mockService);
+  }
+
+}

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/tests/src/Unit/Plugin/Services/PageOptionsManagerTest.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/tests/src/Unit/Plugin/Services/PageOptionsManagerTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Drupal\Tests\cgov_core\Unit\Plugin\Services;
+
+use Drupal\Tests\UnitTestCase;
+use Drupal\cgov_core\Services\PageOptionsManager;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\node\NodeInterface;
+
+/**
+ * Tests Page Options Manager Service.
+ *
+ * @group cgov_core
+ */
+class PageOptionsManagerTest extends UnitTestCase {
+
+  /**
+   * Test service correct handles various node types.
+   *
+   * @dataProvider dataForTests
+   */
+  public function testGetConfig($given, $expected) {
+    $mockNodeInterface = $this->getMock(NodeInterface::class);
+    $mockNodeInterface->expects($this->any())
+      ->method('getType')
+      ->willReturn($given);
+    $mockRouteInterface = $this->getMock(RouteMatchInterface::class);
+    $mockRouteInterface->expects($this->any())
+      ->method('getParameter')
+      ->with('node')
+      ->willReturn($mockNodeInterface);
+    $pageOptionsManager = new PageOptionsManager($mockRouteInterface);
+    $pageOptionsConfig = $pageOptionsManager->getConfig();
+    $this->assertArrayEquals($pageOptionsConfig, $expected);
+
+  }
+
+  /**
+   * Test data for assertions.
+   *
+   * @return array
+   *   Test data.
+   */
+  public function dataForTests() {
+    return [
+      'no node' => [
+        '',
+        [],
+      ],
+      'article node' => [
+        'cgov_article',
+        [
+          'resize' => TRUE,
+          'print' => TRUE,
+          'email' => TRUE,
+          'facebook' => TRUE,
+          'twitter' => TRUE,
+          'pinterest' => TRUE,
+        ],
+      ],
+    ];
+  }
+
+}

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/block/page_options/block--page-options.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/block/page_options/block--page-options.html.twig
@@ -1,6 +1,7 @@
 <div class="page-options-container">
   <!-- PAGE OPTIONS -->
-  <div id="PageOptionsControl1" class="page-options no-resize {% if hasColumnsLayout %}large-5 columns{% endif %}">
+  {# TODO: Add back in support for home and landing "large-5 columns" #}
+  <div id="PageOptionsControl1" class="page-options no-resize">
     {% if content.options %}
       <ul>
         {% if content.options.resize %}

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/block/page_options/block--page-options.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/block/page_options/block--page-options.html.twig
@@ -1,6 +1,6 @@
 <div class="page-options-container">
   <!-- PAGE OPTIONS -->
-  <div id="PageOptionsControl1" class="page-options no-resize {{css-class}}">
+  <div id="PageOptionsControl1" class="page-options no-resize {% if hasColumnsLayout %}large-5 columns{% endif %}">
     {% if content.options %}
       <ul>
         {% if content.options.resize %}

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/block/page_options/block--page-options.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/block/page_options/block--page-options.html.twig
@@ -1,0 +1,2 @@
+<h1>PaGe OpTiOnS</h1>
+{{ content['#options'] }}

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/block/page_options/block--page-options.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/block/page_options/block--page-options.html.twig
@@ -2,7 +2,6 @@
   <!-- PAGE OPTIONS -->
   {# TODO: Add back in support for home and landing "large-5 columns" #}
   <div id="PageOptionsControl1" class="page-options no-resize">
-    {% if content.options %}
       <ul>
         {% if content.options.resize %}
           <li class="page-options--resize">
@@ -35,7 +34,6 @@
           </li>
         {% endif %}
       </ul>
-    {% endif %}
   </div>
   <!-- END PAGE OPTIONS -->
 </div>

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/block/page_options/block--page-options.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/block/page_options/block--page-options.html.twig
@@ -1,2 +1,40 @@
-<h1>PaGe OpTiOnS</h1>
-{{ content['#options'] }}
+<div class="page-options-container">
+  <!-- PAGE OPTIONS -->
+  <div id="PageOptionsControl1" class="page-options no-resize {{css-class}}">
+    {% if content.options %}
+      <ul>
+        {% if content.options.resize %}
+          <li class="page-options--resize">
+            <a title="Resize font" aria-label="Resize font" href="#"></a>
+          </li>
+        {% endif %}
+        {% if content.options.print %}
+          <li class="page-options--print">
+            <a title="Print" aria-label="Print" href="#"></a>
+          </li>
+        {% endif %}
+        {% if content.options.email %}
+          <li class="page-options--email">
+            <a title="Email" aria-label="Email" href="#"></a>
+          </li>
+        {% endif %}
+        {% if content.options.facebook %}
+          <li class="social-share social-share--facebook">
+            <a title="Facebook" aria-label="Facebook" href="#"></a>
+          </li>
+        {% endif %}
+        {% if content.options.twitter %}
+          <li class="social-share social-share--twitter">
+            <a title="Twitter" aria-label="Twitter" href="#"></a>
+          </li>
+        {% endif %}
+        {% if content.options.pinterest %}
+          <li class="social-share social-share--pinterest">
+            <a title="Pinterest" aria-label="Pinterest" href="#"></a>
+          </li>
+        {% endif %}
+      </ul>
+    {% endif %}
+  </div>
+  <!-- END PAGE OPTIONS -->
+</div>

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/article/node--cgov-article--full.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/article/node--cgov-article--full.html.twig
@@ -9,32 +9,6 @@
         <h1>
             {{ node.label }}
         </h1>
-        <div class="page-options-container">
-            <!-- PAGE OPTIONS -->
-            <div id="PageOptionsControl1" class="page-options no-resize ">
-                <ul>
-                    <li class="page-options--resize">
-                        <a title="Font Resizer" aria-label="Font Resizer" href="#"></a>
-                    </li>
-                    <li class="page-options--print">
-                        <a title="Print" aria-label="Print" href="#"></a>
-                    </li>
-                    <li class="page-options--email">
-                        <a title="Email" aria-label="Email" href="#"></a>
-                    </li>
-                    <li class="social-share social-share--facebook">
-                        <a title="Facebook" aria-label="Facebook" href="#"></a>
-                    </li>
-                    <li class="social-share social-share--twitter">
-                        <a title="Twitter" aria-label="Twitter" href="#"></a>
-                    </li>
-                    <li class="social-share social-share--pinterest">
-                        <a title="Pinterest" aria-label="Pinterest" href="#"></a>
-                    </li>
-                </ul>
-            </div>
-            <!-- END PAGE OPTIONS -->
-        </div>
         <div id="cgvBody">
             {# Article image will come from content.field-lead-image #}
             {{ content.field_lead_image }}


### PR DESCRIPTION
The following represents a first revision implementation of the custom Block Plugin and custom Service for Page Options. The service determines the current node type and returns an array of configuration associative arrays for the defined corresponding page options. The block plugin overrides the method blockAccess to allow for conditional rendering of the entire block without depending on a conditional in the twig template itself. The associated twig template in the cgov_common theme conditionally renders each page option type if a config object for it has been passed (future iterations will flesh the simple boolean out into a more complex array allowing for dynamic rendering of the constituent parts in the twig array (and subsequently, dynamic ordering)).