### PR TITLE
Move NavItem filtering to plugin level to avoid cache issue

### DIFF
--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.services.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.services.yml
@@ -1,4 +1,7 @@
 services:
+  logger.channel.cgov_core:
+    parent: logger.channel_base
+    arguments: ['cgov_core']
   cgov_core.page_options_manager:
     class: Drupal\cgov_core\Services\PageOptionsManager
     arguments: ['@current_route_match']
@@ -10,4 +13,4 @@ services:
       - '@entity_type.manager'
   cgov_core.cgov_navigation_manager:
     class: Drupal\cgov_core\Services\CgovNavigationManager
-    arguments: ['@path.current', '@path.alias_manager', '@entity_type.manager', '@entity_field.manager']
+    arguments: ['@path.current', '@path.alias_manager', '@entity_type.manager', '@entity_field.manager', '@logger.channel.cgov_core']

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/NavItem.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/NavItem.php
@@ -156,7 +156,13 @@ class NavItem {
     $this->label = $this->term->field_navigation_label->value
       ? $this->term->field_navigation_label->value
       : $this->term->name->value;
-    $this->href = $this->term->computed_path->value;
+
+    $href = $this->term->computed_path->value;
+    // We need to manually prepend the '/espanol' for spanish terms.
+    if ($this->term->language()->getId() === 'es') {
+      $href = "/espanol$href";
+    }
+    $this->href = $href;
 
     // @var [['value' => string], ['value' => string]]
     $navigationDisplayRules = $this->term->field_navigation_display_options->getValue();

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/NavItem.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/NavItem.php
@@ -161,13 +161,11 @@ class NavItem {
     // @var [['value' => string], ['value' => string]]
     $navigationDisplayRules = $this->term->field_navigation_display_options->getValue();
     $navigationDisplayRules = count($navigationDisplayRules) ? $navigationDisplayRules : [];
-    // Build a lookup table for easier reference later.
-    $displayRules = [];
+    // Populate a lookup table for easier reference later.
     foreach ($navigationDisplayRules as $rule) {
       $rule = $rule['value'];
-      $displayRules[$rule] = TRUE;
+      $this->displayRules[$rule] = TRUE;
     };
-    $this->displayRules = $displayRules;
   }
 
   /**
@@ -266,30 +264,17 @@ class NavItem {
    * Optional, pass an array of class properties
    * with boolean values to filter children against.
    *
-   * @param string[] $filters
-   *   Optional list of properties to filter children
-   *   against, each string should map to a valid
-   *   property on this class instance.
-   *
    * @return \Drupal\cgov_core\NavItemInterface[]
    *   Filtered array of direct descendents.
    */
-  public function getChildren(array $filters = []) {
+  public function getChildren() {
     // @var \Drupal\taxonomy\TermInterface[]
     $allChildTerms = $this->navMgr->getChildTerms($this->term);
     // Build the navItems to make interacting with terms easier.
     $navItems = array_map(function ($term) {
       return $this->navMgr->newNavItem($term);
     }, $allChildTerms);
-    $filteredChildren = array_filter($navItems, function ($child) use ($filters) {
-      foreach ($filters as $filter) {
-        if ($child->hasDisplayRule($filter)) {
-          return FALSE;
-        }
-      }
-      return TRUE;
-    });
-    return $filteredChildren;
+    return $navItems;
   }
 
 }

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Plugin/Block/Breadcrumb.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Plugin/Block/Breadcrumb.php
@@ -135,11 +135,16 @@ class Breadcrumb extends BlockBase implements ContainerFactoryPluginInterface {
     $breadcrumbs = $this->getBreadcrumbs();
     $build = [
       '#type' => 'block',
-      '#cache' => ['max-age' => 0],
       'breadcrumbs' => $breadcrumbs,
     ];
-
     return $build;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheMaxAge() {
+    return 0;
   }
 
 }

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Plugin/Block/Breadcrumb.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Plugin/Block/Breadcrumb.php
@@ -91,7 +91,16 @@ class Breadcrumb extends BlockBase implements ContainerFactoryPluginInterface {
       // We only want to go as far as one level below the current site
       // section.
       while ($child && !$child->isCurrentSiteSection()) {
-        $children = $child->getChildren(['isInActivePath']);
+        $children = $child->getChildren();
+        // Filter results to only the child in the current path.
+        // (Should always be just one).
+        $children = array_filter($children, function ($child) {
+          if ($child->getIsInCurrentPath() === TRUE) {
+            return TRUE;
+          }
+          return FALSE;
+        });
+
         $child = NULL;
         // We should only ever find one child in the active path.
         // Otherwise this is NULL and the while loop exits.

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Plugin/Block/MainNav.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Plugin/Block/MainNav.php
@@ -99,7 +99,14 @@ class MainNav extends BlockBase implements ContainerFactoryPluginInterface {
    *   Markup as string.
    */
   public function renderMainNav(NavItem $navRoot) {
-    $megaNavRootItems = $navRoot->getChildren(['hide_in_main_nav']);
+    $megaNavRootItems = $navRoot->getChildren();
+    $megaNavRootItems = array_filter($megaNavRootItems, function ($child) {
+      if ($child->hasDisplayRule('hide_in_main_nav')) {
+        return FALSE;
+      }
+      return TRUE;
+    });
+
     $renderedMegaNavTrees = [];
     for ($i = 0; $i < count($megaNavRootItems); $i++) {
       $rootItem = $megaNavRootItems[$i];
@@ -152,7 +159,13 @@ class MainNav extends BlockBase implements ContainerFactoryPluginInterface {
    */
   public function renderMobileNavLevel(NavItem $rootItem, bool $isOpen, int $currentDepth) {
     $isNotLastLevel = self::MOBILE_NAV_MAX_DEPTH - $currentDepth > 0;
-    $mobileItemsToRender = $rootItem->getChildren(['hide_in_mobile_nav']);
+    $mobileItemsToRender = $rootItem->getChildren();
+    $mobileItemsToRender = array_filter($mobileItemsToRender, function ($child) {
+      if ($child->hasDisplayRule('hide_in_mobile_nav')) {
+        return FALSE;
+      }
+      return TRUE;
+    });
     $hasItemsToRender = count($mobileItemsToRender);
     if (!$hasItemsToRender) {
       return "";

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Plugin/Block/MainNav.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Plugin/Block/MainNav.php
@@ -215,8 +215,14 @@ class MainNav extends BlockBase implements ContainerFactoryPluginInterface {
     $build = [
       '#markup' => $navTree,
     ];
-
     return $build;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheMaxAge() {
+    return 0;
   }
 
 }

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Plugin/Block/SectionNav.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Plugin/Block/SectionNav.php
@@ -114,7 +114,13 @@ class SectionNav extends BlockBase implements ContainerFactoryPluginInterface {
     $isCurrentSection = $navItem->isCurrentSiteSection();
     $href = $navItem->getHref();
     $label = $navItem->getLabel();
-    $childList = $navItem->getChildren(['hide_in_section_nav']);
+    $childList = $navItem->getChildren();
+    $childList = array_filter($childList, function ($child) {
+      if ($child->hasDisplayRule('hide_in_section_nav')) {
+        return FALSE;
+      }
+      return TRUE;
+    });
     $hasChildren = count($childList) > 0;
     $children = [];
     if ($renderDepth > 1 && $hasChildren) {

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Plugin/Block/SectionNav.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Plugin/Block/SectionNav.php
@@ -156,11 +156,16 @@ class SectionNav extends BlockBase implements ContainerFactoryPluginInterface {
     $navTree = $this->getSectionNav();
     $build = [
       '#type' => 'block',
-      '#cache' => ['max-age' => 0],
       'nav_tree' => $navTree,
     ];
-
     return $build;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheMaxAge() {
+    return 0;
   }
 
 }

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Plugin/Block/SectionNav.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Plugin/Block/SectionNav.php
@@ -156,7 +156,7 @@ class SectionNav extends BlockBase implements ContainerFactoryPluginInterface {
     $navTree = $this->getSectionNav();
     $build = [
       '#type' => 'block',
-      '#cache' => ['contexts' => ['url.path']],
+      '#cache' => ['max-age' => 0],
       'nav_tree' => $navTree,
     ];
 

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Services/CgovNavigationManager.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Services/CgovNavigationManager.php
@@ -8,6 +8,7 @@ use Drupal\Core\Entity\EntityFieldManagerInterface;
 use Drupal\Core\Path\CurrentPathStack;
 use Drupal\taxonomy\TermInterface;
 use Drupal\cgov_core\NavItem;
+use Psr\Log\LoggerInterface;
 
 /**
  * Cgov Navigation Manager Service.
@@ -76,18 +77,27 @@ class CgovNavigationManager {
   protected $entityFieldManager;
 
   /**
+   * Logger.
+   *
+   * @var \Psr\Log\LoggerInterface
+   */
+  protected $logger;
+
+  /**
    * Constructs a new CgovNavigationManager class.
    */
   public function __construct(
     CurrentPathStack $currentPath,
     AliasManagerInterface $pathAliasManager,
     EntityTypeManagerInterface $entityTypeManager,
-    EntityFieldManagerInterface $entityFieldManager
+    EntityFieldManagerInterface $entityFieldManager,
+    LoggerInterface $logger
     ) {
     $this->currentPath = $currentPath;
     $this->pathAliasManager = $pathAliasManager;
     $this->entityTypeManager = $entityTypeManager;
     $this->entityFieldManager = $entityFieldManager;
+    $this->logger = $logger;
   }
 
   /**
@@ -97,6 +107,7 @@ class CgovNavigationManager {
     if ($this->initialized) {
       return;
     }
+    $this->logger->notice('Hello');
     $this->initialized = TRUE;
     $this->closestSiteSection = $this->getClosestSiteSection();
     // Guard against when this service is called inadvertantly by

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Services/CgovNavigationManager.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Services/CgovNavigationManager.php
@@ -107,7 +107,7 @@ class CgovNavigationManager {
     if ($this->initialized) {
       return;
     }
-    $this->logger->notice('Hello');
+    $this->logger->notice('Cgov Navigation Manager initialized.');
     $this->initialized = TRUE;
     $this->closestSiteSection = $this->getClosestSiteSection();
     // Guard against when this service is called inadvertantly by
@@ -115,6 +115,9 @@ class CgovNavigationManager {
     // vocabulary.
     if ($this->closestSiteSection) {
       $this->fullAncestry = $this->getTermAncestry($this->closestSiteSection);
+      $this->logger->notice("NavMgr: Full Ancestry = " . implode(", ", array_map(function ($el) {
+        return "(" . strval($el->id()) . ": '" . $el->computed_path->value . "')";
+      }, $this->fullAncestry)));
     }
   }
 
@@ -293,6 +296,7 @@ class CgovNavigationManager {
         $isNavRoot = $term->{$testFieldName}->value;
         if ($isNavRoot) {
           $navItem = $this->newNavItem($term);
+          $this->logger->notice("NavItem created: href= '{$navItem->getHref()}', id= @id", ["@id" => strval($term->id())]);
           return $navItem;
         }
       }

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Services/CgovNavigationManager.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Services/CgovNavigationManager.php
@@ -296,7 +296,7 @@ class CgovNavigationManager {
         $isNavRoot = $term->{$testFieldName}->value;
         if ($isNavRoot) {
           $navItem = $this->newNavItem($term);
-          $this->logger->notice("NavItem created: href= '{$navItem->getHref()}', id= @id", ["@id" => strval($term->id())]);
+          $this->logger->notice("NavMgr: (NavItem created) href= '{$navItem->getHref()}', id= @id", ["@id" => strval($term->id())]);
           return $navItem;
         }
       }


### PR DESCRIPTION
An issue with Block level caching was causing issues on non-local environments. This PR handles:
- Adding a logger to Nav Manager Service (temporarily?)
- Removing caching on block plugins in a way that actually worked on the ODE
- Fix issue with spanish urls not getting /espanol path prepend
- Moving filtering of child terms from NavItem to plugin to reduce even more potential cache issues.