### PR TITLE
Fix available moderation states for new translation (fixes #371)

### DIFF
--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.module
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.module
@@ -4,3 +4,22 @@
  * @file
  * Contains cgov_core.module.
  */
+
+use Drupal\Core\Entity\EntityInterface;
+
+/**
+ * Implements hook_entity_translation_create().
+ */
+function cgov_core_entity_translation_create(EntityInterface $translation) {
+  $serviceName = 'content_moderation.moderation_information';
+  $moderationInformation = \Drupal::service($serviceName);
+  if ($moderationInformation->isModeratedEntity($translation)) {
+    $workflow = $moderationInformation->getWorkflowForEntity($translation);
+    $configuration = $workflow->getTypePlugin()->getConfiguration();
+    $state = 'draft';
+    if (!empty($configuration['default_moderation_state'])) {
+      $state = $configuration['default_moderation_state'];
+    }
+    $translation->moderation_state = $state;
+  }
+}

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.module
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.module
@@ -14,8 +14,19 @@ use Drupal\node\NodeInterface;
  * Implements hook_entity_translation_create().
  *
  * Corrects the initial moderation state for a new translation.
+ * The hook is called when a new translation is created, giving us
+ * the opportunity to modify the object for that translation. We're
+ * setting the initial moderation state for the translation, and
+ * that in turn is used by the logic which determines which states
+ * are available when the new translation is save. The bug for which
+ * this workaround is implemented just copies the initial state from
+ * the current state of the original language. When the Drupal core
+ * team fixes https://www.drupal.org/project/drupal/issues/3021222,
+ * this workaround can be removed.
+ *
  * See https://github.com/NCIOCPL/cgov-digital-platform/issues/371
- * for more details.
+ * for more details about the bug and exactly what the software is
+ * doing.
  *
  * @var Drupal\Core\Entity\EntityInterface $translation
  *   The entity object for the new translation of a content object.

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/config/install/workflows.workflow.editorial_workflow.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/config/install/workflows.workflow.editorial_workflow.yml
@@ -62,7 +62,7 @@ type_settings:
         - draft
         - review
       to: draft
-      weight: -1
+      weight: -2
     back_to_editing:
       label: 'Back To Editing'
       from:
@@ -105,7 +105,7 @@ type_settings:
       from:
         - draft
       to: review
-      weight: -2
+      weight: -1
     request_review_pub:
       label: 'Request Review of Published Content'
       from:


### PR DESCRIPTION
This is my workaround for https://www.drupal.org/project/drupal/issues/3021222. I gave them the fix (though not as a patch with a new test). We'll see whether they get it into 8.7.0. If they do, the real fix should co-exist peacefully with our workaround until we are satisfied that we can drop it (this workaround, that is).

I noticed when I was testing the workaround that (after pulling down the latest mods from upstream) some, but not all of the moderation states are translated into Spanish. So "Published" becomes "Publicado" but we still have "Draft" and "Review." Seems like they have a ways to go sorting out the fine points of interactions between content translation and content moderation. 🤔

I also noticed that the order of the transitions determines the order of the available states in the dropdown, so I did a tiny bit of tweaking there.