### PR TITLE
Add and enable Cgov Utility form tools service. Limit article text formats

### DIFF
--- a/docroot/profiles/custom/cgov_site/cgov_site.info.yml
+++ b/docroot/profiles/custom/cgov_site/cgov_site.info.yml
@@ -49,6 +49,7 @@ install:
   - cgov_cancer_center
   - cgov_biography
   - cgov_event
+  - cgov_util
   # other Core
   - media
   - workflows

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/cgov_article.module
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/cgov_article.module
@@ -4,3 +4,20 @@
  * @file
  * Contains cgov_article.module.
  */
+
+/**
+ * Implements hook_field_widget_form_alter().
+ *
+ * Limits allowed text formats using the cgov_util form_tools service.
+ */
+function cgov_article_field_widget_form_alter(&$element, $form_state, $context) {
+  // Maps field names to an array containing a single format.
+  $map = [
+    'field_body_section_heading' => ['simple'],
+    'field_body_section_content' => ['full_html'],
+    'field_citation_content'  => ['streamlined'],
+    'field_intro_text' => ['streamlined'],
+  ];
+  $formHelper = \Drupal::service('cgov_util.form_tools');
+  $formHelper->allowTextFormats($map, $element, $context);
+}

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/core.entity_form_display.paragraph.body_section.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/core.entity_form_display.paragraph.body_section.default.yml
@@ -15,7 +15,7 @@ content:
   field_body_section_content:
     weight: 1
     settings:
-      rows: 2
+      rows: 5
       placeholder: ''
     third_party_settings: {  }
     type: text_textarea

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.info.yml
@@ -5,6 +5,7 @@ description: 'CGov Core Components (used by the CGov Site install profile)'
 core: 8.x
 dependencies:
   - cgov_site_section
+  - cgov_util
   - content_moderation
   - content_translation
   - entity_browser

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_util/cgov_util.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_util/cgov_util.info.yml
@@ -1,0 +1,6 @@
+name: 'Cgov Util'
+type: module
+description: 'Cancer.gov Utility module.'
+package: 'CGov Digital Platform'
+core: 8.x
+hidden: false

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_util/cgov_util.services.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_util/cgov_util.services.yml
@@ -1,0 +1,5 @@
+services:
+
+  # Defines a form service of which alters functionality and display of Cgov forms
+  cgov_util.form_tools:
+    class: Drupal\cgov_util\CgovFormTools

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_util/src/CgovFormTools.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_util/src/CgovFormTools.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Drupal\cgov_util;
+
+/**
+ * A service which provides methods to alter and configure form elements.
+ */
+class CgovFormTools {
+
+  /**
+   * Sets the allowed formats property for the given form elements.
+   *
+   * @param array $field_format_map
+   *   A map of fields and allowed text formats.
+   * @param mixed $element
+   *   The field widget form element on which to restrict text formats.
+   * @param mixed $context
+   *   The Drupal form context.
+   */
+  public function allowTextFormats(array $field_format_map, &$element, $context) {
+    $field_name = $context['items']->getFieldDefinition()->getName();
+
+    if (array_key_exists($field_name, $field_format_map)) {
+      $element['#allowed_formats'] = $field_format_map[$field_name];
+      $element['#after_build'][] = [static::class, 'removeTextFormatBox'];
+    }
+  }
+
+  /**
+   * Callback for #after_build. Removes dropdown and help text.
+   */
+  public static function removeTextFormatBox($form_element, $form_state) {
+    // Remove help, guidelines and wrapper.
+    unset($form_element['format']['help']);
+    unset($form_element['format']['guidelines']);
+    unset($form_element['format']['#type']);
+    unset($form_element['format']['#theme_wrappers']);
+
+    return $form_element;
+  }
+
+}

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/011_coping_feelings.content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/011_coping_feelings.content.yml
@@ -139,7 +139,7 @@
           - bundle: 'cgov_image'
             name: 'Elderly Man Looking Out Window'
   field_intro_text:
