### PR TITLE
Add page options script dependencies

### DIFF
--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/entrypoints/article/Article.scss
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/entrypoints/article/Article.scss
@@ -1,1 +1,0 @@
-@import '~Styles/pageOptions';

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/entrypoints/global/Common.js
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/entrypoints/global/Common.js
@@ -1,6 +1,180 @@
-import { newWindow } from 'Core/utilities';
+// Polyfills for older browsers
+// import './polyfills/custom_event';
+// import './polyfills/replaceWith';
+// import 'es6-promise/auto';
+// import 'core-js/fn/array/from';
+// import 'core-js/fn/array/find';
+// import 'core-js/fn/array/includes';
+// import 'core-js/fn/object/assign';
+// import 'core-js/fn/object/entries';
+// import 'core-js/fn/string/includes';
+// import 'core-js/fn/string/starts-with';
+
+import initializeCustomEventHandler from 'Core/libraries/customEventHandler';
+initializeCustomEventHandler();
+
+// import 'Common/Enhancements/analytics';
 import './Common.scss';
 
-const a = { A: 'AAA' };
-const b = { B: 'BBB' };
-const ab = { ...a, ...b };
+// import $ from 'jquery';
+// import 'Common/Enhancements/jQueryUIExtensions';
+// import popupFunctions from 'Common/Enhancements/popup_functions';
+// popupFunctions($);
+
+// import 'Common/Plugins/Enlarge';
+// import 'Plugins/jquery.nci.prevent_enter';
+
+// import { buildOTP, makeOutline } from 'Common/Enhancements/NCI.page';
+// import search from 'Modules/search/search';
+// import mobilemenu from 'Modules/nav/mobilemenu';
+// import sectionmenu from 'Modules/nav/sectionmenu';
+// import exitDisclaimer from 'Common/Enhancements/exitDisclaimer';
+// import backToTop from 'Modules/backToTop/backToTop';
+// import { makeAllAccordions } from 'Modules/accordion/accordion';
+// import tableToggle from 'Modules/tableToggle/tableToggle';
+// import flexVideo from 'Modules/videoPlayer/flexVideo';
+// import formControls from 'Modules/forms/formControls';
+// import tooltips from 'Modules/tooltips/referenceTooltip';
+
+// // Unfortunately AMD doesn't play nice with export default;
+// import proactiveLiveHelp from 'Modules/liveHelpPopup';
+// import sortablejs from 'Modules/sortableTables';
+import pageOptions from 'Libraries/pageOptions';
+
+// import SiteWideSearch from 'Common/Enhancements/sitewidesearch';
+// import megaMenuModule from 'Modules/megamenu/megamenu';
+// import headroomPlugin from 'Modules/headroom/headroom';
+// import DeepLinkPatch from 'Modules/utility/deepLinkPatch';
+// import linkAudioPlayer from 'Modules/linkAudioPlayer/linkAudioPlayer';
+
+// DeepLinkPatch();
+
+//DOM Ready event
+const onDOMContentLoaded = () => {
+
+	// /*** BEGIN header component ***/
+	// megaMenuModule();
+
+	// headroomPlugin();
+
+	// // This initializes jQuery UI Autocomplete on the site-wide search widget.
+	// SiteWideSearch();
+
+	// /*** BEGIN dictionary toggle ***/
+	// // var dictionaryToggle = function () {
+	// // 	$("#utility-dropdown").slideToggle(0, function () {
+	// // 		$("#utility-dictionary").toggleClass('active');
+	// // 	});
+	// // }
+
+	// backToTop();
+
+	// /*** BEGIN mobile nav ("off-canvas flyout functionality") ***/
+
+	// // OCEPROJECT-3098 HACK to fix the Spanish mega menu on the Spanish homepage
+	// if (/^\/espanol\/?$/.test(location.pathname)) {
+	// 	$('#mega-nav .contains-current').removeClass('contains-current');
+	// }
+
+	// mobilemenu();
+
+	// sectionmenu();
+
+	// search.init();
+
+	// /*** END mobile nav ***/
+
+	// /*** BEGIN Exit Disclaimer
+	//  * This script looks for URLs where the href points to websites not in the federal domain (.gov) and if it finds one, it appends an image to the link. The image itself links to the exit disclaimer page.
+	//  ***/
+	// exitDisclaimer();
+
+	pageOptions();
+
+	// /*** BEGIN table toggling
+	//  * This allows for toggling between tables.
+	//  * An example can be seen on grants-research-funding.shtml,
+	//  * as of the first commit with this code.
+	//  ***/
+
+	// // for each toggleable section...
+	// tableToggle();
+
+	// /*** END table toggling ***/
+
+	// /*** BEGIN video embedding
+	//  * This enables the embedding of YouTube videos and playlists as iframes.
+	//  ***/
+	// flexVideo();
+
+	// /*** BEGIN form controls ***/
+	// formControls();
+
+	// /*** BEGIN accordionizer ***/
+	// makeAllAccordions();
+
+	// /*** BEGIN page outlining ***/
+	// // generate the page outline -- this is used for all page-/document-level navigation
+	// // set up outlines
+	// $('article').each(function () {
+	// 	var $this = $(this);
+
+	// 	// check if there already is a built outline for this article
+	// 	if ($this.data('nci-outline')) {
+	// 		return;
+	// 	}
+
+	// 	// otherwise, build and set the outline
+	// 	var outline = makeOutline(this);
+	// 	$this.data('nci-outline', outline);
+	// });
+
+	// if ($('article').length > 0) {
+	// 	buildOTP();
+	// }
+	// /*** END page outlining ***/
+
+	// /*** BEGIN HACK for Blog Series titles
+	//  * TODO: remove when Blog Dynamic List Percussion template is updated
+	//  * with class name for <h3> ***/
+
+	// $('div.blog-post').each(function () {
+	// 	if ($(this).find('a.comment-count').length < 1) {
+	// 		($(this).find('div.post-title h3').addClass('no-comments'))
+	// 	}
+	// });
+
+	// // reference tooltips
+	// tooltips();
+
+	// // initialize the prevent-enter enhancement
+	// $('[data-prevent-enter="true"]').NCI_prevent_enter();
+
+	// // Proactive Live Help for CTS
+	// proactiveLiveHelp();
+
+};// END: DOM Ready event
+
+document.addEventListener('DOMContentLoaded',onDOMContentLoaded);
+
+// $(window).on('load', function () {
+// 	// BEGIN Table Resizing
+// 	//Table enlarging & scrollbar adding.
+// 	//This marks all tables as scrollable, but only adds a shadow to the right side if it is scrolling.
+// 	//Inspired by http://www.456bereastreet.com/archive/201309/responsive_scrollable_tables/
+
+// 	$("#content table:not(.no-auto-enlarge)").overflowEnlarge();
+
+// 	// IMPORTANT: sortabletables-js requires a specific DOM structure for the table it is added to
+// 	// (consult https://github.com/BtheGit/sortable-js for more documentation). Because of this, it needs
+// 	// to run AFTER the enlarge function above, which does some rewriting of the DOM to wrap a table in a figure
+// 	// element, among other things.
+
+// 	// NOTE: The custom settings are handled in a local wrapper module
+
+// 	sortablejs();
+
+// 	// Use custom audio player to override mp3 anchor links
+// 	linkAudioPlayer();
+
+// }); // END: Window Load Event

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/entrypoints/global/Common.scss
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/entrypoints/global/Common.scss
@@ -60,7 +60,6 @@
 @import "~Core/styles/bodybanner";
 // @import "../Scripts/NCI/Modules/accordion/accordion";
 @import "~Core/styles/tables";
