### PR TITLE
#774 Add 

### DIFF
--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/cgov_yaml_content.services.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/cgov_yaml_content.services.yml
@@ -1,6 +1,6 @@
 services:
   cgov_yaml_content.event_subscriber:
     class: Drupal\cgov_yaml_content\Service\CgovYamlContentEventSubscriber
-    arguments: ['@theme.manager', '@entity.query', '@entity_type.manager']
+    arguments: ['@theme.manager', '@entity.query', '@entity_type.manager', '@token']
     tags:
       - {name: event_subscriber}

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/090_research_key-initiatives.content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/090_research_key-initiatives.content.yml
@@ -94,9 +94,9 @@
               '#process':
                 callback: 'reference'
                 args:
-                - 'node'
-                - type: 'cgov_article'
-                  title: 'NCI Community Oncology Research Program (NCORP)'
+                  - 'node'
+                  - type: 'cgov_article'
+                    title: 'NCI Community Oncology Research Program (NCORP)'
         - entity: 'paragraph'
           type: "cgov_card_internal"
           field_override_card_title:

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/press_release.content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/press_release.content.yml
@@ -588,8 +588,7 @@
           - 'image'
           - type: 'module'
             filename: 'cancer-death-rates-declined.__v400101332.png'
-        alt: 'Cancer death rate chart ALT'
-        alt__ES: 'Cancer death rate chart ALT - ES'
+      alt: 'Cancer death rate chart ALT'
   # @todo: not working - alternate graphic for spanish language (eg: Medical Illustration method)
   field_media_image__ES:
     - '#process':
@@ -598,8 +597,7 @@
           - 'image'
           - type: 'module'
             filename: 'cancer-death-rates-declined-esp.__v400125360.png'
-        alt: 'Cancer Death Rates Declined ALT'
-        alt__ES: 'Cancer Death Rates Declined ALT - ES'
+      alt: 'Cancer Death Rates Declined ALT - ES'
   field_credit: "iStock"
   field_credit__ES:
     value: "iStock - ES"

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/src/Service/CgovYamlContentEventSubscriber.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/src/Service/CgovYamlContentEventSubscriber.php
@@ -10,6 +10,11 @@ use Drupal\paragraphs\Entity\Paragraph;
 use Drupal\Core\Theme\ThemeManagerInterface;
 use Drupal\Core\Entity\Query\QueryFactory;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Component\Render\PlainTextOutput;
+use Drupal\Core\Utility\Token;
+use Drupal\Core\TypedData\Exception\MissingDataException;
+use Drupal\file\Plugin\Field\FieldType\FileFieldItemList;
+use Drupal\Core\Entity\EntityInterface;
 
 /**
  * Handle yaml_content custom events.
@@ -38,6 +43,13 @@ class CgovYamlContentEventSubscriber implements EventSubscriberInterface {
   protected $entityTypeManager;
 
   /**
+   * Drupal token service.
+   *
+   * @var \Drupal\Core\Utility\Token
+   */
+  protected $token;
+
+  /**
    * Create new Event Subscriber class.
    *
    * @param \Drupal\Core\Theme\ThemeManagerInterface $themeManager
@@ -46,15 +58,19 @@ class CgovYamlContentEventSubscriber implements EventSubscriberInterface {
    *   Query factory.
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
    *   Drupal Entity Type Manager.
+   * @param \Drupal\Core\Utility\Token $token
+   *   Drupal token service.
    */
   public function __construct(
     ThemeManagerInterface $themeManager,
     QueryFactory $entityQueryFactory,
-    EntityTypeManagerInterface $entityTypeManager
+    EntityTypeManagerInterface $entityTypeManager,
+    Token $token
     ) {
     $this->themeManager = $themeManager;
     $this->entityQueryFactory = $entityQueryFactory;
     $this->entityTypeManager = $entityTypeManager;
+    $this->token = $token;
   }
 
   /**
@@ -166,15 +182,74 @@ class CgovYamlContentEventSubscriber implements EventSubscriberInterface {
       $query->condition($property, $value);
     }
     $entity_ids = $query->execute();
-    if (count($entity_ids) > 0) {
-      $first_id = array_shift($entity_ids);
-      $fieldReferenceArray = ['target_id' => $first_id];
+
+    // Reference entity can't be found. Create it.
+    if (empty($entity_ids)) {
+      $entity = $this->entityTypeManager->getStorage($entity_type)->create($args);
+      $entity_ids = [$entity->id()];
+    }
+
+    // Creating it failed.
+    if (empty($entity_ids)) {
+      return $this->throwParamError('Unable to process reference. Reference not found.', $entity_type);
+    }
+
+    $first_id = array_shift($entity_ids);
+    $fieldReferenceArray = ['target_id' => $first_id];
+    return $fieldReferenceArray;
+  }
+
+  /**
+   * Handle #process file directives.
+   *
+   * @param array $processConfig
+   *   Config.
+   * @param \Drupal\file\Plugin\Field\FieldType\FileFieldItemList $field
+   *   Field.
+   */
+  public function processFile(array $processConfig, FileFieldItemList $field) {
+    var_dump(get_class($field));
+    $entity_type = $processConfig['#process']['args'][0];
+    $filename = $processConfig['#process']['args'][1]['filename'];
+    unset($processConfig['#process']);
+    // After unsetting the #process config, we should be
+    // left with anything intended for the field, such as alt
+    // tags.
+    $path = drupal_get_path('module', 'cgov_yaml_content');
+    $directory = '/data_files/';
+    // If the entity type is an image, look in to the /images directory.
+    if ($entity_type == 'image') {
+      $directory = '/images/';
+    }
+    $fileData = file_get_contents($path . $directory . $filename);
+    $fileExists = $fileData !== FALSE;
+    if ($fileExists) {
+      $destination = 'public://';
+      // Look-up the field's directory configuration.
+      // Returns a token pattern.
+      $directory = $field->getSetting('file_directory');
+      if ($directory) {
+        $directory = trim($directory, '/');
+        $directory = PlainTextOutput::renderFromHtml($this->token->replace($directory));
+        if ($directory) {
+          $destination .= $directory . '/';
+        }
+      }
+
+      // Create the destination directory if it does not already exist.
+      file_prepare_directory($destination, FILE_CREATE_DIRECTORY);
+
+      // Save the file data or return an existing file.
+      $file = file_save_data($fileData, $destination . $filename, FILE_EXISTS_REPLACE);
+
+      // Use the newly created file id as the value.
+      $processConfig['target_id'] = $file->id();
+      return $processConfig;
     }
     else {
-      // Reference can't be found.
-      // TODO: Create thing instead?
+      return $this->throwParamError('Unable to process file content. File not found.', $entity_type);
     }
-    return $fieldReferenceArray;
+
   }
 
   /**
@@ -182,11 +257,13 @@ class CgovYamlContentEventSubscriber implements EventSubscriberInterface {
    *
    * @param array|string $fields
    *   Entity/Field data as array.
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   Entity.
    *
    * @return array
    *   Processed fields.
    */
