### PR TITLE
Fix Pretty URL helper text

### DIFF
--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/config/install/field.field.node.cgov_mini_landing.field_pretty_url.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/config/install/field.field.node.cgov_mini_landing.field_pretty_url.yml
@@ -9,7 +9,7 @@ field_name: field_pretty_url
 entity_type: node
 bundle: cgov_mini_landing
 label: 'Pretty URL'
-description: ''
+description: 'Used as the last segment of the URL. Do not include slash. Leave blank if page is the designated landing page in the site section. Must be lowercase, with no space. Use hyphens to separate words. [See SEO Guidelines PDF for more details.]'
 required: false
 translatable: true
 default_value: {  }

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_site_section/config/install/field.field.taxonomy_term.cgov_site_sections.field_pretty_url.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_site_section/config/install/field.field.taxonomy_term.cgov_site_sections.field_pretty_url.yml
@@ -9,7 +9,7 @@ field_name: field_pretty_url
 entity_type: taxonomy_term
 bundle: cgov_site_sections
 label: 'Pretty URL'
-description: 'Used as the "tail" of the URL. When building URL paths for the section, the parent sections pretty URL path is pre-pended to this.'
+description: 'Used as the "tail" of the URL for the assigned landing page. When building URL paths for the section, the parent sections'' pretty URL path is pre-pended to this.'
 required: false
 translatable: false
 default_value: {  }

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_site_section/config/install/field.field.taxonomy_term.cgov_site_sections.field_pretty_url.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_site_section/config/install/field.field.taxonomy_term.cgov_site_sections.field_pretty_url.yml
@@ -9,7 +9,7 @@ field_name: field_pretty_url
 entity_type: taxonomy_term
 bundle: cgov_site_sections
 label: 'Pretty URL'
-description: 'Used as the "tail" of the URL for the assigned landing page. When building URL paths for the section, the parent sections'' pretty URL path is pre-pended to this.'
+description: 'Used as the "tail" of the URL for the assigned landing page. When building URL paths for the section, the parent section''s pretty URL path is pre-pended to this.'
 required: false
 translatable: false
 default_value: {  }


### PR DESCRIPTION
Add missing helper text to Mini Landing Page.
Update Pretty URL helper text for Site Section.

Closes #694.

(No seriously. It really does close it this time. (Probably.))