### PR TITLE
Feature/pdq summaries

### DIFF
--- a/docroot/profiles/custom/cgov_site/cgov_site.info.yml
+++ b/docroot/profiles/custom/cgov_site/cgov_site.info.yml
@@ -37,6 +37,7 @@ install:
   - cgov_home_landing
   - cgov_content_block
   - cgov_press_release
+  - pdq_cancer_information_summary
   # other Core
   - media
   - workflows

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.base_field_override.node.pdq_cancer_information_summary.promote.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.base_field_override.node.pdq_cancer_information_summary.promote.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.pdq_cancer_information_summary
+id: node.pdq_cancer_information_summary.promote
+field_name: promote
+entity_type: node
+bundle: pdq_cancer_information_summary
+label: 'Promoted to front page'
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.base_field_override.node.pdq_cancer_information_summary.status.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.base_field_override.node.pdq_cancer_information_summary.status.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.pdq_cancer_information_summary
+id: node.pdq_cancer_information_summary.status
+field_name: status
+entity_type: node
+bundle: pdq_cancer_information_summary
+label: Published
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_form_display.node.pdq_cancer_information_summary.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_form_display.node.pdq_cancer_information_summary.default.yml
@@ -1,0 +1,80 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.pdq_cancer_information_summary
+  module:
+    - content_moderation
+    - path
+  enforced:
+    module:
+    - cgov_core
+id: node.pdq_cancer_information_summary.default
+targetEntityType: node
+bundle: pdq_cancer_information_summary
+mode: default
+content:
+  created:
+    type: datetime_timestamp
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  moderation_state:
+    type: moderation_state_default
+    weight: 100
+    settings: {  }
+    region: content
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  promote:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 15
+    region: content
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 120
+    region: content
+    third_party_settings: {  }
+  sticky:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 16
+    region: content
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: -5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 5
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    region: content
+    third_party_settings: {  }
+hidden: {  }

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_form_display.node.pdq_cancer_information_summary.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_form_display.node.pdq_cancer_information_summary.default.yml
@@ -2,7 +2,9 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.node.pdq_cancer_information_summary.field_short_title
     - node.type.pdq_cancer_information_summary
+    - workflows.workflow.pdq_workflow
   module:
     - content_moderation
     - path
@@ -20,6 +22,14 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  field_short_title:
+    weight: 121
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
   langcode:
     type: language_select
     weight: 2

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_view_display.node.pdq_cancer_information_summary.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_view_display.node.pdq_cancer_information_summary.default.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.pdq_cancer_information_summary
+  module:
+    - user
+  enforced:
+    module:
+    - cgov_core
+id: node.pdq_cancer_information_summary.default
+targetEntityType: node
+bundle: pdq_cancer_information_summary
+mode: default
+content:
+  links:
+    weight: 100
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+hidden:
+  langcode: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_view_display.node.pdq_cancer_information_summary.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_view_display.node.pdq_cancer_information_summary.default.yml
@@ -2,6 +2,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.node.pdq_cancer_information_summary.field_short_title
     - node.type.pdq_cancer_information_summary
   module:
     - user
@@ -13,6 +14,19 @@ targetEntityType: node
 bundle: pdq_cancer_information_summary
 mode: default
 content:
+  content_moderation_control:
+    weight: -20
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+  field_short_title:
+    weight: 101
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
   links:
     weight: 100
     settings: {  }

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_view_display.node.pdq_cancer_information_summary.teaser.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_view_display.node.pdq_cancer_information_summary.teaser.yml
@@ -3,6 +3,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.teaser
+    - field.field.node.pdq_cancer_information_summary.field_short_title
     - node.type.pdq_cancer_information_summary
   module:
     - user
@@ -17,4 +18,5 @@ content:
     third_party_settings: {  }
     region: content
 hidden:
+  field_short_title: true
   langcode: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_view_display.node.pdq_cancer_information_summary.teaser.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_view_display.node.pdq_cancer_information_summary.teaser.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - node.type.pdq_cancer_information_summary