-// @import "pageOptions";
 @import "~Core/styles/font_resizer";
 // @import "../Scripts/NCI/Modules/carousel/carousel";
 // @import "../Scripts/NCI/Modules/backToTop/backToTop";

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/libraries/README.md
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/libraries/README.md
@@ -1,0 +1,7 @@
+# Folder Info
+
+## What goes here?
+
+Sometimes libraries need to have access to theme specific assets like sprite sheets (and by extension are scoped to only one theme's entry points).
+
+For example, beacause pageOptions is a library that is only used in the Common.js entry point and because it is dependent on the cgov_common sprite sheet it goes here instead of in Core/libraries.

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/libraries/pageOptions/index.js
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/libraries/pageOptions/index.js
@@ -1,0 +1,25 @@
+import {
+    getDocumentLanguage,
+    getNodeArray,
+} from 'Core/utilities';
+import pageOptionsTypes from './types';
+
+const getPageOptionsNodes = (pageOptionsTypes) => {
+    const pageOptions = Object.entries(pageOptionsTypes).reduce((acc, [type, settings]) => {
+        const { hook, link, windowSettings, initialize, initializeAnalytics } = settings;
+        const lang = getDocumentLanguage(window.document);
+        const nodes = getNodeArray(hook)
+            .map(initialize(lang)(settings))
+            .map(initializeAnalytics)
+        acc[type] = { hook, link, nodes, windowSettings };
+        return acc;
+    }, {})
+    return pageOptions;
+}
+
+const initialize = () => {
+    const pageOptions = getPageOptionsNodes(pageOptionsTypes);
+    return pageOptions;
+}
+
+export default initialize;

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/libraries/pageOptions/index.js
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/libraries/pageOptions/index.js
@@ -3,6 +3,7 @@ import {
     getNodeArray,
 } from 'Core/utilities';
 import pageOptionsTypes from './types';
+import './index.scss';
 
 const getPageOptionsNodes = (pageOptionsTypes) => {
     const pageOptions = Object.entries(pageOptionsTypes).reduce((acc, [type, settings]) => {

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/libraries/pageOptions/index.scss
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/libraries/pageOptions/index.scss
@@ -1,6 +1,6 @@
 @import '~Core/styles/breakpoints';
 @import '~Core/styles/colors';
-@import 'sprites/svg-sprite';
+@import '~Styles/sprites/svg-sprite';
 /* COMMON for all page options */
 .page-options {
 	margin: 1em 0;
@@ -53,7 +53,7 @@ a.social-share--custom-tweet {
 	align-items: center;
 	height: 56px;
 	width: 166px;
-	
+
 	&::after {
 		content: '';
 		@include svg-sprite(tweet-this, mq);
@@ -185,11 +185,11 @@ a.social-share--custom-tweet {
 @include bp(small) {
 
 	#blogPageOptionsOuterContainer {
-		// This is to hide some craziness where a margin is being applied to a script only block 
+		// This is to hide some craziness where a margin is being applied to a script only block
 		// because of how the page-options are being moved around.
 		display: none;
 	}
-	
+
 	.page-options-container {
 		display: flex;
 		align-items: center;
@@ -218,7 +218,7 @@ a.social-share--custom-tweet {
 	.page-options {
 		width: 100%;
 		float: none;
-		
+
 		ul {
 			justify-content: space-between;
 		}
@@ -228,7 +228,7 @@ a.social-share--custom-tweet {
 			height: 48px;
 		}
 	}
-	
+
 }
 
 /* TABLET page options */

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/libraries/pageOptions/types/customTweet.js
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/libraries/pageOptions/types/customTweet.js
@@ -1,0 +1,46 @@
+import { newWindow } from 'Core/utilities/popups';
+import {
+    onClickAnalytics,
+    getContent,
+} from '../utilities';
+
+const customTweet = {
+    hook: 'a.social-share--custom-tweet',
+    textContent: {
+        title: {
+            'en': () => 'Share on Twitter',
+        },
+    },
+    classList: ['tl-link'],
+    initialize: language => settings => node => {
+        // Set up the node attributes that a content owner doesn't need to be responsible for
+        const title = getContent(settings.textContent.title, language)();
+        node.title = title;
+        node.setAttribute('aria-label', title);
+        settings.classList.forEach(className => node.classList.add(className));
+        node.href = "#";
+
+        const customTweetClickHandler = event => {
+            event.preventDefault();
+            // Extract attributes added by content owner to build a custom tweet window event
+            const customTitle = event.target.dataset.title || '';
+            const url = event.target.dataset.url || '';
+            const link = `https://twitter.com/share?url=${ encodeURIComponent(url) }&text=${ encodeURIComponent(customTitle) }`;
+            newWindow(link);
+        }
+
+        node.addEventListener('click', customTweetClickHandler);
+        return node;
+    },
+    initializeAnalytics: node => {
+        const tlCode = node.dataset.tlCode || '';
+        const detail = {
+            type: 'CustomTweetClick',
+            args: [tlCode]
+        };
+        node.addEventListener('click', onClickAnalytics({ node, detail }))
+        return node;
+    },
+};
+
+export default customTweet;

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/libraries/pageOptions/types/email.js
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/libraries/pageOptions/types/email.js
@@ -1,0 +1,54 @@
+import {
+    getURL,
+    onClickAnalytics,
+    getContent,
+} from '../utilities';
+
+const email = {
+    hook: '.page-options--email a',
+    textContent: {
+        title: {
+            'en': () => 'Email',
+            'es': () => 'Enviar por correo electrónico',
+        },
+        href: {
+            'en': url => `
+                ${
+                    encodeURI(`mailto:?subject=Information from the National Cancer Institute Web Site&body=I found this information on www.cancer.gov and I'd like to share it with you: `)
+                }${
+                    encodeURIComponent(url)
+                }${
+                    encodeURI(`\n\n NCI's Web site, www.cancer.gov, provides accurate, up-to-date, comprehensive cancer information from the U.S. government's principal agency for cancer research. If you have questions or need additional information, we invite you to contact NCI’s LiveHelp instant messaging service at https://livehelp.cancer.gov, or call the NCI's Contact Center 1-800-4-CANCER (1-800-422-6237) (toll-free from the United States).`)
+                }`,
+            'es': url => `
+                ${
+                    encodeURI(`mailto:?subject=Información del portal de Internet del Instituto Nacional del Cáncer&body=Encontré esta información en cancer.gov/espanol y quiero compartirla contigo: `)
+                }${
+                    encodeURIComponent(url)
+                }${
+                    encodeURI(`\n\n El sitio web del Instituto Nacional del Cáncer (NCI), www.cancer.gov/espanol, provee información precisa, al día y completa de la dependencia principal del gobierno de EE. UU. sobre investigación de cáncer. Si tiene preguntas o necesita más información, le invitamos a que se comunique en español con el servicio de mensajería instantánea LiveHelp del NCI en https://livehelp-es.cancer.gov, o llame el Centro de Contacto del NCI al 1-800-422-6237 (1-800-4-CANCER) sin cargos en los Estados Unidos.`)
+                }`,
+        }
+    },
+    initialize: language => settings => node => {
+        const title = getContent(settings.textContent.title, language)();
+        node.title = title;
+        node.setAttribute('aria-label', title);
+        node.addEventListener('click', event => {
+            const url = getURL(document);
+            const href = getContent(settings.textContent.href, language)(url);
+            node.href = href;
+            return true;
+        })
+        return node;
+    },
+    initializeAnalytics: node => {
+        const detail = {
+            type: 'eMailLink',
+        };
+        node.addEventListener('click', onClickAnalytics({ node, detail }))
+        return node;
+    },
+};
+
+export default email;

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/libraries/pageOptions/types/facebook.js
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/libraries/pageOptions/types/facebook.js
@@ -1,0 +1,33 @@
+import {
+    onClickShareButton,
+    onClickAnalytics,
+    getContent,
+} from '../utilities';
+
+const facebook =  {
+    hook: '.social-share--facebook a',
+    link: url => `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(url)}`,
+    windowSettings: {},
+    textContent: {
+        title: {
+            'en': () => 'Facebook',
+            'es': () => 'Facebook',
+        },
+    },
+    initialize: language => settings => node => {
+        const title = getContent(settings.textContent.title, language)();
+        node.title = title;
+        node.setAttribute('aria-label', title);       
+        node.addEventListener('click', onClickShareButton(settings));
+        return node;
+    },
+    initializeAnalytics: node => {
+        const detail = {
+            type: 'BookmarkShareClick',
+        };
+        node.addEventListener('click', onClickAnalytics({ node, detail }))
+        return node;
+    },
+}
+
+export default facebook;

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/libraries/pageOptions/types/index.js
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/libraries/pageOptions/types/index.js
@@ -1,0 +1,17 @@
+import facebook from './facebook';
+import twitter from './twitter';
+import customTweet from './customTweet';
+import pinterest from './pinterest';
+import email from './email';
+import print from './print';
+import resize from './resize';
+
+export default {
+    facebook,
+    twitter,
+    pinterest,
+    email,
+    print,
+    resize,
+    customTweet,
+};

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/libraries/pageOptions/types/pinterest.js
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/libraries/pageOptions/types/pinterest.js
@@ -1,0 +1,35 @@
+import {
+    onClickShareButton,
+    onClickAnalytics,
+    getContent,
+} from '../utilities';
+
+const pinterest = {
+    hook: '.social-share--pinterest a',
+    link: url => `https://pinterest.com/pin/create/button/?url=${encodeURIComponent(url)}`,
+    windowSettings: {
+        width: 700
+    },
+    textContent: {
+        title: {
+            'en': () => 'Pinterest',
+            'es': () => 'Pinterest',
+        },
+    },
+    initialize: language => settings => node => {
+        const title = getContent(settings.textContent.title, language)();
+        node.title = title;
+        node.setAttribute('aria-label', title);
+        node.addEventListener('click', onClickShareButton(settings));
+        return node;
+    },
+    initializeAnalytics: node => {
+        const detail = {
+            type: 'BookmarkShareClick',
+        };
+        node.addEventListener('click', onClickAnalytics({ node, detail }))
+        return node;
+    },
+};
+
+export default pinterest;

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/libraries/pageOptions/types/print.js
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/libraries/pageOptions/types/print.js
@@ -1,0 +1,33 @@
+import { 
+    onClickAnalytics,
+    getContent,
+} from '../utilities';
+
+const print = {
+    hook: '.page-options--print a',
+    textContent: {
+        title: {
+            'en': () => 'Print',
+            'es': () => 'Imprimir',
+        },
+    },
+    initialize: language => settings => node => {
+        const title = getContent(settings.textContent.title, language)();
+        node.title = title;
+        node.setAttribute('aria-label', title);
+        node.addEventListener('click', event => {
+            event.preventDefault();
+            window.print();
+        })
+        return node;
+    },
+    initializeAnalytics: node => {
+        const detail = {
+            type: 'PrintLink',
+        };
+        node.addEventListener('click', onClickAnalytics({ node, detail }))
+        return node;
+    },
+};
+
+export default print;

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/libraries/pageOptions/types/resize.js
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/libraries/pageOptions/types/resize.js
@@ -4,13 +4,13 @@ import {
 } from '../utilities';
 import {
     getNodeArray,
-} from 'Utilities/domManipulation'
+} from 'Core/utilities/domManipulation';
 
 const getCurrentFontSize = () => {
     const testElement = document.querySelector('.resize-content') || document.getElementById('cgvBody');
     const size = parseFloat(window.getComputedStyle(testElement).getPropertyValue('font-size'), 10);
-    const fontSize = 
-        size < 19 
+    const fontSize =
+        size < 19
         ? 'Normal'
         : size < 23
         ? 'Medium'
@@ -31,13 +31,13 @@ const resize = {
     initialize: language => settings => node => {
         const title = getContent(settings.textContent.title, language)();
         node.title = title;
-        node.setAttribute('aria-label', title);       
+        node.setAttribute('aria-label', title);
 
         const clickHandler = resizeableElements => {
             const multiplier = 1.2;
             let originalSize = parseFloat(window.getComputedStyle(document.body).getPropertyValue('font-size'), 10);
             let currentSize = 0;
-            
+
             return event => {
                 event.preventDefault();
                 currentSize = parseFloat(window.getComputedStyle(resizeableElements[0]).getPropertyValue('font-size'), 10);
@@ -48,16 +48,16 @@ const resize = {
                 })
             };
         }
-        
+
         const resizeableElements = getNodeArray(".resize-content");
         if(resizeableElements.length){
             node.addEventListener('click', clickHandler(resizeableElements));
         }
-        
+
         return node;
     },
     initializeAnalytics: node => {
-        const mouseleaveHandler = () => {            
+        const mouseleaveHandler = () => {
             const fontSize = getCurrentFontSize();
             const detail = {
                 type: 'fontResizer',

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/libraries/pageOptions/types/resize.js
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/libraries/pageOptions/types/resize.js
@@ -1,0 +1,77 @@
+import {
+    onClickAnalytics,
+    getContent,
+} from '../utilities';
+import {
+    getNodeArray,
+} from 'Utilities/domManipulation'
+
+const getCurrentFontSize = () => {
+    const testElement = document.querySelector('.resize-content') || document.getElementById('cgvBody');
+    const size = parseFloat(window.getComputedStyle(testElement).getPropertyValue('font-size'), 10);
+    const fontSize = 
+        size < 19 
+        ? 'Normal'
+        : size < 23
+        ? 'Medium'
+        : size < 27
+        ? 'Large'
+        : 'Extra Large';
+    return fontSize;
+}
+
+const resize = {
+    hook: '.page-options--resize a',
+    textContent: {
+        title: {
+            'en': () => 'Font Resizer',
+            'es': () => 'Control de tamaño de fuente',
+        },
+    },
+    initialize: language => settings => node => {
+        const title = getContent(settings.textContent.title, language)();
+        node.title = title;
+        node.setAttribute('aria-label', title);       
+
+        const clickHandler = resizeableElements => {
+            const multiplier = 1.2;
+            let originalSize = parseFloat(window.getComputedStyle(document.body).getPropertyValue('font-size'), 10);
+            let currentSize = 0;
+            
+            return event => {
+                event.preventDefault();
+                currentSize = parseFloat(window.getComputedStyle(resizeableElements[0]).getPropertyValue('font-size'), 10);
+                let newSize = currentSize * multiplier;
+                newSize = newSize > 30 ? originalSize : newSize;
+                resizeableElements.forEach(el => {
+                    el.style.fontSize = newSize + "px";
+                })
+            };
+        }
+        
+        const resizeableElements = getNodeArray(".resize-content");
+        if(resizeableElements.length){
+            node.addEventListener('click', clickHandler(resizeableElements));
+        }
+        
+        return node;
+    },
+    initializeAnalytics: node => {
+        const mouseleaveHandler = () => {            
+            const fontSize = getCurrentFontSize();
+            const detail = {
+                type: 'fontResizer',
+                args: [fontSize],
+            };
+            onClickAnalytics({ node, detail })();
+            node.removeEventListener('mouseleave', mouseleaveHandler);
+        }
+
+        node.addEventListener('click', () => {
+            node.addEventListener('mouseleave', mouseleaveHandler)
+        })
+        return node;
+    },
+};
+
+export default resize;

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/libraries/pageOptions/types/twitter.js
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/libraries/pageOptions/types/twitter.js
@@ -1,0 +1,40 @@
+import {
+    onClickShareButton,
+    onClickAnalytics,
+    getContent,
+} from '../utilities';
+
+const twitter = {
+    hook: '.social-share--twitter a',
+    link: (url, {'og:title': text}) => {
+        // Check for global config object with custom overrides from content creator
+        if(window.pageOptionsContentOverride && window.pageOptionsContentOverride.title){
+            text = window.pageOptionsContentOverride.title;
+        }
+        return `https://twitter.com/share?url=${ encodeURIComponent(url) }&text=${ encodeURIComponent(text) }`
+    }, 
+    windowSettings: {},
+    textContent: {
+        title: {
+            'en': () => 'Twitter',
+            'es': () => 'Twitter',
+        },
+    },
+    initialize: language => settings => node => {
+        const title = getContent(settings.textContent.title, language)();
+        node.title = title;
+        node.setAttribute('aria-label', title);       
+
+        node.addEventListener('click', onClickShareButton(settings));
+        return node;
+    },
+    initializeAnalytics: node => {
+        const detail = {
+            type: 'BookmarkShareClick',
+        };
+        node.addEventListener('click', onClickAnalytics({ node, detail }))
+        return node;
+    },
+};
+
+export default twitter;

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/libraries/pageOptions/utilities/index.js
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/libraries/pageOptions/utilities/index.js
@@ -1,0 +1,76 @@
+import { newWindow } from 'Core/utilities/popups';
+import {
+    getMetaData,
+    getMetaURL,
+    getCanonicalURL,
+} from 'Core/utilities/domManipulation';
+import { broadcastCustomEvent } from 'Core/libraries/customEventHandler';
+
+// Currently we aren't using most of these tags since the services themselves are scraping the info they
+// need. But I'm leaving this here as a point of reference ('og:title' is the only one being used
+// at the moment, by Twitter) BB 3/2018
+export const metaTags = [
+    ['property', 'og:url'],
+    ['property', 'og:title'],
+    // ['property', 'og:description'],
+    // ['property', 'og:site_name'],
+    // ['property', 'og:type'],
+    // ['name', 'twitter:card']
+]
+
+// In the event that the metaData is not pulled down (which is a non-case as of this comment but might
+// change shortly), we want to default to the opengraph url with the canonical as a fallback.
+export const getURL = (document, metaData) => {
+    const metaURL = metaData ? metaData['og:url'] : getMetaURL(document);
+    return metaURL ? metaURL : getCanonicalURL(document);
+}
+
+/**
+ *
+ * @param {Object} dict
+ * @param {string} language
+ * @return {function}
+ */
+export const getContent = (dict, language = 'en') => {
+    if(!dict){
+        console.warn('No i18n dictionary provided');
+        return () => '';
+    }
+
+    if(!Object.keys(dict).length){
+        console.warn('Empty dictionary')
+        return () => '';
+    }
+
+    if(!dict[language] && !dict['en']){
+        console.warn('No default english value found')
+        return () => '';
+    }
+
+    if(!dict[language]){
+        console.warn('Desired language not available, defaulting to english')
+        return dict['en'];
+    }
+
+    return dict[language];
+}
+
+// We don't want to take the metadata until the share link has been activated (so that if some
+// of it was changed dynamically, we can capture the new data)
+export const onClickShareButton = ({
+    link,
+    windowSettings
+}) => event => {
+    event.preventDefault();
+    const metaData = getMetaData(metaTags, document)
+    const url = getURL(document, metaData);
+    newWindow(link(url, metaData), windowSettings);
+}
+
+export const onClickAnalytics = ({
+    node,
+    detail = {},
+}) => broadcastCustomEvent('NCI.page_option.clicked', {
+    node,
+    data: detail
+})

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/webpack.config.js
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/webpack.config.js
@@ -8,7 +8,8 @@ const themeConfig = {
         modules: [path.resolve(__dirname, '../src'), 'node_modules'],
         alias: {
             "Core": path.resolve(__dirname, '..', 'src'),
-            "Styles": path.resolve(__dirname, 'src', 'styles')
+            "Styles": path.resolve(__dirname, 'src', 'styles'),
+            "Libraries": path.resolve(__dirname, 'src', 'libraries'),
         }
     },
     output: {

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/src/libraries/README.md
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/src/libraries/README.md
@@ -1,0 +1,9 @@
+# Folder Info
+
+## What goes here?
+
+Some code is not generic enough or not small enough to be connsidered a helper function. This code is what we alternately call a library, feature, enhancement, or module. Some features will be single files, some will have attendant stylesheets, some will forever be of the 'dear god, this code makes no sense and I swear I will rewrite it from scratch (but in reality it never happens)' persuasion. It all goes here.
+
+### Why didn't we call it 'Modules' again, like the old site?
+
+Dear god man, how many modules folders can a person truly bear in a single repo before he snaps and drops all his tables??

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/src/libraries/customEventHandler/README.md
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/src/libraries/customEventHandler/README.md
@@ -1,0 +1,54 @@
+# Custom Event Handler
+
+## Summary
+Use this to broadcast events to a global custom event handler. Subscribe listeners to the global handler rather than to the element generating the event itself.
+
+## Broadcasting:
+### broadcastCustomEvent(eventType: string, { node: HTMLElement, data: object })
+Use the method broadcastCustomEvent inside event listener callbacks. The first argument should be the event type as a string (used by the global handler to lookup matching listeners) and the second argument an object with two properties: a) "node", which is the DOM Node the event was triggered on b) "data", an optional object containing any custom data to be used by listeners.
+
+## Listening:
+### registerCustomEventListener(eventType: string, eventListener: function)
+### eventListener(eventType: string, { node: HTMLElement, data: object })
+Register a custom listener to the global custom event handler. The first argument is a string that matches the event type from the broadcast method. The second argument is a callback that takes two arguments (which match the arguments passed to broadcastCustomEvent).
+
+Use the customEventListener to do logic and formatting and to directly call core NCIAnalytics methods like ClickParams.
+
+## Example:
+
+```javascript
+// animatedButton.js
+import { broadcastCustomEvent } from 'Core/libraries/customEventHandler';
+
+const animatedButton = document.querySelector('#animated-button');
+const onClick = event => {
+  event.target.classlist.toggle('active');
+  broadcastCustomEvent('NCI.animated-button.click', {
+    node: event.target,
+    data: {
+      currentState: event.target.classlist.indexOf('active') !== -1 ? 'active' : 'inactive'
+    }
+  });
+}
+animatedButton.addEventListener('click', onClick);
+```
+
+```javascript
+// analytics.js
+import { registerCustomEventListener } from 'Core/libraries/customEventHandler';
+...
+const animatedButtonClickAnayticsEvent = (target, data) => {
+  const { currentState } = data;
+  const clickParams = new NCIAnalytics.ClickParams(target, 'nciglobal', 'o', 'NCI.animated-button.click');
+  clickParams.Events = [42];
+  clickParams.Evars = {
+    43: 'Animated Button'
+  };
+  clickParams.Props = {
+    44: currentState,
+  };
+  clickParams.LogToOmniture();
+};
+registerCustomEventListener('NCI.animated-button.click', animatedButtonClickAnalyticsEvent);
+...
+```

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/src/libraries/customEventHandler/__tests__/index.test.js
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/src/libraries/customEventHandler/__tests__/index.test.js
@@ -1,0 +1,75 @@
+import {
+    registerCustomEventListener,
+    unregisterCustomEventListener,
+    broadcastCustomEvent,
+    __attachCustomEventHandler__,
+} from '../index';
+
+describe('Module: customEventHandler', () => {
+
+    describe('registerCustomEventListener()', () => {
+        it('should throw if [eventType: string] and [listener: function] arguments are passed', () => {
+            expect(registerCustomEventListener).toThrow();
+            expect(() => { 
+                registerCustomEventListener('valid'); 
+            }).toThrow();
+            expect(() => { 
+                registerCustomEventListener('valid', {}); 
+            }).toThrow();
+            expect(() => { 
+                registerCustomEventListener(null, () => {}); 
+            }).toThrow();
+        })
+        it('should return undefined if a listener was successfully subscribed to the customEventHandler', () => {
+            expect(registerCustomEventListener('string', () => {})).toBe(undefined);
+        })
+        it('should register a listener for a custom event', () => {
+            __attachCustomEventHandler__();
+            const eventType = 'test';
+            const listener = jest.fn();
+            document.body.innerHTML = '<div id="node"></div>';
+            const node = document.getElementById('node');
+            registerCustomEventListener(eventType, listener);
+            broadcastCustomEvent(eventType, { node });
+            // Hacky way to obviate async issue
+            setTimeout(() => {
+                expect(listener.mock.calls.length).toBe(1);
+            }, 0)
+        })
+    })
+
+    describe('unregisterCustomEventListener()', () => {
+        it('should throw if [eventType: string] and [listener: function] arguments are passed', () => {
+            expect(unregisterCustomEventListener).toThrow();
+            expect(() => { 
+                unregisterCustomEventListener('valid'); 
+            }).toThrow();
+            expect(() => { 
+                unregisterCustomEventListener('valid', {}); 
+            }).toThrow();
+            expect(() => { 
+                unregisterCustomEventListener(null, () => {}); 
+            }).toThrow();
+        })
+        it('should throw if an unregistered eventType is specified', () => {
+            expect(() => {
+                unregisterCustomEventListener('valid', () => {});
+            }).toThrow();
+        })
+        it('should throw if a listener is not already registered for a given eventType', () => {
+            const eventType = 'test';
+            const listener = () => {};
+            registerCustomEventListener(eventType, listener);
+            unregisterCustomEventListener(eventType, listener);
+            expect(() => {
+                unregisterCustomEventListener(eventType, listener);
+            }).toThrow();
+        })
+        it('should return undefined if a listener was successfully unregistered', () => {
+            const eventType = 'test';
+            const listener = () => {};
+            registerCustomEventListener(eventType, listener);
+            expect(unregisterCustomEventListener(eventType, listener)).toBe(undefined);
+        })
+    })
+})

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/src/libraries/customEventHandler/index.js
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/src/libraries/customEventHandler/index.js
@@ -1,0 +1,116 @@
+import { createCustomEventBroadcaster } from '../../utilities/domEvents';
+
+export const customEventGlobalNamespace = 'NCI.UX.Action';
+let registeredEventListeners = {};
+let isCustomEventHandlerAttached = false;
+
+/**
+ * Attach a global listener to the window that handles custom events broadcast using the method broadcastCustomEvent.
+ * If the events have an eventType property that corresponds to a custom listener function registered using the method registerCustomEventListener,
+ * this function will call that listener with the passed arguments.
+ */
+const initialize = () => {
+    if(!isCustomEventHandlerAttached){
+        isCustomEventHandlerAttached = true;
+        __attachCustomEventHandler__();
+    }
+};
+export default initialize;
+
+/**
+ * DO NOT CALL DIRECTLY!
+ * This is a setup function that should not be used directly.
+ * It is only being exported for testing purposes.
+ */
+export const __attachCustomEventHandler__ = () => {
+    if(typeof window == undefined){
+        throw new Error('No global window present, cannot initialize customEventHandler');
+    }
+
+    const eventHandler = event => {
+        const {
+            target,
+            detail = {}
+        } = event;
+        const {
+            eventType,
+            data
+        } = detail;
+        if(
+            typeof eventType === 'string'
+            && registeredEventListeners.hasOwnProperty(eventType)
+        ){
+            const listeners = registeredEventListeners[eventType];
+            listeners.forEach(listener => listener(target, data));
+        }
+    };
+
+    window.addEventListener(customEventGlobalNamespace, eventHandler);
+};
+
+/**
+ * Dispatch custom events on a DOM node on execution.
+ *
+ *
+ * @param {string} eventType Used by the customEventHandler to find the appropriate listener function to execute
+ * @param {object} settings
+ * @param {HTMLElement} settings.node The event target node
+ * @param {object} [settings.data = {}] Any custom user data to be passed through the CustomEvent detail object
+ * @return {function} Event Handler
+ */
+export const broadcastCustomEvent = createCustomEventBroadcaster(customEventGlobalNamespace);
+
+/**
+ * Register an event listener to the customEventHandler listener store.
+ *
+ * @param {string} eventType the key used to reference the listener
+ * @param {function} listener
+ */
+export const registerCustomEventListener = (eventType, listener) => {
+    if(typeof eventType !== 'string' || typeof listener !== 'function'){
+        throw new Error('Expected eventType to be a string and listener to be a function')
+    }
+
+    // If the eventType is already registered we want to add to the array, otherwise create a new array of listeners
+    registeredEventListeners = {
+        ...registeredEventListeners,
+        [eventType]: registeredEventListeners.hasOwnProperty(eventType) ? [ ...registeredEventListeners[eventType], listener ] : [ listener ]
+    };
+}
+
+/**
+ * Remove a custom listener from the customEventHandler listener store.
+ *
+ * @param {string} eventType
+ */
+export const unregisterCustomEventListener = (eventType, listenerToUnregister) => {
+    if(typeof eventType !== 'string' || typeof listenerToUnregister !== 'function'){
+        throw new Error('Expected eventType to be a string and listener to unregister to be a function')
+    }
+
+    if(!registeredEventListeners.hasOwnProperty(eventType)){
+        throw new Error(`Can't unregister event of type ${ eventType }. No registered listeners exist for that type.`);
+    }
+
+    const listeners = registeredEventListeners[eventType];
+    const filteredListeners = listeners.filter(listener => listener !== listenerToUnregister);
+
+    if(listeners.length === filteredListeners.length){
+        throw new Error(`Cannot unregister a listener that is not previously registered.`);
+    }
+
+    if(filteredListeners.length){
+        registeredEventListeners = {
+            ...registeredEventListeners,
+            [eventType]: filteredListeners,
+        };
+    }
+    else{
+        // Delete the property if the array is empty
+        const {
+            [eventType]: listener,
+            ...otherListeners
+        } = registeredEventListeners;
+        registeredEventListeners = otherListeners;
+    }
+}

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/src/utilities/README.md
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/src/utilities/README.md
@@ -1,0 +1,9 @@
+# Folder Info
+
+## What goes here?
+
+Useful helper functions that are generic enough to be shared across multiple custom libraries and/or entry points.
+
+### But what about helper functions only used in one theme's entry points?
+
+Well, if the code is generic enough to be considered a utility and does not have an associated library, than it should be here even if its use is currently scoped to onnly one theme. Requirements may change and having a single store of all of our custom utility functions will make it easier for future work.

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/src/utilities/domManipulation.js
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/src/utilities/domManipulation.js
@@ -121,7 +121,12 @@ export const getCanonicalURL = (document = window.document) => document.querySel
  * @param {HTMLElement} [document=window.document]
  * @return {string}
  */
-export const getMetaURL = document => document.querySelector("meta[property='og:url']").getAttribute('content');
+export const getMetaURL = document => {
+  // MIGRATION NOTE:
+  // The elvis operator check is needed until the og:url metatag is available.
+  return document.querySelector("meta[property='og:url']")
+            && document.querySelector("meta[property='og:url']").getAttribute('content');
+}
 
 /**
  * On Some pages, the Page Options block is manually moved around the DOM based on the window width.

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/src/utilities/domManipulation.js
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/src/utilities/domManipulation.js
@@ -3,8 +3,8 @@
  * a provided class is found. Returns true if classname is found on any DOM node higher in the tree than
  * the provided node.
  * A DNA test for DOM Nodes if you will.
- * 
- * @param {node} node 
+ *
+ * @param {node} node
  * @param {string} className - classname only, do not use '.' selector
  * @return {boolean}
  */
@@ -18,7 +18,7 @@ export const checkNodeAncestryForClass = (node, className) => {
 		}
 		node = node.parentNode;
 	}
-	
+
 	return hasAncestor;
 };
 
@@ -26,12 +26,12 @@ export const checkNodeAncestryForClass = (node, className) => {
 /**
  * Return an array of nodes that match a given selector string starting from a given node
  * in the DOM tree.
- * 
- * DOM Querying typically returns nodelists not true arrays. We want to always get an array 
+ *
+ * DOM Querying typically returns nodelists not true arrays. We want to always get an array
  * back from querySelectorAll for easy reasoning.
- * 
- * @param {string} selector 
- * @param {node} [node=document] 
+ *
+ * @param {string} selector
+ * @param {node} [node=document]
  * @returns {node[]}
  */
 export const getNodeArray = (selector, node = document) => {
@@ -58,17 +58,17 @@ export const createFragment = html => {
 export const appendNodes = (nodes, parent) => nodes.map(node => parent.appendChild(node));
 
 /**
- * Given an array of arrays containing meta property attribute names and the corresponding value, will 
+ * Given an array of arrays containing meta property attribute names and the corresponding value, will
  * return an object with the property names as keys and the metatags content as values
- * 
+ *
  * Example metaTags = [
     ['property', 'og:url'],
-    ['property', 'og:title'], 
+    ['property', 'og:title'],
     ['property', 'og:description'],
     ['name', 'twitter:card']
 ]
  *returns { 'og:url': 'XXXX', 'og:description': 'XXXX'}
- *  
+ *
  * @param {Array[]} metaTags Array of arrays of propertyType & propertyName pairs for metatags
  * @param {Object} document Document (or document.documentElement for quicker searching) explicit for testing without DOM
  * @return {Object}
@@ -96,12 +96,20 @@ export const getMetaData = (metaTags, document) => {
  * @return {string}
  */
 export const getDocumentLanguage = (document = window.document) => {
-	return document.querySelector('meta[name="content-language"]').getAttribute('content');
+  // MIGRATION NOTE:
+  // The fallback values were added during migration because a content-language attribute was not available
+  // at the time this file was ported.
+  const language = document.querySelector('meta[name="content-language"]')
+    ? document.querySelector('meta[name="content-language"]').getAttribute('content')
+    : document.documentElement.lang
+      ? document.documentElement.lang
+      : 'en';
+  return language;
 }
 
 /**
  * Retrieve the canonical URL from the document head
- * 
+ *
  * @param {HTMLElement} [document=window.document]
  * @return {string}
  */
@@ -109,7 +117,7 @@ export const getCanonicalURL = (document = window.document) => document.querySel
 
 /**
  * Retrieve the URL from the document metadata og:url property
- * 
+ *
  * @param {HTMLElement} [document=window.document]
  * @return {string}
  */
@@ -131,7 +139,7 @@ export const pageOptionsTransporter = () => {
 		}
 	}
 	mediaQueryListener.addListener(mqEventHandler)
-	// Initialize page options block in correct page location on load 
+	// Initialize page options block in correct page location on load
 	// mediaQueryListeners don't automatically handle load events (they are for resizes primarily)
 	// so we need to manually invoke the handler. mediaQueryListener has a property .matches
 	// at all times which matches the event.matches property as well, so the callback works the same.


### PR DESCRIPTION
This marks the beginning of migrating the script assets we have. As a result, several extra changes were included. 
* The libraries directories and webpack aliases and the Common.js module code (heavily commented out to act as guide placeholders while we slowly flesh it out again). 
* Stub explanatory files were added to the directories to give a sense of where to place new or migrated assets.
* The page options partial was moved into its library scope and to maintain override hierarchy, the common.scss file import was moved to the top of common.js to allow libraries to override it as needed.
* page options relied on certain metadata elements to be extant that currently aren't. Extra checks/fallbacks were added to avoid errors. At the moment however, og:url nnot being there means things like twitter will have undefined as their url. When html.html.twig is fleshed out in a future sprint, this should fix itself.
* page options is also dependent on the customEventHandler library which was ported as well in this ticket.