### PR TITLE
Prevent npm install from trying to switch user IDs.

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -15,6 +15,8 @@ services:
       - ./web/runtime/apache2.conf:/etc/apache2/apache2.conf
       - ./web/runtime/php_apache2.ini:/etc/php/7.2/apache2/php.ini
       - ./web/runtime/php_cli.ini:/etc/php/7.2/cli/php.ini
+      # NPM config
+      - ./web/runtime/.npmrc:/root/.npmrc
       ## Block git repo management within the container
       - ./web/runtime/container-hooks:/var/www/scripts/hooks
     env_file:

--- a/docker/web/runtime/.npmrc
+++ b/docker/web/runtime/.npmrc
@@ -1,0 +1,9 @@
+;;;;
+; npm userconfig file
+; this is a simple ini-formatted file
+; lines that start with semi-colons are comments.
+; read `npm help config` for help on the various options
+;;;;
+
+; Allow NPM to run as root without trying to change user accounts.
+unsafe-perm=true


### PR DESCRIPTION
When run as root, npm install attempts to switch to a non-root user account.
No such account exists, causing install (and thus blt) to fail.
Closes #532.