### PR TITLE
Fix Drupal moderation handling of new translations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -169,7 +169,8 @@
         "patches": {
             "drupal/core": {
                 "2599228 : Programmatically created translatable content type returns SQL error on content creation": "https://www.drupal.org/files/issues/2019-03-11/2599228-135.patch",
-                "2952990 : Missing schema for display_options.defaults.sitename_title": "https://www.drupal.org/files/issues/2018-03-14/views-schema-2952990-2.patch"
+                "2952990 : Missing schema for display_options.defaults.sitename_title": "https://www.drupal.org/files/issues/2018-03-14/views-schema-2952990-2.patch",
+                "3029219 : State transition validation ignores language when determining \"first time moderation\"": "https://www.drupal.org/files/issues/2019-03-24/3029219-8.patch"
             },
             "drupal/page_manager": {
                 "2876880 : page_variant entity type does not exist when installing or enabling": "https://www.drupal.org/files/issues/2876880-page-varient-cache-2.patch",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d8163a5b9cab289bf80216e553bbdeec",
+    "content-hash": "72b1fef19e228597cc6e75ca85ce44b9",
     "packages": [
         {
             "name": "acquia/acsf-tools",
@@ -3497,7 +3497,8 @@
                 },
                 "patches_applied": {
                     "2599228 : Programmatically created translatable content type returns SQL error on content creation": "https://www.drupal.org/files/issues/2019-03-11/2599228-135.patch",
-                    "2952990 : Missing schema for display_options.defaults.sitename_title": "https://www.drupal.org/files/issues/2018-03-14/views-schema-2952990-2.patch"
+                    "2952990 : Missing schema for display_options.defaults.sitename_title": "https://www.drupal.org/files/issues/2018-03-14/views-schema-2952990-2.patch",
+                    "3029219 : State transition validation ignores language when determining \"first time moderation\"": "https://www.drupal.org/files/issues/2019-03-24/3029219-8.patch"
                 }
             },
             "autoload": {


### PR DESCRIPTION
Applies the patch for [Drupal core bug 3042889](https://www.drupal.org/project/drupal/issues/3029219).

That bug did not correctly recognize that a new translation was
at the beginning of its moderation state cycle, instead conflating
the moderation history of the original language content with that
of the new translation. This resulted in failed saves because of
rejection of what should have been accepted as valid state transitions.

The Drupal core team seems reluctant to accept our patch (or even
acknowledge that this is a bug), so we have no choice but to move on
and just apply the patch ourselves.

Closes #475