-    - format: "simple"
+    - format: "streamlined"
       value: |
         <p>Just as cancer affects your physical health, it can bring up a wide range of feelings you&rsquo;re not used to dealing with. It can also make&nbsp;existing&nbsp;feelings seem more intense. They may change daily, hourly, or even minute to minute. This is true whether you&rsquo;re currently in treatment, done with treatment, or a friend or family member. These feelings are all normal.</p>
         <p>Often the values you grew up with affect how you think about and&nbsp;cope with cancer. For example some people:</p>
@@ -151,7 +151,7 @@
         </ul>
         <p>Whatever you decide, it's important to do what's right for you and not to compare yourself with others. Your friends and family members may share some of the same feelings. If you feel comfortable, share this information with them.</p>
   field_intro_text__ES:
-    - format: "simple"
+    - format: "streamlined"
       value: |
         <p>Del mismo modo como el c&aacute;ncer afecta su salud f&iacute;sica, tambi&eacute;n puede ocasionar una amplia variedad de sentimientos que usted no&nbsp;acostumbra enfrentar. Asimismo, puede hacer que los&nbsp;sentimientos que se presentan&nbsp;parezcan&nbsp;m&aacute;s intensos. Estos sentimientos pueden cambiar a diario, cada hora o incluso cada minuto. Esto es cierto ya sea que usted est&eacute; actualmente en tratamiento,&nbsp;que lo haya terminado, o que se trate de&nbsp;un amigo o de un&nbsp;familiar. Todos estos sentimientos son normales.</p>
         <p>A menudo los valores con los que se cri&oacute; afectan su manera de pensar y de hacer frente al c&aacute;ncer. Por ejemplo, algunas personas:</p>

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/011_coping_feelings.content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/011_coping_feelings.content.yml
@@ -139,7 +139,7 @@
           - bundle: 'cgov_image'
             name: 'Elderly Man Looking Out Window'
   field_intro_text:
-    - format: "full_html"
+    - format: "simple"
       value: |
         <p>Just as cancer affects your physical health, it can bring up a wide range of feelings you&rsquo;re not used to dealing with. It can also make&nbsp;existing&nbsp;feelings seem more intense. They may change daily, hourly, or even minute to minute. This is true whether you&rsquo;re currently in treatment, done with treatment, or a friend or family member. These feelings are all normal.</p>
         <p>Often the values you grew up with affect how you think about and&nbsp;cope with cancer. For example some people:</p>
@@ -151,7 +151,7 @@
         </ul>
         <p>Whatever you decide, it's important to do what's right for you and not to compare yourself with others. Your friends and family members may share some of the same feelings. If you feel comfortable, share this information with them.</p>
   field_intro_text__ES:
-    - format: "full_html"
+    - format: "simple"
       value: |
         <p>Del mismo modo como el c&aacute;ncer afecta su salud f&iacute;sica, tambi&eacute;n puede ocasionar una amplia variedad de sentimientos que usted no&nbsp;acostumbra enfrentar. Asimismo, puede hacer que los&nbsp;sentimientos que se presentan&nbsp;parezcan&nbsp;m&aacute;s intensos. Estos sentimientos pueden cambiar a diario, cada hora o incluso cada minuto. Esto es cierto ya sea que usted est&eacute; actualmente en tratamiento,&nbsp;que lo haya terminado, o que se trate de&nbsp;un amigo o de un&nbsp;familiar. Todos estos sentimientos son normales.</p>
         <p>A menudo los valores con los que se cri&oacute; afectan su manera de pensar y de hacer frente al c&aacute;ncer. Por ejemplo, algunas personas:</p>


### PR DESCRIPTION
TIcket #835. Ability to limit text formats
* Adds and enables the Cgov Utility module
* Limits article WYSIWYG fields to allowed text formats
* Updates row size for Article body content field
