### PR TITLE
Ticket/904 Test for active site section improvement.

### DIFF
--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/NavItem.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/NavItem.php
@@ -274,6 +274,20 @@ class NavItem {
   }
 
   /**
+   * Test if this term is the landing page for current site section.
+   *
+   * For visual reasons section navigation requires distinguishing
+   * between the state of being the closest site section in the
+   * current path's ancestry and also being that section's landing page.
+   *
+   * @return bool
+   *   Bool.
+   */
+  public function isCurrentSiteSectionLandingPage() {
+    return $this->isCurrentSiteSection() && $this->navMgr->isCurrentSiteSectionLandingPage();
+  }
+
+  /**
    * Get immediate descendent NavItems.
    *
    * Optional, pass an array of class properties

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Plugin/Block/SectionNav.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Plugin/Block/SectionNav.php
@@ -111,7 +111,7 @@ class SectionNav extends BlockBase implements ContainerFactoryPluginInterface {
     // TODO: Consider building this as nested markup elements to completely
     // obviate the need for a template that simply parallels this logic.
     $isInCurrentPath = $navItem->getIsInCurrentPath();
-    $isCurrentSection = $navItem->isCurrentSiteSection();
+    $isCurrentSectionLandingPage = $navItem->isCurrentSiteSectionLandingPage();
     $href = $navItem->getHref();
     $label = $navItem->getLabel();
     $childList = $navItem->getChildren();
@@ -143,7 +143,7 @@ class SectionNav extends BlockBase implements ContainerFactoryPluginInterface {
       'label' => $label,
       'class' => $class,
       'isExpanded' => $isExpanded,
-      'isCurrentSection' => $isCurrentSection,
+      'isCurrentSectionLandingPage' => $isCurrentSectionLandingPage,
       'children' => $children,
     ];
     return $renderElement;

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/block/section_nav/block--cgov-section-nav.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/block/section_nav/block--cgov-section-nav.html.twig
@@ -2,7 +2,7 @@
   {% import _self as macros %}
   {% for link in links %}
     <li class="{{ link.class }}">
-      <div class="{{ link.isCurrentSection ? 'current-page' : '' }}">
+      <div class="{{ link.isCurrentSectionLandingPage ? 'current-page' : '' }}">
         <a href="{{ link.href }}">{{ link.label }}</a>
         {# Sadly, for legacy reasons, we need to defer to the FE code for injecting buttons #}
         {# TODO: Post-migration refactor to move template generating to templates.  %}


### PR DESCRIPTION
For purposes of visual rendering, the section navigation needs to not only know when it's rendering the current site section for the request, but also whether the request was made from that site section's landing page. 

This fixes that by offering a service method and a navitem method to make that accessible to the section nav plugin. 

http://ncigovcdode25.prod.acquia-sites.com