### PR TITLE
Ticket/155 create press release content type

### DIFF
--- a/docroot/profiles/custom/cgov_site/cgov_site.info.yml
+++ b/docroot/profiles/custom/cgov_site/cgov_site.info.yml
@@ -36,6 +36,7 @@ install:
   - cgov_article
   - cgov_home_landing
   - cgov_content_block
+  - cgov_press_release
   # other Core
   - media
   - workflows

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/cgov_press_release.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/cgov_press_release.info.yml
@@ -5,4 +5,3 @@ description: 'The Press Release content type'
 core: 8.x
 dependencies:
   - cgov_core
-  - paragraphs_asymmetric_translation_widgets

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/cgov_press_release.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/cgov_press_release.info.yml
@@ -1,0 +1,8 @@
+name: 'CGov Press Release'
+type: module
+package: 'CGov Digital Platform'
+description: 'The Press Release content type'
+core: 8.x
+dependencies:
+  - cgov_core
+  - paragraphs_asymmetric_translation_widgets

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/cgov_press_release.install
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/cgov_press_release.install
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * @file
+ * Contains cgov_press_release.install.
+ */
+
+/**
+ * Implements hook_install().
+ *
+ * Perform actions to set up the site for this profile.
+ *
+ * @see system_install()
+ */
+function cgov_press_release_install() {
+  // Get our helper.
+  $siteHelper = \Drupal::service('cgov_core.tools');
+
+  // Add content type permissions.
+  $siteHelper->addContentTypePermissions('cgov_press_release', ['content_author']);
+  $siteHelper->attachContentTypeToWorkflow('cgov_press_release', 'editorial_workflow');
+
+}

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/cgov_press_release.module
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/cgov_press_release.module
@@ -1,0 +1,6 @@
+<?php
+
+/**
+ * @file
+ * Contains cgov_press_release.module.
+ */

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/core.base_field_override.node.cgov_press_release.promote.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/core.base_field_override.node.cgov_press_release.promote.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.cgov_press_release
+id: node.cgov_press_release.promote
+field_name: promote
+entity_type: node
+bundle: cgov_press_release
+label: 'Promoted to front page'
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/core.base_field_override.node.cgov_press_release.status.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/core.base_field_override.node.cgov_press_release.status.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.cgov_press_release
+id: node.cgov_press_release.status
+field_name: status
+entity_type: node
+bundle: cgov_press_release
+label: Published
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/core.entity_form_display.node.cgov_press_release.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/core.entity_form_display.node.cgov_press_release.default.yml
@@ -53,7 +53,7 @@ content:
     type: string_textfield
     region: content
   field_card_title:
-    weight: 6
+    weight: 5
     settings:
       size: 60
       placeholder: ''
@@ -109,7 +109,7 @@ content:
     type: string_textfield
     region: content
   field_page_description:
-    weight: 4
+    weight: 6
     settings:
       size: 60
       placeholder: ''
@@ -129,7 +129,7 @@ content:
     type: options_buttons
     region: content
   field_short_title:
-    weight: 5
+    weight: 4
     settings:
       size: 60
       placeholder: ''

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/core.entity_form_display.node.cgov_press_release.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/core.entity_form_display.node.cgov_press_release.default.yml
@@ -3,9 +3,13 @@ status: true
 dependencies:
   config:
     - field.field.node.cgov_press_release.body
+    - field.field.node.cgov_press_release.field_press_release_type
+    - field.field.node.cgov_press_release.field_sort_date
     - node.type.cgov_press_release
+    - workflows.workflow.editorial_workflow
   module:
     - content_moderation
+    - datetime
     - path
     - text
 id: node.cgov_press_release.default
@@ -28,6 +32,18 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  field_press_release_type:
+    weight: 122
+    settings: {  }
+    third_party_settings: {  }
+    type: options_select
+    region: content
+  field_sort_date:
+    weight: 123
+    settings: {  }
+    third_party_settings: {  }
+    type: datetime_default
+    region: content
   langcode:
     type: language_select
     weight: 2
