### PR TITLE
Fixes #200 Add Search Engine Restrictions field

### DIFF
--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/config/install/field.storage.node.field_search_engine_restrictions.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/config/install/field.storage.node.field_search_engine_restrictions.yml
@@ -1,0 +1,29 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - options
+  enforced:
+    module:
+      - cgov_core
+id: node.field_search_engine_restrictions
+field_name: field_search_engine_restrictions
+entity_type: node
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: IncludeSearch
+      label: 'Include in search'
+    -
+      value: ExcludeSearch
+      label: 'Exclude from search'
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: true
+custom_storage: false

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/tests/src/Kernel/FieldStorage/CGovFieldStorageTest.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/tests/src/Kernel/FieldStorage/CGovFieldStorageTest.php
@@ -84,6 +84,11 @@ class CGovFieldStorageTest extends KernelTestBase {
       "label" => "Date Display Mode",
       "type" => "list_string",
     ],
+    [
+      "name" => "field_search_engine_restrictions",
+      "label" => "Search Engine Restrictions",
+      "type" => "list_string",
+    ],
   ];
 
   /**


### PR DESCRIPTION
This matches the requirements of https://github.com/NCIOCPL/cgov-digital-platform/wiki/Common-Fields#search-engine-restrictions but the requirements are unusual.   I would expect this field to be a Boolean given the available options.   I heard it had additional options in the current implementation, and perhaps it will again (perhaps `Include in Site Search` and `Include in Internet Search` or something (though that may be better implemented as as `Site Search` boolean and an `Internet Search` boolean), so I have implemented it as listed.

If it is to be a boolean, the field name and labels should be changed accordingly so the display is not confusing (`[X] Search Engine Restrictions` would imply that there `are` restrictions, not that it should be included in the search).