### PR TITLE
Ticket/1134 admin ui role

### DIFF
--- a/cgov-drupal-users.yml
+++ b/cgov-drupal-users.yml
@@ -10,12 +10,14 @@ additional_users:
     roles:
       - 'content_author'
       - 'image_manager'
+      - 'admin_ui'
   - username: 'editor'
     password: 'password123'
     roles:
       - 'content_author'
       - 'content_editor'
       - 'image_manager'
+      - 'admin_ui'
   - username: 'adveditor'
     password: 'password123'
     roles:
@@ -23,6 +25,7 @@ additional_users:
       - 'content_editor'
       - 'advanced_editor'
       - 'image_manager'
+      - 'admin_ui'
   - username: 'siteadmin'
     password: 'password123'
     roles:
@@ -31,3 +34,4 @@ additional_users:
       - 'advanced_editor'
       - 'site_admin'
       - 'image_manager'
+      - 'admin_ui'

--- a/docroot/profiles/custom/cgov_site/config/install/user.role.admin_ui.yml
+++ b/docroot/profiles/custom/cgov_site/config/install/user.role.admin_ui.yml
@@ -1,0 +1,19 @@
+# Siphon off some of the administrative UI permissions
+# See https://github.com/NCIOCPL/cgov-digital-platform/issues/1134.
+langcode: en
+status: true
+dependencies: {  }
+id: admin_ui
+label: 'Admin UI'
+weight: 3
+is_admin: null
+permissions:
+  - 'access administration pages'
+  - 'access toolbar'
+  - 'link to any page'
+  - 'use text format basic_html'
+  - 'use text format full_html'
+  - 'use text format raw_html'
+  - 'use text format simple'
+  - 'use text format streamlined'
+  - 'view the administration theme'

--- a/docroot/profiles/custom/cgov_site/config/install/user.role.admin_ui.yml
+++ b/docroot/profiles/custom/cgov_site/config/install/user.role.admin_ui.yml
@@ -11,7 +11,6 @@ permissions:
   - 'access administration pages'
   - 'access toolbar'
   - 'link to any page'
-  - 'use text format basic_html'
   - 'use text format full_html'
   - 'use text format raw_html'
   - 'use text format simple'

--- a/docroot/profiles/custom/cgov_site/config/install/user.role.authenticated.yml
+++ b/docroot/profiles/custom/cgov_site/config/install/user.role.authenticated.yml
@@ -6,14 +6,5 @@ label: 'Authenticated user'
 weight: 1
 is_admin: false
 permissions:
-  - 'access administration pages'
   - 'access content'
-  - 'access toolbar'
-  - 'link to any page'
-  - 'use text format basic_html'
-  - 'use text format full_html'
-  - 'use text format raw_html'
-  - 'use text format simple'
-  - 'use text format streamlined'
   - 'view media'
-  - 'view the administration theme'

--- a/docroot/profiles/custom/cgov_site/tests/src/Functional/CgovSiteTest.php
+++ b/docroot/profiles/custom/cgov_site/tests/src/Functional/CgovSiteTest.php
@@ -33,10 +33,12 @@ class CgovSiteTest extends BrowserTestBase {
     $this->assertArrayHasKey('anonymous', $roles, 'Anonymous role exists.');
     $this->assertArrayHasKey('authenticated', $roles, 'Authenticated role exists.');
     $this->assertArrayHasKey('administrator', $roles, 'Administrator role exists.');
+    $this->assertArrayHasKey('admin_ui', $roles, 'Admin UI role exists.');
 
     // Create admin user and login.
     $this->adminUser = $this->drupalCreateUser();
     $this->adminUser->addRole('administrator');
+    $this->adminUser->addRole('admin_ui');
     $this->adminUser->save();
     $this->drupalLogin($this->adminUser);
 


### PR DESCRIPTION
- Create a new role (`admin_ui`)
- Add the following permissions to the new role:
  - `access administration pages`
  - `access toolbar`
  - `link to any page`
  - `use text format full_html`
  - `use text format raw_html`
  - `use text format simple`
  - `use text format streamlined`
  - `view the administration theme`
- Remove those permissions, as well as `use text format basic_html` from the `authenticated` "role"
- Add the `admin_ui` role to all of the development accounts created in `cgov-drupal-users.yml`

Closes #1134