+  module:
+    - user
+id: node.pdq_cancer_information_summary.teaser
+targetEntityType: node
+bundle: pdq_cancer_information_summary
+mode: teaser
+content:
+  links:
+    weight: 100
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+hidden:
+  langcode: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/field.field.node.pdq_cancer_information_summary.field_short_title.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/field.field.node.pdq_cancer_information_summary.field_short_title.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_short_title
+    - node.type.pdq_cancer_information_summary
+id: node.pdq_cancer_information_summary.field_short_title
+field_name: field_short_title
+entity_type: node
+bundle: pdq_cancer_information_summary
+label: 'Short Title'
+description: 'Short title for the page. [Displays on: CTHP Research Cards, Social Media Sharing, Compact Lists, and when Browser Title or Card Title is blank. SEO best practice – 45 characters including spaces]'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/language.content_settings.node.pdq_cancer_information_summary.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/language.content_settings.node.pdq_cancer_information_summary.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.pdq_cancer_information_summary
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '1'
+id: node.pdq_cancer_information_summary
+target_entity_type_id: node
+target_bundle: pdq_cancer_information_summary
+default_langcode: site_default
+language_alterable: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/node.type.pdq_cancer_information_summary.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/node.type.pdq_cancer_information_summary.yml
@@ -1,0 +1,10 @@
+langcode: en
+status: true
+dependencies: {  }
+name: 'PDQ Cancer Information Summary'
+type: pdq_cancer_information_summary
+description: 'Contains the content of a single PDQ Cancer Information Summary.'
+help: ''
+new_revision: true
+preview_mode: 1
+display_submitted: false

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/pdq_cancer_information_summary.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/pdq_cancer_information_summary.info.yml
@@ -1,0 +1,8 @@
+name: 'PDQ Cancer Information Summary'
+type: module
+package: 'CGov Digital Platform'
+description: 'The PDQ Cancer Information Summary content type'
+core: 8.x
+dependencies:
+  - cgov_core
+  - paragraphs_asymmetric_translation_widgets

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/pdq_cancer_information_summary.install
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/pdq_cancer_information_summary.install
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * @file
+ * Contains pdq_cancer_information_summary.install.
+ */
+
+use Drupal\cgov_core\CgovCoreTools;
+
+/**
+ * Implements hook_install().
+ *
+ * Perform actions to set up the site for this profile.
+ *
+ * @see system_install()
+ */
+function pdq_cancer_information_summary_install() {
+  // Get our helper.
+  $siteHelper = \Drupal::service('cgov_core.tools');
+
+  // Add content type permissions and assign to workflow.
+  $siteHelper->addContentTypePermissions('pdq_cancer_information_summary', ['pdq_importer'], CgovCoreTools::DEFAULT_PERMISSIONS);
+  $siteHelper->attachContentTypeToWorkflow('pdq_cancer_information_summary', 'pdq_workflow');
+}

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/pdq_cancer_information_summary.module
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/pdq_cancer_information_summary.module
@@ -1,0 +1,6 @@
+<?php
+
+/**
+ * @file
+ * Contains pdq_cancer_information_summary.module.
+ */

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/tests/src/Functional/PDQSummaryTest.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/tests/src/Functional/PDQSummaryTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Drupal\Tests\cgov_site\Functional;
+
+use Drupal\Tests\SchemaCheckTestTrait;
+use Drupal\Tests\BrowserTestBase;
+
+/**
+ * Tests Functionality of the PDQ Cancer Information Summary content type.
+ *
+ * @group cgov
+ * @group cgov_site
+ */
+class PDQSummaryTest extends BrowserTestBase {
+
+  use SchemaCheckTestTrait;
+
+  protected $profile = 'cgov_site';
+
+  /**
+   * The admin user.
+   *
+   * @var \Drupal\user\UserInterface
+   */
+  protected $adminUser;
+
+  /*
+  Set up friendly names for the various fields as the generated IDs can be
+  rather confusing at first.
+   */
+  const PAGE_TITLE = 'edit-title-0-value';
+  const SHORT_TITLE = 'edit-field-short-title-0-value';
+
+  const SAVE_BUTTON = 'edit-submit';
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp() {
+    parent::setUp();
+
+    // Create admin user and login.
+    $this->adminUser = $this->drupalCreateUser();
+    $this->adminUser->addRole('administrator');
+    $this->adminUser->save();
+    $this->drupalLogin($this->adminUser);
+  }
+
+  /**
+   * Tests Adding a PDQ Summary.
+   */
+  public function testSummaryFieldsExist() {
+
+    // Load new content item page.
+    $this->drupalGet('node/add/pdq_cancer_information_summary');
+    // Verify we have permission to view page.
+    $this->assertResponse(200);
+
+    // Verify fields exist.
+    $this->assertSession()->fieldExists(PDQSummaryTest::PAGE_TITLE);
+    $this->assertSession()->fieldExists(PDQSummaryTest::SHORT_TITLE);
+
+    // Fill out the fields.
+    $this->getSession()->getPage()->fillField(PDQSummaryTest::PAGE_TITLE, 'pony');
+    $this->getSession()->getPage()->fillField(PDQSummaryTest::SHORT_TITLE, 'pony');
+
+    // Submit the form and check for success.
+    $this->getSession()->getPage()->pressButton(PDQSummaryTest::SAVE_BUTTON);
+    $this->assertResponse(200);
+  }
+
+}