-  public function handleProcessDirectives($fields) {
+  public function handleProcessDirectives($fields, EntityInterface $entity) {
     foreach ($fields as $fieldName => $fieldData) {
       // Test for process directives:
       // Process directives are associative arrays with
@@ -211,13 +288,14 @@ class CgovYamlContentEventSubscriber implements EventSubscriberInterface {
               $processedFieldContents[] = $processedReference;
             }
             elseif ((isset($value['#process']['callback']) && $value['#process']['callback'] === 'file')) {
-              // TODO: Handle file process directives. Until then, avoid errors
-              // by skipping the translated field altogether.
+              $field = $entity->get($fieldName);
+              $processedReference = $this->processFile($value, $field);
+              $processedFieldContents[] = $processedReference;
             }
             else {
               // You made a mistake formatting your process directive. Ha ha.
               // Go directly to jail, do not pass go.
-              // TODO: Throw, when exception handling gets added in.
+              return $this->throwParamError('Unable to process file content. Process callback not file or reference.', "", $value);
             }
           }
           else {
@@ -313,7 +391,7 @@ class CgovYamlContentEventSubscriber implements EventSubscriberInterface {
     // as callbacks in the yml.
     // Translated fields also doing that don't have access to this feature
     // so we are going to recreate the functionality on an as-needed basis.
-    $translatedFields = $this->handleProcessDirectives($translatedFields);
+    $translatedFields = $this->handleProcessDirectives($translatedFields, $entity);
 
     // 4. Create translation.
     $spanishTranslationAlreadyExists = $entity->hasTranslation('es');
@@ -452,6 +530,31 @@ class CgovYamlContentEventSubscriber implements EventSubscriberInterface {
     ];
     $siteSection->set('field_landing_page', $savedEntityReference);
     $siteSection->save();
+  }
+
+  /**
+   * Prepare an error message and throw error.
+   *
+   * @param string $error_message
+   *   The error message to display.
+   * @param string $entity_type
+   *   The entity type.
+   * @param array $filter_params
+   *   The filters for the query conditions.
+   */
+  protected function throwParamError($error_message, $entity_type = "ENTITY TYPE UNKNOWN", array $filter_params = []) {
+    // Build parameter output description for error message.
+    $error_params = [
+      '[',
+      '  "entity_type" => ' . $entity_type . ',',
+    ];
+    foreach ($filter_params as $key => $value) {
+      $error_params[] = sprintf("  '%s' => '%s',", $key, $value);
+    }
+    $error_params[] = ']';
+    $param_output = implode("\n", $error_params);
+
+    throw new MissingDataException(__CLASS__ . ': ' . $error_message . ': ' . $param_output);
   }
 
 }


### PR DESCRIPTION
Closes #774.

 This update adds:
- The ability for field translations to include 'file' #process directives.
- The ability for 'reference' #process directives to create non-existent references.
- Exception handling

This update fixes a few yaml files that were previously silently failing and now throwing due to the update.