@@ -76,6 +92,11 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+  translation:
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+    region: content
   uid:
     type: entity_reference_autocomplete
     weight: 5

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/core.entity_form_display.node.cgov_press_release.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/core.entity_form_display.node.cgov_press_release.default.yml
@@ -3,7 +3,19 @@ status: true
 dependencies:
   config:
     - field.field.node.cgov_press_release.body
+    - field.field.node.cgov_press_release.field_browser_title
+    - field.field.node.cgov_press_release.field_card_title
+    - field.field.node.cgov_press_release.field_date_display_mode
+    - field.field.node.cgov_press_release.field_date_posted
+    - field.field.node.cgov_press_release.field_date_reviewed
+    - field.field.node.cgov_press_release.field_date_updated
+    - field.field.node.cgov_press_release.field_feature_card_description
+    - field.field.node.cgov_press_release.field_intro_text
+    - field.field.node.cgov_press_release.field_list_description
+    - field.field.node.cgov_press_release.field_page_description
     - field.field.node.cgov_press_release.field_press_release_type
+    - field.field.node.cgov_press_release.field_search_engine_restrictions
+    - field.field.node.cgov_press_release.field_short_title
     - field.field.node.cgov_press_release.field_sort_date
     - node.type.cgov_press_release
     - workflows.workflow.editorial_workflow
@@ -19,7 +31,7 @@ mode: default
 content:
   body:
     type: text_textarea_with_summary
-    weight: 121
+    weight: 10
     settings:
       rows: 9
       summary_rows: 3
@@ -28,38 +40,124 @@ content:
     region: content
   created:
     type: datetime_timestamp
-    weight: 10
+    weight: 19
     region: content
     settings: {  }
     third_party_settings: {  }
+  field_browser_title:
+    weight: 3
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_card_title:
+    weight: 6
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_date_display_mode:
+    weight: 14
+    settings: {  }
+    third_party_settings: {  }
+    type: options_buttons
+    region: content
+  field_date_posted:
+    weight: 11
+    settings: {  }
+    third_party_settings: {  }
+    type: datetime_default
+    region: content
+  field_date_reviewed:
+    weight: 13
+    settings: {  }
+    third_party_settings: {  }
+    type: datetime_default
+    region: content
+  field_date_updated:
+    weight: 12
+    settings: {  }
+    third_party_settings: {  }
+    type: datetime_default
+    region: content
+  field_feature_card_description:
+    weight: 8
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_intro_text:
+    weight: 9
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+    type: text_textarea
+    region: content
+  field_list_description:
+    weight: 7
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_page_description:
+    weight: 4
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
   field_press_release_type:
-    weight: 122
+    weight: 16
     settings: {  }
     third_party_settings: {  }
     type: options_select
     region: content
+  field_search_engine_restrictions:
+    weight: 17
+    settings: {  }
+    third_party_settings: {  }
+    type: options_buttons
+    region: content
+  field_short_title:
+    weight: 5
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
   field_sort_date:
-    weight: 123
+    weight: 15
     settings: {  }
     third_party_settings: {  }
     type: datetime_default
     region: content
   langcode:
     type: language_select
-    weight: 2
+    weight: 0
     region: content
     settings:
       include_locked: true
     third_party_settings: {  }
   moderation_state:
     type: moderation_state_default
-    weight: 100
+    weight: 23
     settings: {  }
     region: content
     third_party_settings: {  }
   path:
     type: path
-    weight: 30
+    weight: 22
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -67,39 +165,39 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 15
+    weight: 20
     region: content
     third_party_settings: {  }
   status:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 120
+    weight: 24
     region: content
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 16
+    weight: 21
     region: content
     third_party_settings: {  }
   title:
     type: string_textfield
-    weight: -5
+    weight: 2
     region: content
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
   translation:
-    weight: 10
+    weight: 1
+    region: content
     settings: {  }
     third_party_settings: {  }
-    region: content
   uid:
     type: entity_reference_autocomplete
