### PR TITLE
Add helper function to attach content types to workflow (closes #127)

### DIFF
--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.services.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.services.yml
@@ -4,4 +4,7 @@ services:
     arguments: ['@current_route_match']
   cgov_core.tools:
     class: Drupal\cgov_core\CgovCoreTools
-    arguments: ['@config.factory', '@language_negotiator']
+    arguments:
+      - '@config.factory'
+      - '@language_negotiator'
+      - '@entity_type.manager'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/CgovCoreTools.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/CgovCoreTools.php
@@ -3,6 +3,7 @@
 namespace Drupal\cgov_core;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Entity\EntityTypeManager;
 use Drupal\language\LanguageNegotiatorInterface;
 
 /**
@@ -25,6 +26,13 @@ class CgovCoreTools {
    * @var \Drupal\language\LanguageNegotiatorInterface
    */
   protected $negotiator;
+
+  /**
+   * The entity type manager.
+   *
+   * @var Drupal\Core\Entity\EntityTypeManager
+   */
+  protected $entityTypeManager;
 
   /**
    * Our Language Negotiation settings.
@@ -74,10 +82,18 @@ class CgovCoreTools {
    *   The factory for configuration objects.
    * @param \Drupal\language\LanguageNegotiatorInterface $negotiator
    *   The language negotiation methods manager.
+   * @param Drupal\Core\Entity\EntityTypeManager $entity_type_manager
+   *   Access to the workflow storage.
    */
-  public function __construct(ConfigFactoryInterface $config_factory, LanguageNegotiatorInterface $negotiator) {
+  public function __construct(
+      ConfigFactoryInterface $config_factory,
+      LanguageNegotiatorInterface $negotiator,
+      EntityTypeManager $entity_type_manager
+    ) {
+
     $this->negotiator = $negotiator;
     $this->configFactory = $config_factory;
+    $this->entityTypeManager = $entity_type_manager;
   }
 
   /**
@@ -108,6 +124,18 @@ class CgovCoreTools {
         $typeConf['enabled']
       );
     }
+  }
+
+  /**
+   * Links a content type to a workflow.
+   *
+   * See https://github.com/NCIOCPL/cgov-digital-platform/issues/127.
+   */
+  public function attachContentTypeToWorkflow($type_name, $workflow_name) {
+    $workflows = $this->entityTypeManager->getStorage('workflow')->loadMultiple();
+    $workflow = $workflows[$workflow_name];
+    $workflow->getTypePlugin()->addEntityTypeAndBundle('node', $type_name);
+    $workflow->save(TRUE);
   }
 
 }

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/tests/src/Kernel/WorkflowTest.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/tests/src/Kernel/WorkflowTest.php
@@ -89,11 +89,8 @@ class WorkflowTest extends KernelTestBase {
     $this->users['advanced']->addRole('content_author');
     $this->users['advanced']->addRole('content_editor');
     $this->users['advanced']->addRole('advanced_editor');
-    $entityTypeManager = $this->container->get('entity_type.manager');
-    $workflows = $entityTypeManager->getStorage('workflow')->loadMultiple();
-    $workflow = $workflows['editorial_workflow'];
-    $workflow->getTypePlugin()->addEntityTypeAndBundle('node', 'pony');
-    $workflow->save(TRUE);
+    $tools = $this->container->get('cgov_core.tools');
+    $tools->attachContentTypeToWorkflow('pony', 'editorial_workflow');
   }
 
   /**


### PR DESCRIPTION
I have included the test for this new method by modifying `WorkflowTest.php` to invoke it instead of loading the workflow through the entity type manager directly.

It seems to me that as time goes on and the `CgovCoreTools` class is expanded to support more and more functionality that the argument list for the constructor is going to get pretty unwieldy. Not only is this ungainly and a bit hard to read in the code, but it's somewhat inefficient as well. As I understand it, one of the selling points for dependency injection is that the services needed for a component are only loaded when they are needed. However, that advantage starts to unravel when you build an omnibus service which in turn might need one or two of a bunch of other services, depending on which method of the new service is being invoked. If I were King of the Forest, I think I might have designed an architecture which allowed the dependency container to be passed to the constructor and saved as a member of the service class, and have the `$container->get()` method invoked for the specific service(s) needed by each of the methods. But I don't see a way to do that with the way Drupal has things set up (if there is a way, please let me know). And I'm not KOTF, so ....