### PR TITLE
Add rule to reset ULs back to normal

### DIFF
--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/entrypoints/ckeditor/Ckeditor.scss
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/entrypoints/ckeditor/Ckeditor.scss
@@ -243,3 +243,13 @@ body {
   background-color: #f9f9f8;
   padding: 0 0 0 20px;
 }
+
+// Override the override that doesn't render Lists with bulletting.
+ul {
+  list-style: inherit;
+}
+
+li {
+  // 28px is one of two default bullet left margin standards on cgov.
+  margin-left: 28px;
+}


### PR DESCRIPTION
Closes #1238 . This is a simple fix that a) resets ul display override and b) gives a margin-left to li elements.