### PR TITLE
Install chrome and fix behat's invocation of it (fixes #48)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -153,6 +153,9 @@
         "patches": {
             "drupal/core": {
                 "2599228 : Programmatically created translatable content type returns SQL error on content creation": "https://www.drupal.org/files/issues/2018-11-29/2599228-104.patch"
+            },
+            "acquia/blt": {
+                "NCIOCPL#48": "patches/blt/issue-48-fix-behat-chrome-invocation.patch"
             }
         },
         "drupal-scaffold": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0dd1209d3a16e9319338664caabab6ad",
+    "content-hash": "a83716b7fd75a8af9c8ad50ed58a187b",
     "packages": [
         {
             "name": "acquia/blt",
@@ -68,6 +68,9 @@
                 "composer-exit-on-patch-failure": true,
                 "branch-alias": {
                     "dev-master": "9.x-dev"
+                },
+                "patches_applied": {
+                    "NCIOCPL#48": "patches/blt/issue-48-fix-behat-chrome-invocation.patch"
                 }
             },
             "autoload": {
@@ -8555,6 +8558,11 @@
         {
             "name": "webflo/drupal-core-require-dev",
             "version": "8.7.x-dev",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webflo/drupal-core-require-dev.git",
+                "reference": "f551d0b71bbfd10444f5d8805ebf2052fb155a46"
+            },
             "require": {
                 "behat/mink": "1.7.x-dev",
                 "behat/mink-goutte-driver": "^1.2",

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -41,6 +41,28 @@ RUN DEBIAN_FRONTEND=noninteractive \
     vim \
     zip
 
+# Install google chrome (for some reason, tacking on gnupg to previous list failed).
+# https://github.com/NCIOCPL/cgov-digital-platform/issues/48
+# See also https://hub.docker.com/r/selenium/node-chrome/~/dockerfile/
+RUN apt install gnupg -y
+RUN curl https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+  && echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list \
+  && apt-get update -qqy \
+  && apt-get -qqy install google-chrome-stable \
+  && rm /etc/apt/sources.list.d/google-chrome.list \
+  && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+
+# Install the chrome webdriver.
+# Using 'latest' in download URL no longer works, apparently.
+RUN CD_VERSION=2.44 && echo "Using chromedriver version: "$CD_VERSION \
+  && curl -o /tmp/chromedriver_linux64.zip https://chromedriver.storage.googleapis.com/$CD_VERSION/chromedriver_linux64.zip \
+  && rm -rf /opt/selenium/chromedriver \
+  && unzip /tmp/chromedriver_linux64.zip -d /opt/selenium \
+  && rm /tmp/chromedriver_linux64.zip \
+  && mv /opt/selenium/chromedriver /opt/selenium/chromedriver-latest \
+  && chmod 755 /opt/selenium/chromedriver-latest \
+  && ln -fs /opt/selenium/chromedriver-latest /usr/bin/chromedriver
+
 # Set Timezone
 RUN ln -fs /usr/share/zoneinfo/America/New_York /etc/localtime && \
   dpkg-reconfigure --frontend noninteractive tzdata

--- a/patches/blt/issue-48-fix-behat-chrome-invocation.patch
+++ b/patches/blt/issue-48-fix-behat-chrome-invocation.patch
@@ -1,0 +1,11 @@
+--- vendor/acquia/blt/src/Robo/Commands/Tests/BehatCommand.php-dist	2018-12-28 14:59:44.000000000 -0500
++++ vendor/acquia/blt/src/Robo/Commands/Tests/BehatCommand.php	2018-12-28 15:00:37.000000000 -0500
+@@ -175,7 +175,7 @@
+     $this->logger->info("Launching headless chrome...");
+     $this->getContainer()
+       ->get('executor')
+-      ->execute("'$chrome_bin' --headless --disable-web-security --remote-debugging-port={$this->chromePort} {$this->chromeArgs} $chrome_host")
++      ->execute("'$chrome_bin' --no-sandbox --headless --disable-web-security --remote-debugging-port={$this->chromePort} {$this->chromeArgs} $chrome_host")
+       ->background(TRUE)
+       ->printOutput(TRUE)
+       ->printMetadata(TRUE)

--- a/patches/blt/issue-48-fix-behat-chrome-invocation.patch
+++ b/patches/blt/issue-48-fix-behat-chrome-invocation.patch
@@ -1,6 +1,8 @@
---- vendor/acquia/blt/src/Robo/Commands/Tests/BehatCommand.php-dist	2018-12-28 14:59:44.000000000 -0500
-+++ vendor/acquia/blt/src/Robo/Commands/Tests/BehatCommand.php	2018-12-28 15:00:37.000000000 -0500
-@@ -175,7 +175,7 @@
+diff --git a/src/Robo/Commands/Tests/BehatCommand.php b/src/Robo/Commands/Tests/BehatCommand.php
+index 3eca7c3e..ad58ee0e 100644
+--- a/src/Robo/Commands/Tests/BehatCommand.php
++++ b/src/Robo/Commands/Tests/BehatCommand.php
+@@ -175,7 +175,7 @@ protected function launchChrome() {
      $this->logger->info("Launching headless chrome...");
      $this->getContainer()
        ->get('executor')


### PR DESCRIPTION
I believe I have finally wrestled this one to the ground. I won't go into _all_ of the problems I ran into, but the highlights included very sketchy documentation (no information on how to generate the patch file or determine what the `--level` should be), next to no information provided when a patch fails, and the fact that `--dry-run` is useless when testing plugins (because there's no mechanism for `composer` to have the plugins say what they would do without doing it).

You have to run `composer cgov-clean` followed by `composer install` and then rebuild the containers. I did that, ran `blt setup` and then `blt tests:behat:run` and the `behat` tests ran and completed successfully.