### PR TITLE
Ticket/269  add twig tweak module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
         "drupal/devel": "^1.2",
         "drupal/seckit": "^1.1",
         "drupal/shield": "^1.2",
+        "drupal/twig_tweak": "^2.1",
         "drupal/yaml_content": "1.x-dev",
         "drush/drush": "^9.0.0",
         "vlucas/phpdotenv": "^2.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "baf4c77bf7f80df036d7cc2ee9e8d388",
+    "content-hash": "07a5532fdbac7a56b19254a2df7501db",
     "packages": [
         {
             "name": "acquia/blt",
@@ -3229,6 +3229,61 @@
             "homepage": "https://www.drupal.org/project/shield",
             "support": {
                 "source": "http://cgit.drupalcode.org/shield"
+            }
+        },
+        {
+            "name": "drupal/twig_tweak",
+            "version": "2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupal.org/project/twig_tweak",
+                "reference": "8.x-2.1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/twig_tweak-8.x-2.1.zip",
+                "reference": "8.x-2.1",
+                "shasum": "ce1534d3270d916b55902c686057c0b5038d6b1d"
+            },
+            "require": {
+                "drupal/core": "~8.0"
+            },
+            "suggest": {
+                "symfony/var-dumper": "better dump() function for debugging Twig variables"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "branch-alias": {
+                    "dev-2.x": "2.x-dev"
+                },
+                "drupal": {
+                    "version": "8.x-2.1",
+                    "datestamp": "1531889025",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "Chi",
+                    "homepage": "https://www.drupal.org/user/556138"
+                }
+            ],
+            "description": "A Twig extension with some useful functions and filters for Drupal development.",
+            "homepage": "https://www.drupal.org/project/twig_tweak",
+            "keywords": [
+                "Drupal",
+                "Twig"
+            ],
+            "support": {
+                "source": "http://cgit.drupalcode.org/twig_tweak",
+                "issues": "https://www.drupal.org/project/issues/twig_tweak"
             }
         },
         {
@@ -8306,17 +8361,6 @@
         {
             "name": "webflo/drupal-core-require-dev",
             "version": "8.7.x-dev",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/webflo/drupal-core-require-dev.git",
-                "reference": "f551d0b71bbfd10444f5d8805ebf2052fb155a46"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/webflo/drupal-core-require-dev/zipball/f551d0b71bbfd10444f5d8805ebf2052fb155a46",
-                "reference": "f551d0b71bbfd10444f5d8805ebf2052fb155a46",
-                "shasum": ""
-            },
             "require": {
                 "behat/mink": "1.7.x-dev",
                 "behat/mink-goutte-driver": "^1.2",

--- a/docroot/profiles/custom/cgov_site/cgov_site.info.yml
+++ b/docroot/profiles/custom/cgov_site/cgov_site.info.yml
@@ -48,6 +48,7 @@ install:
   - admin_toolbar_links_access_filter
   # other
   - yaml_content
+  - twig_tweak
 themes:
   - cgov_common
   - cgov_admin

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/article/node--cgov-article--full.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/article/node--cgov-article--full.html.twig
@@ -9,6 +9,7 @@
         <h1>
             {{ node.label }}
         </h1>
+        {{ drupal_block('page_options') }}
         <div id="cgvBody">
             {# Article image will come from content.field-lead-image #}
             {{ content.field_lead_image }}
@@ -40,9 +41,9 @@
                             cancer. <i>Journal of Translational Medicine</i> 2009;7:11.</p> <a href="http://www.ncbi.nlm.nih.gov/pubmed/19175928">[PubMed
                             Abstract]</a>
                     </li>
-                </ol>                    
+                </ol>
             </div>
-        </div>                
+        </div>
         {{ content.field_related_resources }}
         <div id="cgvDate">
             <div class="document-dates horizontal">


### PR DESCRIPTION
The twig tweak library gives us a lot more flexibility for easily subverting the normal inheritance scheme of twig templates. This installs the module and uses it to insert the page options block into the node article template.