### PR TITLE
Match default yaml to fields on article node

### DIFF
--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/article.content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/article.content.yml
@@ -5,7 +5,7 @@
   status: 1
   moderation_state:
     value: 'published'
-  body:
+  field_article_body:
     - format: "full_html"
       value: |
        <div class="rxbodyfield">
@@ -82,7 +82,7 @@
   status: 1
   moderation_state:
     value: 'published'
-  body:
+  field_article_body:
     - format: "full_html"
       value: |
         <div id="cgvBody">
@@ -147,7 +147,7 @@
   status: 1
   moderation_state:
     value: 'published'
-  body:
+  field_article_body:
     - format: "full_html"
       value: |
        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed vobis voluptatum perceptarum recordatio
@@ -180,7 +180,7 @@
   status: 1
   moderation_state:
     value: 'published'
-  body:
+  field_article_body:
     - format: "full_html"
       value: |
        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed vobis voluptatum perceptarum recordatio


### PR DESCRIPTION
Hotfix because article.content.yml was still referencing "body" on article node instead of new "field_article_body"