-    weight: 5
+    weight: 18
     settings:
       match_operator: CONTAINS
       size: 60

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/core.entity_form_display.node.cgov_press_release.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/core.entity_form_display.node.cgov_press_release.default.yml
@@ -1,0 +1,88 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.cgov_press_release.body
+    - node.type.cgov_press_release
+  module:
+    - content_moderation
+    - path
+    - text
+id: node.cgov_press_release.default
+targetEntityType: node
+bundle: cgov_press_release
+mode: default
+content:
+  body:
+    type: text_textarea_with_summary
+    weight: 121
+    settings:
+      rows: 9
+      summary_rows: 3
+      placeholder: ''
+    third_party_settings: {  }
+    region: content
+  created:
+    type: datetime_timestamp
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  moderation_state:
+    type: moderation_state_default
+    weight: 100
+    settings: {  }
+    region: content
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  promote:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 15
+    region: content
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 120
+    region: content
+    third_party_settings: {  }
+  sticky:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 16
+    region: content
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: -5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 5
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    region: content
+    third_party_settings: {  }
+hidden: {  }

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/core.entity_view_display.node.cgov_press_release.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/core.entity_view_display.node.cgov_press_release.default.yml
@@ -3,8 +3,12 @@ status: true
 dependencies:
   config:
     - field.field.node.cgov_press_release.body
+    - field.field.node.cgov_press_release.field_press_release_type
+    - field.field.node.cgov_press_release.field_sort_date
     - node.type.cgov_press_release
   module:
+    - datetime
+    - options
     - text
     - user
 id: node.cgov_press_release.default
@@ -18,6 +22,27 @@ content:
     weight: 101
     settings: {  }
     third_party_settings: {  }
+    region: content
+  content_moderation_control:
+    weight: -20
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+  field_press_release_type:
+    weight: 102
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: list_default
+    region: content
+  field_sort_date:
+    weight: 103
+    label: above
+    settings:
+      format_type: medium
+      timezone_override: ''
+    third_party_settings: {  }
+    type: datetime_default
     region: content
   links:
     weight: 100

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/core.entity_view_display.node.cgov_press_release.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/core.entity_view_display.node.cgov_press_release.default.yml
@@ -3,7 +3,19 @@ status: true
 dependencies:
   config:
     - field.field.node.cgov_press_release.body
+    - field.field.node.cgov_press_release.field_browser_title
+    - field.field.node.cgov_press_release.field_card_title
+    - field.field.node.cgov_press_release.field_date_display_mode
+    - field.field.node.cgov_press_release.field_date_posted
+    - field.field.node.cgov_press_release.field_date_reviewed
+    - field.field.node.cgov_press_release.field_date_updated
+    - field.field.node.cgov_press_release.field_feature_card_description
+    - field.field.node.cgov_press_release.field_intro_text
+    - field.field.node.cgov_press_release.field_list_description
+    - field.field.node.cgov_press_release.field_page_description
     - field.field.node.cgov_press_release.field_press_release_type
+    - field.field.node.cgov_press_release.field_search_engine_restrictions
+    - field.field.node.cgov_press_release.field_short_title
     - field.field.node.cgov_press_release.field_sort_date
     - node.type.cgov_press_release
   module:
@@ -28,12 +40,108 @@ content:
     settings: {  }
     third_party_settings: {  }
     region: content
+  field_browser_title:
+    weight: 110
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_card_title:
+    weight: 109
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_date_display_mode:
+    weight: 107
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: list_default
+    region: content
+  field_date_posted:
+    weight: 104
+    label: above
+    settings:
+      format_type: medium
+      timezone_override: ''
+    third_party_settings: {  }
+    type: datetime_default
+    region: content
+  field_date_reviewed:
+    weight: 105
+    label: above
+    settings:
+      format_type: medium
+      timezone_override: ''
+    third_party_settings: {  }
+    type: datetime_default
+    region: content
+  field_date_updated:
+    weight: 106
+    label: above
+    settings:
+      format_type: medium
+      timezone_override: ''
+    third_party_settings: {  }
+    type: datetime_default
+    region: content
+  field_feature_card_description:
+    weight: 112
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_intro_text:
+    weight: 113
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: text_default
+    region: content
+  field_list_description:
+    weight: 111
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_page_description:
+    weight: 115
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
   field_press_release_type:
     weight: 102
     label: above
     settings: {  }
     third_party_settings: {  }
     type: list_default
