### PR TITLE
Feature/cgov yaml content rev2

### DIFF
--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/cgov_yaml_content.services.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/cgov_yaml_content.services.yml
@@ -1,6 +1,6 @@
 services:
   cgov_yaml_content.event_subscriber:
     class: Drupal\cgov_yaml_content\Service\CgovYamlContentEventSubscriber
-    arguments: ['@theme.manager']
+    arguments: ['@theme.manager', '@yaml_content.content_loader']
     tags:
       - {name: event_subscriber}

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/coping_feelings_relaxation.content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/coping_feelings_relaxation.content.yml
@@ -20,7 +20,8 @@
           - type: 'module'
             filename: 'ocean-sunset-view-mykonos-article.jpg'
       alt: 'sunset ocean view in Mykonos'
-      alt__ES: "vista del mar en el ocaso en Mykonos"
+      alt__ES:
+        value: "vista del mar en el ocaso en Mykonos"
   field_credit:
     value: "iStock"
   field_credit__ES:

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/src/Service/CgovYamlContentEventSubscriber.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/src/Service/CgovYamlContentEventSubscriber.php
@@ -172,13 +172,16 @@ class CgovYamlContentEventSubscriber implements EventSubscriberInterface {
     // 4. Create translation.
     $spanishTranslationAlreadyExists = $entity->hasTranslation('es');
     if (!$spanishTranslationAlreadyExists) {
-      $entity->addTranslation('es');
+      $entityArray = $entity->toArray();
+      $translation = array_merge($entityArray, $translatedFields);
+      $entity->addTranslation('es', $translation);
     }
     $spanishTranslation = $entity->getTranslation('es');
     foreach ($translatedFields as $fieldName => $fieldValue) {
       $spanishTranslation->{$fieldName} = $processedTranslatedEntity->{$fieldName};
     }
-    $spanishTranslation->save();
+    $spanishTranslation->{'moderation_state'} = $entity->{'moderation_state'};
+    $entity->save();
   }
 
   /**

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/src/Service/CgovYamlContentEventSubscriber.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/src/Service/CgovYamlContentEventSubscriber.php
@@ -3,6 +3,7 @@
 namespace Drupal\cgov_yaml_content\Service;
 
 use Drupal\yaml_content\Event\YamlContentEvents;
+use Drupal\yaml_content\ContentLoader\ContentLoaderInterface;
 use Drupal\yaml_content\Event\EntityPostSaveEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Drupal\block\Entity\Block;
@@ -22,13 +23,23 @@ class CgovYamlContentEventSubscriber implements EventSubscriberInterface {
   protected $themeManager;
 
   /**
+   * Yaml Content Content Loader.
+   *
+   * @var \Drupal\yaml_content\ContentLoader\ContentLoaderInterface
+   */
+  protected $contentLoader;
+
+  /**
    * Create new Event Subscriber class.
    *
    * @param \Drupal\Core\Theme\ThemeManagerInterface $themeManager
    *   Theme Manager.
+   * @param \Drupal\yaml_content\ContentLoader\ContentLoaderInterface $contentLoader
+   *   Content Loader.
    */
-  public function __construct(ThemeManagerInterface $themeManager) {
+  public function __construct(ThemeManagerInterface $themeManager, ContentLoaderInterface $contentLoader) {
     $this->themeManager = $themeManager;
+    $this->contentLoader = $contentLoader;
   }
 
   /**

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/src/Service/CgovYamlContentEventSubscriber.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/src/Service/CgovYamlContentEventSubscriber.php
@@ -99,6 +99,17 @@ class CgovYamlContentEventSubscriber implements EventSubscriberInterface {
       }
     }
 
+    // Guard clause: Don't translate fields that don't have an
+    // english counterpart.
+    foreach ($translatedFields as $fieldName => $fieldValue) {
+      $fieldExistsOnEnglishEntity = $entity->hasField($fieldName);
+      if (!$fieldExistsOnEnglishEntity) {
+        unset($translatedFields[$fieldName]);
+      }
+    }
+
+    // Guard clause: Don't add an entity translation when no fields
+    // have translations.
     $noFieldsToTranslate = count($translatedFields) === 0;
     if ($noFieldsToTranslate) {
       return;
@@ -167,7 +178,7 @@ class CgovYamlContentEventSubscriber implements EventSubscriberInterface {
     foreach ($translatedFields as $fieldName => $fieldValue) {
       $spanishTranslation->{$fieldName} = $processedTranslatedEntity->{$fieldName};
     }
-    $entity->save();
+    $spanishTranslation->save();
   }
 
   /**

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/src/Service/CgovYamlContentEventSubscriber.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/src/Service/CgovYamlContentEventSubscriber.php
@@ -98,6 +98,12 @@ class CgovYamlContentEventSubscriber implements EventSubscriberInterface {
         }
       }
     }
+
+    $noFieldsToTranslate = count($translatedFields) === 0;
+    if ($noFieldsToTranslate) {
+      return;
+    }
+
     // 2. Check for paragraphs.
     // Paragraphs have to be treated differently from other
     // entity types. Instead of adding a translation to the


### PR DESCRIPTION
Handles #497.

Fixes:
- Don't translate nonexistent fields.
- Don't translate when no fields to translate
- Fix moderation state issue to mirror original state
- Add support for #process directives in yaml_content on translated fields.