--- a/docroot/profiles/custom/cgov_site/tests/src/Functional/PdqNodeTypeTest.php
+++ b/docroot/profiles/custom/cgov_site/tests/src/Functional/PdqNodeTypeTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Drupal\Tests\node\Functional;
+
+use Drupal\node\Entity\NodeType;
+use Drupal\Tests\system\Functional\Menu\AssertBreadcrumbTrait;
+use Drupal\Tests\system\Functional\Cache\AssertPageCacheContextsAndTagsTrait;
+
+/**
+ * Ensures the PDQ content types are correctly configured.
+ *
+ * @group node
+ */
+class PdqNodeTypeTest extends NodeTestBase {
+
+  use AssertBreadcrumbTrait;
+  use AssertPageCacheContextsAndTagsTrait;
+
+  /**
+   * Load the CancerGov site profile.
+   *
+   * @var string
+   */
+  protected $profile = 'cgov_site';
+
+  /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  public static $modules = [];
+
+
+  /**
+   * PDQ Content types.
+   *
+   * This field contains a list of all the content types to be tested.
+   * Potentially, this could be expanded to include a list of the fields
+   * expected to be associated with the type.
+   *
+   * @var array
+   */
+  private $contentTypes = [
+    'pdq_cancer_information_summary',
+  ];
+
+  /**
+   * Ensures that node type functions (node_type_get_*) work correctly.
+   *
+   * Load available node types and validate the returned data.
+   */
+  public function testNodeTypesArePresent() {
+
+    foreach ($this->contentTypes as $name) {
+      $node = NodeType::load($name);
+
+      $this->assertTrue(isset($node), "Node type $name is available.");
+
+      $label = $node->label();
+      $this->assertTrue($label != NULL && strlen($label) > 0, "Node type $name has a non-blank label.");
+
+      $description = $node->getDescription();
+      $this->assertTrue($description != NULL && strlen($description) > 0, "Node type $name has a non-blank description.");
+    }
+  }
+
+}


### PR DESCRIPTION
Closes:
  #396 - Attach the Page Title field to the PDQ Summary
  #397 - Attach the Short Title field to PDQ Summary
  #395 - Add unit test for PDQ Cancer Information Summary content type.
  #413 - Set permissions for PDQ Summary type
  #414 - Connect PDQ Summary to the PDQ workflow