### PR TITLE
Add Press Release views

### DIFF
--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.info.yml
@@ -10,4 +10,5 @@ dependencies:
   - content_moderation
   - language
   - content_translation
+  - config_translation
   - cgov_site_section

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.info.yml
@@ -10,5 +10,4 @@ dependencies:
   - content_moderation
   - language
   - content_translation
-  - config_translation
   - cgov_site_section

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/core.entity_view_display.node.cgov_press_release.list_item_title_date_desc.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/core.entity_view_display.node.cgov_press_release.list_item_title_date_desc.yml
@@ -48,6 +48,14 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
+  field_page_description:
+    type: string
+    weight: 2
+    region: content
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
 hidden:
   body: true
   content_moderation_control: true
@@ -59,7 +67,6 @@ hidden:
   field_feature_card_description: true
   field_image_article: true
   field_image_promotional: true
-  field_page_description: true
   field_press_release_type: true
   field_pretty_url: true
   field_public_use: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/core.entity_view_display.node.cgov_press_release.list_item_title_date_desc_image.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/core.entity_view_display.node.cgov_press_release.list_item_title_date_desc_image.yml
@@ -42,25 +42,33 @@ content:
     third_party_settings: {  }
   field_image_article:
     type: entity_reference_entity_view
-    weight: 3
-    region: content
-    label: hidden
-    settings:
-      link: true
-      view_mode: default
-    third_party_settings: {  }
-  field_image_promotional:
-    type: entity_reference_entity_view
     weight: 2
     region: content
     label: hidden
     settings:
-      link: true
-      view_mode: default
+      view_mode: image_crop_thumbnail
+      link: false
+    third_party_settings: {  }
+  field_image_promotional:
+    type: entity_reference_entity_view
+    weight: 1
+    region: content
+    label: hidden
+    settings:
+      view_mode: image_crop_thumbnail
+      link: false
     third_party_settings: {  }
   field_list_description:
     type: string
-    weight: 1
+    weight: 3
+    region: content
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+  field_page_description:
+    type: string
+    weight: 4
     region: content
     label: hidden
     settings:
@@ -75,7 +83,6 @@ hidden:
   field_date_reviewed: true
   field_date_updated: true
   field_feature_card_description: true
-  field_page_description: true
   field_press_release_type: true
   field_pretty_url: true
   field_public_use: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/core.entity_view_display.node.cgov_press_release.list_item_title_date_image.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/core.entity_view_display.node.cgov_press_release.list_item_title_date_image.yml
@@ -35,7 +35,7 @@ content:
     type: datetime_default
     weight: 0
     region: content
-    label: above
+    label: hidden
     settings:
       timezone_override: ''
       format_type: cgov_display_date

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/core.entity_view_display.node.cgov_press_release.list_item_title_desc.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/core.entity_view_display.node.cgov_press_release.list_item_title_desc.yml
@@ -38,6 +38,14 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
+  field_page_description:
+    type: string
+    weight: 1
+    region: content
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
 hidden:
   body: true
   content_moderation_control: true
@@ -50,7 +58,6 @@ hidden:
   field_feature_card_description: true
   field_image_article: true
   field_image_promotional: true
-  field_page_description: true
   field_press_release_type: true
   field_pretty_url: true
   field_public_use: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/core.entity_view_display.node.cgov_press_release.list_item_title_desc_image.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/core.entity_view_display.node.cgov_press_release.list_item_title_desc_image.yml
@@ -32,7 +32,7 @@ mode: list_item_title_desc_image
 content:
   field_image_article:
     type: entity_reference_entity_view
-    weight: 2
+    weight: 1
     region: content
     label: hidden
     settings:
@@ -41,7 +41,7 @@ content:
     third_party_settings: {  }
   field_image_promotional:
     type: entity_reference_entity_view
-    weight: 1
+    weight: 0
     region: content
     label: hidden
     settings:
@@ -50,7 +50,15 @@ content:
     third_party_settings: {  }
   field_list_description:
     type: string
-    weight: 0
+    weight: 2
+    region: content
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+  field_page_description:
+    type: string
+    weight: 3
     region: content
     label: hidden
     settings:
@@ -66,7 +74,6 @@ hidden:
   field_date_reviewed: true
   field_date_updated: true
   field_feature_card_description: true
-  field_page_description: true
   field_press_release_type: true
   field_pretty_url: true
   field_public_use: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/views.view.press_releases.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/views.view.press_releases.yml
