### PR TITLE
Set Drupal timezone

### DIFF
--- a/docker/db/Dockerfile
+++ b/docker/db/Dockerfile
@@ -18,13 +18,6 @@ RUN apt-get install -y mariadb-server
 # Reconfigure the bind address of MySQL to allow any incoming network connection.
 RUN sed -i -e "s/^bind-address\s*=\s*127.0.0.1/bind-address = 0.0.0.0/" /etc/mysql/mariadb.conf.d/50-server.cnf
 
-# Set Timezone
-# NOTE: The xenial (16.04) base image doesn't include timezone data, so that needs to be installed.
-#       The bionic (18.04) image resolves this problem.
-RUN DEBIAN_FRONTEND=noninteractive && \
-  apt install -y tzdata && \
-  ln -fs /usr/share/zoneinfo/America/New_York /etc/localtime && \
-  dpkg-reconfigure --frontend noninteractive tzdata
 
 
 # Copy our custom entrypoint and make it executable.

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -63,10 +63,6 @@ RUN CD_VERSION=2.44 && echo "Using chromedriver version: "$CD_VERSION \
   && chmod 755 /opt/selenium/chromedriver-latest \
   && ln -fs /opt/selenium/chromedriver-latest /usr/bin/chromedriver
 
-# Set Timezone
-RUN ln -fs /usr/share/zoneinfo/America/New_York /etc/localtime && \
-  dpkg-reconfigure --frontend noninteractive tzdata
-
 
 # Replace configuration files with our own.
 ## We will be mounting these in the composer so that

--- a/docker/web/runtime/php.ini
+++ b/docker/web/runtime/php.ini
@@ -921,7 +921,7 @@ cli_server.color = On
 [Date]
 ; Defines the default timezone used by the date functions
 ; http://php.net/date.timezone
-date.timezone = America/New_York
+date.timezone = Etc/UTC
 
 ; http://php.net/date.default-latitude
 ;date.default_latitude = 31.7667

--- a/docker/web/runtime/php_apache2.ini
+++ b/docker/web/runtime/php_apache2.ini
@@ -936,7 +936,7 @@ cli_server.color = On
 [Date]
 ; Defines the default timezone used by the date functions
 ; http://php.net/date.timezone
-date.timezone = America/New_York
+date.timezone = Etc/UTC
 
 ; http://php.net/date.default-latitude
 ;date.default_latitude = 31.7667

--- a/docker/web/runtime/php_cli.ini
+++ b/docker/web/runtime/php_cli.ini
@@ -936,7 +936,7 @@ cli_server.color = On
 [Date]
 ; Defines the default timezone used by the date functions
 ; http://php.net/date.timezone
-date.timezone = America/New_York
+date.timezone = Etc/UTC
 
 ; http://php.net/date.default-latitude
 ;date.default_latitude = 31.7667

--- a/docroot/profiles/custom/cgov_site/config/install/system.date.yml
+++ b/docroot/profiles/custom/cgov_site/config/install/system.date.yml
@@ -1,0 +1,9 @@
+country:
+  default: ''
+first_day: 0
+timezone:
+  default: America/New_York
+  user:
+    configurable: true
+    warn: false
+    default: 0


### PR DESCRIPTION
- Set system.date in cgov_site.
- Revert containers to OS-default timzeone (Etc/UTC).
- Specify Etc/UTC for Php INI files in order to prevent timzeone warnings.

Closes #950