+    region: content
+  field_search_engine_restrictions:
+    weight: 114
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: list_default
+    region: content
+  field_short_title:
+    weight: 108
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
     region: content
   field_sort_date:
     weight: 103

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/core.entity_view_display.node.cgov_press_release.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/core.entity_view_display.node.cgov_press_release.default.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.cgov_press_release.body
+    - node.type.cgov_press_release
+  module:
+    - text
+    - user
+id: node.cgov_press_release.default
+targetEntityType: node
+bundle: cgov_press_release
+mode: default
+content:
+  body:
+    label: hidden
+    type: text_default
+    weight: 101
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+  links:
+    weight: 100
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+hidden:
+  langcode: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/core.entity_view_display.node.cgov_press_release.teaser.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/core.entity_view_display.node.cgov_press_release.teaser.yml
@@ -1,0 +1,30 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - field.field.node.cgov_press_release.body
+    - node.type.cgov_press_release
+  module:
+    - text
+    - user
+id: node.cgov_press_release.teaser
+targetEntityType: node
+bundle: cgov_press_release
+mode: teaser
+content:
+  body:
+    label: hidden
+    type: text_summary_or_trimmed
+    weight: 101
+    settings:
+      trim_length: 600
+    third_party_settings: {  }
+    region: content
+  links:
+    weight: 100
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+hidden:
+  langcode: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/field.field.node.cgov_press_release.body.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/field.field.node.cgov_press_release.body.yml
@@ -17,5 +17,5 @@ translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:
-  display_summary: true
+  display_summary: false
 field_type: text_with_summary

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/field.field.node.cgov_press_release.body.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/field.field.node.cgov_press_release.body.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.body
+    - node.type.cgov_press_release
+  module:
+    - text
+id: node.cgov_press_release.body
+field_name: body
+entity_type: node
+bundle: cgov_press_release
+label: Body
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  display_summary: true
+field_type: text_with_summary

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/field.field.node.cgov_press_release.field_browser_title.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/field.field.node.cgov_press_release.field_browser_title.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_browser_title
+    - node.type.cgov_press_release
+id: node.cgov_press_release.field_browser_title
+field_name: field_browser_title
+entity_type: node
+bundle: cgov_press_release
+label: 'Browser Title'
+description: 'Abbreviated version of page title that will appear on browser tabs and in search engine results. Browser titles are appended with National Cancer Institute automatically. [Displays in: Site-wide and external search results. SEO best practice – 42 characters including spaces and excluding NCI]'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/field.field.node.cgov_press_release.field_card_title.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/field.field.node.cgov_press_release.field_card_title.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_card_title
+    - node.type.cgov_press_release
+id: node.cgov_press_release.field_card_title
+field_name: field_card_title
+entity_type: node
+bundle: cgov_press_release
+label: 'Card Title'
+description: 'Leave blank for feature card team to fill in as needed. [Displays on: Home or Landing page Feature Card. SEO best practice – 45 characters including spaces]'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/field.field.node.cgov_press_release.field_date_display_mode.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/field.field.node.cgov_press_release.field_date_display_mode.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_date_display_mode
+    - node.type.cgov_press_release
+  module:
+    - options
+id: node.cgov_press_release.field_date_display_mode
+field_name: field_date_display_mode
+entity_type: node
+bundle: cgov_press_release
+label: 'Date Display Mode'
+description: 'Select which date to display. [Displays on page, beneath the body text. On lists, most recent date is displayed.]'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/field.field.node.cgov_press_release.field_date_posted.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/field.field.node.cgov_press_release.field_date_posted.yml
@@ -1,0 +1,23 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_date_posted
+    - node.type.cgov_press_release
+  module:
+    - datetime
+id: node.cgov_press_release.field_date_posted
+field_name: field_date_posted
+entity_type: node
+bundle: cgov_press_release
+label: 'Posted Date'
+description: 'Date the content was posted. Defaults to today''s date but can be overridden. '
+required: true
+translatable: true
+default_value:
+  -
+    default_date_type: now
+    default_date: now
+default_value_callback: ''
+settings: {  }
+field_type: datetime

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/field.field.node.cgov_press_release.field_date_reviewed.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/field.field.node.cgov_press_release.field_date_reviewed.yml
@@ -1,0 +1,23 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_date_reviewed
+    - node.type.cgov_press_release
+  module:
+    - datetime
+id: node.cgov_press_release.field_date_reviewed
+field_name: field_date_reviewed
+entity_type: node
+bundle: cgov_press_release
+label: 'Reviewed Date'
+description: 'Date that the content was last reviewed by subject matter expert. Defaults to today''s date but can be overridden.'
+required: true
+translatable: true
+default_value:
+  -
+    default_date_type: now
+    default_date: now
+default_value_callback: ''
+settings: {  }
+field_type: datetime

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/field.field.node.cgov_press_release.field_date_updated.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/field.field.node.cgov_press_release.field_date_updated.yml
@@ -1,0 +1,23 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_date_updated
+    - node.type.cgov_press_release
+  module:
+    - datetime
+id: node.cgov_press_release.field_date_updated
+field_name: field_date_updated
+entity_type: node
+bundle: cgov_press_release
+label: 'Updated Date'
+description: 'Date that changes were published to body text of page.'
+required: true
+translatable: true
+default_value:
+  -
+    default_date_type: now
+    default_date: now
+default_value_callback: ''
+settings: {  }
+field_type: datetime

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/field.field.node.cgov_press_release.field_feature_card_description.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/field.field.node.cgov_press_release.field_feature_card_description.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_feature_card_description
+    - node.type.cgov_press_release
+id: node.cgov_press_release.field_feature_card_description
+field_name: field_feature_card_description
+entity_type: node
+bundle: cgov_press_release
+label: 'Feature Card Description'
+description: 'Concise description for the page. [Displays on: Home/Landing page feature cards. SEO best practice – 75 characters including spaces]'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/field.field.node.cgov_press_release.field_intro_text.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/field.field.node.cgov_press_release.field_intro_text.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_intro_text
+    - node.type.cgov_press_release
+  module:
+    - text
+id: node.cgov_press_release.field_intro_text
+field_name: field_intro_text
+entity_type: node
+bundle: cgov_press_release
+label: 'Intro Text'
+description: 'Introductory text for the content on the page. [Displays above the body content; no character limit]'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text_long

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/field.field.node.cgov_press_release.field_list_description.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/field.field.node.cgov_press_release.field_list_description.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_list_description
+    - node.type.cgov_press_release
+id: node.cgov_press_release.field_list_description
+field_name: field_list_description
+entity_type: node
+bundle: cgov_press_release
+label: 'List Description'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/field.field.node.cgov_press_release.field_page_description.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/field.field.node.cgov_press_release.field_page_description.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_page_description
+    - node.type.cgov_press_release
+id: node.cgov_press_release.field_page_description
+field_name: field_page_description
+entity_type: node
+bundle: cgov_press_release
+label: 'Meta Description'
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/field.field.node.cgov_press_release.field_press_release_type.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/field.field.node.cgov_press_release.field_press_release_type.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_press_release_type
+    - node.type.cgov_press_release
+  module:
+    - options
+id: node.cgov_press_release.field_press_release_type
+field_name: field_press_release_type
+entity_type: node
+bundle: cgov_press_release
+label: 'Press Release Type'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/field.field.node.cgov_press_release.field_search_engine_restrictions.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/field.field.node.cgov_press_release.field_search_engine_restrictions.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_search_engine_restrictions
+    - node.type.cgov_press_release
+  module:
+    - options
+id: node.cgov_press_release.field_search_engine_restrictions
+field_name: field_search_engine_restrictions
+entity_type: node
+bundle: cgov_press_release
+label: 'Search Engine Restrictions'
+description: ''
+required: true
+translatable: true
+default_value:
+  -
+    value: IncludeSearch
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/field.field.node.cgov_press_release.field_short_title.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/field.field.node.cgov_press_release.field_short_title.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_short_title
+    - node.type.cgov_press_release
+id: node.cgov_press_release.field_short_title
+field_name: field_short_title
+entity_type: node
+bundle: cgov_press_release
+label: 'Short Title'
+description: 'Short title for the page. [Displays on: CTHP Research Cards, Social Media Sharing, Compact Lists, and when Browser Title or Card Title is blank. SEO best practice – 45 characters including spaces]'
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/field.field.node.cgov_press_release.field_sort_date.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/field.field.node.cgov_press_release.field_sort_date.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_sort_date
+    - node.type.cgov_press_release
+  module:
+    - datetime
+id: node.cgov_press_release.field_sort_date
+field_name: field_sort_date
+entity_type: node
+bundle: cgov_press_release
+label: 'Sort Date'
+description: 'Select the date to be used to sort content. This date will override the posted date (for sorting).'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: datetime

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/field.storage.node.field_press_release_type.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/field.storage.node.field_press_release_type.yml
@@ -4,6 +4,9 @@ dependencies:
   module:
     - node
     - options