@@ -1,0 +1,259 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.list_item_title_date
+    - core.entity_view_mode.node.list_item_title_date_image
+    - node.type.cgov_press_release
+  module:
+    - datetime
+    - node
+    - user
+id: press_releases
+label: 'Press Releases'
+module: views
+description: ''
+tag: ''
+base_table: node_field_data
+base_field: nid
+core: 8.x
+display:
+  default:
+    display_plugin: default
+    id: default
+    display_title: Master
+    position: 0
+    display_options:
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: false
+          distinct: true
+          replica: false
+          query_comment: ''
+          query_tags: {  }
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      pager:
+        type: full
+        options:
+          items_per_page: 20
+          offset: 0
+          id: 0
+          total_pages: null
+          tags:
+            previous: ‹‹
+            next: ››
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
+      style:
+        type: default
+      row:
+        type: 'entity:node'
+        options:
+          relationship: none
+          view_mode: list_item_title_date_image
+      fields:
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          entity_type: node
+          entity_field: title
+          label: ''
+          alter:
+            alter_text: false
+            make_link: false
+            absolute: false
+            trim: false
+            word_boundary: false
+            ellipsis: false
+            strip_tags: false
+            html: false
+          hide_empty: false
+          empty_zero: false
+          settings:
+            link_to_entity: true
+          plugin_id: field
+          relationship: none
+          group_type: group
+          admin_label: ''
+          exclude: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+      filters:
+        status:
+          value: '1'
+          table: node_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: node
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+          group: 1
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          value:
+            cgov_press_release: cgov_press_release
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+      sorts:
+        field_date_posted_value:
+          id: field_date_posted_value
+          table: node__field_date_posted
+          field: field_date_posted_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          order: DESC
+          exposed: false
+          expose:
+            label: ''
+          granularity: second
+          plugin_id: datetime
+      title: 'Press Releases'
+      header: {  }
+      footer: {  }
+      empty: {  }
+      relationships: {  }
+      arguments:
+        field_date_posted_value_year:
+          id: field_date_posted_value_year
+          table: node__field_date_posted
+          field: field_date_posted_value_year
+          relationship: none
+          group_type: group
+          admin_label: ''
+          default_action: ignore
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: fixed
+          default_argument_options:
+            argument: ''
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            items_per_page: 25
+            override: false
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          plugin_id: datetime_year
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  block_1:
+    display_plugin: block
+    id: block_1
+    display_title: 'Press Releases-Title Date'
+    position: 1
+    display_options:
+      display_extenders: {  }
+      rendering_language: '***LANGUAGE_language_interface***'
+      display_description: ''
+      style:
+        type: default
+        options: {  }
+      defaults:
+        style: false
+        row: false
+      row:
+        type: 'entity:node'
+        options:
+          relationship: none
+          view_mode: list_item_title_date
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  block_2:
+    display_plugin: block
+    id: block_2
+    display_title: 'Press Releases-Title Date Image'
+    position: 1
+    display_options:
+      display_extenders: {  }
+      rendering_language: '***LANGUAGE_language_interface***'
+      display_description: ''
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/views.view.press_releases.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/views.view.press_releases.yml
@@ -146,6 +146,46 @@ display:
           entity_type: node
           entity_field: type
           plugin_id: bundle
+        langcode:
+          id: langcode
+          table: node_field_revision
+          field: langcode
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: in
+          value:
+            '***LANGUAGE_language_interface***': '***LANGUAGE_language_interface***'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: node
+          entity_field: langcode
+          plugin_id: language
       sorts:
         field_date_posted_value:
           id: field_date_posted_value

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/views.view.press_releases.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/views.view.press_releases.yml
@@ -253,7 +253,7 @@ display:
   block_1:
     display_plugin: block
     id: block_1
-    display_title: 'Press Releases-Title Date'
+    display_title: 'Press Releases-Listing'
     position: 1
     display_options:
       display_extenders: {  }
@@ -282,18 +282,43 @@ display:
   block_2:
     display_plugin: block
     id: block_2
-    display_title: 'Press Releases-Title Date Image'
+    display_title: 'Press Releases-News Page Block'
     position: 1
     display_options:
       display_extenders: {  }
       rendering_language: '***LANGUAGE_language_interface***'
       display_description: ''
+      pager:
+        type: some
+        options:
+          items_per_page: 10
+          offset: 0
+      defaults:
+        pager: false
+        use_more: false
+        use_more_always: false
+        use_more_text: false
+        footer: false
+      use_more: false
+      use_more_always: true
+      use_more_text: 'All NCI News'
+      footer:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: false
+          tokenize: false
+          content: '<a class="arrow-link news-footer" href="/news-events/press-releases/2019">All NCI news</a>'
+          plugin_id: text_custom
     cache_metadata:
       max-age: -1
       contexts:
         - 'languages:language_interface'
         - url
-        - url.query_args
         - 'user.node_grants:view'
         - user.permissions
       tags: {  }

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/press_release.content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/press_release.content.yml
@@ -193,6 +193,7 @@
     value: "Press Release Title English"
   field_date_display_mode:
   field_list_description:
+    value: "List Description overriding meta description"
   field_page_description:
     value: "This is the Meta Description AKA Page Description"
   field_date_posted:


### PR DESCRIPTION
Add Press Release view blocks to system.  Also enables Config Translation module and removes a stray field label.

To create demo content:
- Enable Devel Generate
- Remove Press Releases from the Editorial workflow (can't publish via VBO while managed)
- Generate 50 English and 50 Spanish Content items
- Go to /admin/content, filter on Press Release, select all nodes and bulk Publish.

Fixes #299  
Helps #297 but doesn't close them, as the mini landing pages still need to be created.