### PR TITLE
Feature/blt locale

### DIFF
--- a/blt/src/Commands/SlevenCommand.php
+++ b/blt/src/Commands/SlevenCommand.php
@@ -20,6 +20,7 @@ class SlevenCommand extends BltTasks {
       'drupal:install' => [],
       'drupal:toggle:modules' => [],
       'cgov:user:load-all' => [],
+      'custom:locales:translate' => [],
       'custom:install_cgov_yaml_content_by_module' => [
         'module' => 'cgov_yaml_content',
       ],

--- a/blt/src/Commands/SlevenCommand.php
+++ b/blt/src/Commands/SlevenCommand.php
@@ -20,7 +20,7 @@ class SlevenCommand extends BltTasks {
       'drupal:install' => [],
       'drupal:toggle:modules' => [],
       'cgov:user:load-all' => [],
-      'custom:locales:translate' => [],
+      'cgov:locales:translate' => [],
       'custom:install_cgov_yaml_content_by_module' => [
         'module' => 'cgov_yaml_content',
       ],

--- a/blt/src/Commands/TranslateCommand.php
+++ b/blt/src/Commands/TranslateCommand.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Acquia\Blt\Custom\Commands;
+
+use Acquia\Blt\Robo\BltTasks;
+
+/**
+ * Handle importing default yaml content.
+ */
+class TranslateCommand extends BltTasks {
+
+  /**
+   * Translate strings for all available locales.
+   *
+   * @command custom:locales:translate
+   */
+  public function translateAll() {
+    $commands = [
+      'custom:locales:check' => [],
+      'custom:locales:update' => [],
+    ];
+    $this->invokeCommands($commands);
+  }
+
+  /**
+   * Checks for available translation updates.
+   *
+   * @command custom:locales:check
+   */
+  public function localeCheck() {
+    $this->say("=======================================");
+    $this->say("=== Check for all available locales! ==");
+    $this->say("=======================================");
+    /** @var \Acquia\Blt\Robo\Tasks\DrushTask $task */
+    $task = $this->taskDrush()
+      ->drush('locale:check')
+      ->printOutput(TRUE);
+    $result = $task->interactive($this->input()->isInteractive())->run();
+    return $result;
+  }
+
+  /**
+   * Import the available translation updates.
+   *
+   * @command custom:locales:update
+   */
+  public function localeUpdate() {
+    $this->say("=====================================");
+    $this->say("=== Update all available locales! ===");
+    $this->say("=====================================");
+    /** @var \Acquia\Blt\Robo\Tasks\DrushTask $task */
+    $task = $this->taskDrush()
+      ->drush('locale:update')
+      ->drush('cr')
+      ->printOutput(TRUE);
+    $result = $task->interactive($this->input()->isInteractive())->run();
+    return $result;
+  }
+
+}

--- a/blt/src/Commands/TranslateCommand.php
+++ b/blt/src/Commands/TranslateCommand.php
@@ -12,12 +12,12 @@ class TranslateCommand extends BltTasks {
   /**
    * Translate strings for all available locales.
    *
-   * @command custom:locales:translate
+   * @command cgov:locales:translate
    */
   public function translateAll() {
     $commands = [
-      'custom:locales:check' => [],
-      'custom:locales:update' => [],
+      'cgov:locales:check' => [],
+      'cgov:locales:update' => [],
     ];
     $this->invokeCommands($commands);
   }
@@ -25,7 +25,7 @@ class TranslateCommand extends BltTasks {
   /**
    * Checks for available translation updates.
    *
-   * @command custom:locales:check
+   * @command cgov:locales:check
    */
   public function localeCheck() {
     $this->say("=======================================");
@@ -42,7 +42,7 @@ class TranslateCommand extends BltTasks {
   /**
    * Import the available translation updates.
    *
-   * @command custom:locales:update
+   * @command cgov:locales:update
    */
   public function localeUpdate() {
     $this->say("=====================================");

--- a/hooks/common/post-code-deploy/post-code-deploy.sh
+++ b/hooks/common/post-code-deploy/post-code-deploy.sh
@@ -30,6 +30,7 @@ users_file="$HOME/cgov-drupal-users.yml"
 ## Perform a fresh install.
 blt artifact:install:drupal --environment=$target_env -v --yes --no-interaction
 blt cgov:user:load-all -D cgov.drupal_users_file=$users_file
+blt custom:locales:translate
 blt custom:install_cgov_yaml_content_by_module cgov_yaml_content
 
 set +v

--- a/hooks/common/post-code-deploy/post-code-deploy.sh
+++ b/hooks/common/post-code-deploy/post-code-deploy.sh
@@ -30,7 +30,7 @@ users_file="$HOME/cgov-drupal-users.yml"
 ## Perform a fresh install.
 blt artifact:install:drupal --environment=$target_env -v --yes --no-interaction
 blt cgov:user:load-all -D cgov.drupal_users_file=$users_file
-blt custom:locales:translate
+blt cgov:locales:translate
 blt custom:install_cgov_yaml_content_by_module cgov_yaml_content
 
 set +v

--- a/hooks/common/post-code-update/post-code-update.sh
+++ b/hooks/common/post-code-update/post-code-update.sh
@@ -32,7 +32,7 @@ users_file="$HOME/cgov-drupal-users.yml"
 ## Perform a fresh install
 blt artifact:install:drupal --environment=$target_env -v --yes --no-interaction
 blt cgov:user:load-all -D cgov.drupal_users_file=$users_file
-blt custom:locales:translate
+blt cgov:locales:translate
 blt custom:install_cgov_yaml_content_by_module cgov_yaml_content
 
 set +v

--- a/hooks/common/post-code-update/post-code-update.sh
+++ b/hooks/common/post-code-update/post-code-update.sh
@@ -32,6 +32,7 @@ users_file="$HOME/cgov-drupal-users.yml"
 ## Perform a fresh install
 blt artifact:install:drupal --environment=$target_env -v --yes --no-interaction
 blt cgov:user:load-all -D cgov.drupal_users_file=$users_file
+blt custom:locales:translate
 blt custom:install_cgov_yaml_content_by_module cgov_yaml_content
 
 set +v


### PR DESCRIPTION
Added blt command for locale update/translation

Addresses an issue where translations are not being imported for twig files.
To 'rebuild' all translations, we need to run `drush locale:check`, `drush locale:update`, and `drush cr` in that order. This consolidates those steps into a single BLT command.