+  enforced:
+    module:
+    - cgov_press_release
 id: node.field_press_release_type
 field_name: field_press_release_type
 entity_type: node

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/field.storage.node.field_press_release_type.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/field.storage.node.field_press_release_type.yml
@@ -1,0 +1,26 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - options
+id: node.field_press_release_type
+field_name: field_press_release_type
+entity_type: node
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: nci_press_release
+      label: 'NCI Press Release'
+    -
+      value: nci_news_note
+      label: 'NCI News Note'
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/field.storage.node.field_sort_date.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/field.storage.node.field_sort_date.yml
@@ -4,6 +4,9 @@ dependencies:
   module:
     - datetime
     - node
+  enforced:
+    module:
+    - cgov_press_release
 id: node.field_sort_date
 field_name: field_sort_date
 entity_type: node

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/field.storage.node.field_sort_date.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/field.storage.node.field_sort_date.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - datetime
+    - node
+id: node.field_sort_date
+field_name: field_sort_date
+entity_type: node
+type: datetime
+settings:
+  datetime_type: date
+module: datetime
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/language.content_settings.node.cgov_press_release.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/language.content_settings.node.cgov_press_release.yml
@@ -1,0 +1,15 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.cgov_press_release
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+id: node.cgov_press_release
+target_entity_type_id: node
+target_bundle: cgov_press_release
+default_langcode: site_default
+language_alterable: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/node.type.cgov_press_release.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/node.type.cgov_press_release.yml
@@ -1,0 +1,10 @@
+langcode: en
+status: true
+dependencies: {  }
+name: 'Press Release'
+type: cgov_press_release
+description: 'Press Release content page that supports some structured information, like citations and inline feature cards. This content is likely to be useful to other websites/parties.'
+help: ''
+new_revision: true
+preview_mode: 1
+display_submitted: false

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/node.type.cgov_press_release.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/node.type.cgov_press_release.yml
@@ -1,6 +1,10 @@
 langcode: en
 status: true
-dependencies: {  }
+dependencies:
+  enforced:
+    module:
+    - cgov_core
+    - cgov_press_release
 name: 'Press Release'
 type: cgov_press_release
 description: 'Press Release content page that supports some structured information, like citations and inline feature cards. This content is likely to be useful to other websites/parties.'


### PR DESCRIPTION
Closes #155.   Has not added common fields noted in ticket comments that have yet to be created.  If any default value for Sort Date should be set via hooks (comment on ticket and in #digital_platform), we should create a ticket for that.