### PR TITLE
Date display mode using preprocess approach

### DIFF
--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/cgov_common.theme
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/cgov_common.theme
@@ -5,3 +5,117 @@
  * Functions to support theming in the cgov_common theme.
  */
 
+ /**
+  * Date Display Mode.
+  *
+  * This is some classic Drupal contortionist work possibly better handled with
+  * a computed field value or a custom block in the future.
+  * In order to have three unassociated fields' display mode controlled by a
+  * fourth unassociated field's (this one) preprocess function, we need a way
+  * to both examine and render those fields outside the normal flow.
+  */
+function cgov_common_preprocess_field__field_date_display_mode(&$variables) {
+  $node = $variables['element']['#object'];
+  if (!$node) {
+    return;
+  }
+  // If there are no display modes this preprocess never runs. But
+  // leaving the guard clause anyway for the nonce.
+  if (!isset($variables['items']) || empty($variables['items'])) {
+    return;
+  }
+
+  // This is a mapping of the field machine name and content display text.
+  // Unfortunately the content display text needs to match and it's a string.
+  // Ugh.
+  // NB: The current sort method is stable, so in the case of two dates, being
+  // the same, the order of priority is determined by the order of this map.
+  // I.e., if all three date types are the same time stamp, field_date_reviewed
+  // will be the only one shown on an article page.
+  $dates = [
+    'Posted Date' => 'field_date_posted',
+    'Updated Date' => 'field_date_updated',
+    'Reviewed Date' => 'field_date_reviewed',
+  ];
+
+  // Retrieve date types selected for display.
+  // Also, if there are no display modes this preprocess never runs. but
+  // leaving the array type check anyway for the nonce.
+  $items = $variables['items'];
+  $availableModes = [];
+  foreach ($items as $item) {
+    $type = $item['content']['#markup'];
+    // Weird preferred php push method, not array declaration.
+    $availableModes[] = $type;
+  }
+
+  // Now we need to filter out the date types we don't want.
+  // (Based on the user selected date display modes).
+  $filteredDates = [];
+  foreach ($dates as $formattedDate => $machineName) {
+    $selectedDateType = in_array($formattedDate, $availableModes);
+    if ($selectedDateType) {
+      $filteredDates[$formattedDate] = $machineName;
+    }
+  };
+
+  // The date entities to pass to the render array.
+  // (They are not renderable in the twig template in their current state).
+  $dateEntities = [];
+  foreach ($filteredDates as $machineName) {
+    $dateEntities[$machineName] = $node->get($machineName);
+  }
+
+  // If it is an article, we need to retrieve the date values, sort them
+  // and remove all but the first.
+  $nodeType = $node->getType();
+  $isArticlePage = $nodeType === 'cgov_article';
+  if ($isArticlePage) {
+    // --------------------------------------------------------------------
+    // TODO: if() code should be an external function, taking and returning the
+    // $dateEntities array, for cleanness.
+    // --------------------------------------------------------------------
+    // 1. Create a multidimensional array including the date value for sorting.
+    $dateEntitiesWithValues = [];
+    foreach ($dateEntities as $machineName => $dateEntity) {
+      $dateEntitiesWithValues[] = [
+        $machineName,
+        $dateEntity,
+        // The following retrieves the DateTimeItem fromt he DateTimeItemList
+        // and then pulls it's datetime_iso8601 time for sorting, rather than
+        // the formatted value.
+        $dateEntity->get(0)->value,
+      ];
+    };
+
+    // 2. Sort (in place) according to datetime_iso8601 value ascending.
+    usort($dateEntitiesWithValues, function ($entity1, $entity2) {
+      $entity1UnixTime = strtotime($entity1[2]);
+      $entity2UnixTime = strtotime($entity2[2]);
+      if ($entity1UnixTime == $entity2UnixTime) {
+        return 0;
+      }
+      return ($entity1UnixTime > $entity2UnixTime) ? 1 : -1;
+    });
+
+    // 3. Retrieve most recent value after sort.
+    $mostRecentDate = array_pop($dateEntitiesWithValues);
+
+    // 4. Clear the $dateEntities array and replace most recent element only.
+    $dateEntities = [];
+    $mostRecentMachineName = $mostRecentDate[0];
+    $mostRecentDateEntity = $mostRecentDate[1];
+    $dateEntities[$mostRecentMachineName] = $mostRecentDateEntity;
+  }
+
+  // We want to render the date fields in the display field template,
+  // so we replace the entity with it's view here to render them.
+  // (Hopefully means it doesn't break translation this way,
+  // rather than passing values already formatted.)
+  foreach ($dateEntities as $machineName => $entity) {
+    $dateEntities[$machineName] = $dateEntities[$machineName]->view();
+  }
+
+  // Pass the renderable entities to the template.
+  $variables['dates'] = $dateEntities;
+}

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/article/node--cgov-article--full.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/article/node--cgov-article--full.html.twig
@@ -13,5 +13,7 @@
     </div>
     {# TODO: Article footer stuff has to go somewhere. TBD. #}
     <footer class="article-footer">
+      {# This will render the article date fields. #}
+      {{ content.field_date_display_mode }}
     </footer>
 </article>

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/field/field--field-date-display-mode.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/field/field--field-date-display-mode.html.twig
@@ -1,0 +1,3 @@
+{{ dates['field_date_posted'] }}
+{{ dates['field_date_updated'] }}
+{{ dates['field_date_reviewed'] }}


### PR DESCRIPTION
Handles #129.

This is definitely an approach worth reconsidering sooner or later, when we all get a bit more fluent in computed fields and plugins. It may well be a good way to go about it all told, but it's more than likely swimming upstream and not an ideal approach for replication.

The gist is as follows:

Setup:
A date display mode field exists that tracks what kinds of dates (posted, updated, reviewed) a content creator wants to appear on a piece of content. It is effectively a list of strings that match the formatted display text of the options in the editor ui. (This seems to be the crux of it, instead of a substantial link to the other field entities themselves, and is what requires a brittler approach).

Goal:
Be able to constrain the visible dates on certain content types (article in this case) by certain logical parameters.

Approach:
Do this using the field_date_display_mode preprocess function

Implementation:
First of all, the preprocess function is only called when the field is called in a twig template, so we need to at least include it in the node level template. 
Second of all, computed values in the preprocess function get passed to the render array, so they aren't available in the node template in a straightforward way. This means what we really want to do is nest the other fields' templates inside of the display mode one so they are appropriately only rendered conditionally based on the computed values. That's not so straightforward. The implementation I took here is to grab the date fields off the node, filter them if necessary, and then pass them through on the render array of the display mode. However, that wasn't sufficient. I found I needed to first call their 'view' method in order to have them render correctly (using the default templates at least - thereby hopefully not creating new translation problems). (The alternative was reaching onto the node from the twig template itself and wrapping the whole thing in conditionals based on the preprocess output, but this seemed dirtier since it split the logic between the preprocess and template. My approach keeps everything in the preprocess.)

Thirdly, I had to use a hard coded copy of the field_date_display_mode's formatted text in the preprocess function to be able to programmatically call and associate the field entities with the user selections in the field_date_display_mode. 
(Side note, using a stable sort method on the dates, the order of the elements in that array determines their priority in rendering when only one will be rendered but two selected dates are both equally recent. (PHP associative arrays are ordered, unlike JS)).

Lastly, don't merge this PR until I can strip out the in progress type comments!