### PR TITLE
[WIP] Initial setup and configuration of cache Purging.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
         "cweagans/composer-patches": "^1.6.5",
         "drupal-composer/drupal-scaffold": "^2.5",
         "drupal/acquia_connector": "^1.16",
+        "drupal/acquia_purge": "^1.0@beta",
         "drupal/acsf": "^2.47.0",
         "drupal/address": "~1.0",
         "drupal/admin_toolbar": "^1.25",
@@ -201,6 +202,11 @@
                 "sites/default/default.settings.php": "sites/default/settings.php"
             }
         },
-        "composer-exit-on-patch-failure": true
+        "composer-exit-on-patch-failure": true,
+        "drush": {
+            "services": {
+                "drush.services.yml": "^9"
+            }
+        }
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "16d342330848e9eb7e619b6f8535bf71",
+    "content-hash": "a8149ce29439ed1802d7e2e89592a31c",
     "packages": [
         {
             "name": "acquia/acsf-tools",
@@ -2181,6 +2181,62 @@
             }
         },
         {
+            "name": "drupal/acquia_purge",
+            "version": "1.0.0-beta3",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/acquia_purge.git",
+                "reference": "8.x-1.0-beta3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/acquia_purge-8.x-1.0-beta3.zip",
+                "reference": "8.x-1.0-beta3",
+                "shasum": "989ec4a2168eb62340b65d1313fe4245ad781a2f"
+            },
+            "require": {
+                "drupal/core": "*",
+                "drupal/purge": "*",
+                "drupal/purge_drush": "*",
+                "drupal/purge_processor_cron": "*",
+                "drupal/purge_processor_lateruntime": "*",
+                "drupal/purge_queuer_coretags": "*"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                },
+                "drupal": {
+                    "version": "8.x-1.0-beta3",
+                    "datestamp": "1504537744",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Beta releases are not covered by Drupal security advisories."
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "anavarre",
+                    "homepage": "https://www.drupal.org/user/796160"
+                },
+                {
+                    "name": "nielsvm",
+                    "homepage": "https://www.drupal.org/user/163285"
+                }
+            ],
+            "description": "Top-notch cache invalidation on Acquia Cloud!",
+            "homepage": "https://www.drupal.org/project/acquia_purge",
+            "support": {
+                "source": "https://git.drupalcode.org/project/acquia_purge"
+            }
+        },
+        {
             "name": "drupal/acsf",
             "version": "2.51.0",
             "source": {
@@ -2654,17 +2710,17 @@
         },
         {
             "name": "drupal/config_filter",
-            "version": "1.3.0",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/config_filter.git",
-                "reference": "8.x-1.3"
+                "reference": "8.x-1.4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/config_filter-8.x-1.3.zip",
-                "reference": "8.x-1.3",
-                "shasum": "56255a17c45dcbb0af713215885a8d74214d2ebc"
+                "url": "https://ftp.drupal.org/files/projects/config_filter-8.x-1.4.zip",
+                "reference": "8.x-1.4",
+                "shasum": "4b2b7f4dfc8358212f9e25f63dcc77cc2c1dcf6c"
             },
             "require": {
                 "drupal/core": "~8.0"
@@ -2678,7 +2734,7 @@
                     "dev-1.x": "1.x-dev"
                 },
                 "drupal": {
-                    "version": "8.x-1.3",
+                    "version": "8.x-1.4",
                     "datestamp": "1542184982",
                     "security-coverage": {
                         "status": "covered",
@@ -4493,6 +4549,241 @@
             "homepage": "https://www.drupal.org/project/pathauto",
             "support": {
                 "source": "http://cgit.drupalcode.org/pathauto"
+            }
+        },
+        {
+            "name": "drupal/purge",
+            "version": "3.0.0-beta8",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/purge.git",
+                "reference": "8.x-3.0-beta8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/purge-8.x-3.0-beta8.zip",
+                "reference": "8.x-3.0-beta8",
+                "shasum": "5b6a53d6adcfa0d4e081edf2563d366fc7205bc4"
+            },
+            "require": {
+                "drupal/core": "~8.0"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "branch-alias": {
+                    "dev-3.x": "3.x-dev"
+                },
+                "drupal": {
+                    "version": "8.x-3.0-beta8",
+                    "datestamp": "1502719311",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Beta releases are not covered by Drupal security advisories."
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "SqyD",
+                    "homepage": "https://www.drupal.org/user/106525"
+                },
+                {
+                    "name": "djbobbydrake",
+                    "homepage": "https://www.drupal.org/user/336378"
+                },
+                {
+                    "name": "nielsvm",
+                    "homepage": "https://www.drupal.org/user/163285"
+                }
+            ],
+            "description": "Provides a generic external cache invalidation API and queue service.",
+            "homepage": "https://www.drupal.org/project/purge",
+            "support": {
+                "source": "https://git.drupalcode.org/project/purge"
+            }
+        },
+        {
+            "name": "drupal/purge_drush",
+            "version": "3.0.0-beta8",
+            "require": {
+                "drupal/core": "~8.0",
+                "drupal/purge": "self.version"
+            },
+            "type": "metapackage",
+            "extra": {
+                "branch-alias": {
+                    "dev-3.x": "3.x-dev"
+                },
+                "drupal": {
+                    "version": "8.x-3.0-beta8",
+                    "datestamp": "1502719311",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Beta releases are not covered by Drupal security advisories."
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "SqyD",
+                    "homepage": "https://www.drupal.org/user/106525"
+                },
+                {
+                    "name": "djbobbydrake",
+                    "homepage": "https://www.drupal.org/user/336378"
+                },
+                {
+                    "name": "nielsvm",
+                    "homepage": "https://www.drupal.org/user/163285"
+                }
+            ],
+            "description": "Administrative Drush commands for Purge.",
+            "homepage": "https://www.drupal.org/project/purge",
+            "support": {
+                "source": "https://git.drupalcode.org/project/purge"
+            }
+        },
+        {
+            "name": "drupal/purge_processor_cron",
+            "version": "3.0.0-beta8",
+            "require": {
+                "drupal/core": "~8.0",
+                "drupal/purge": "self.version"
+            },
+            "type": "metapackage",
+            "extra": {
+                "branch-alias": {
+                    "dev-3.x": "3.x-dev"
+                },
+                "drupal": {
+                    "version": "8.x-3.0-beta8",
+                    "datestamp": "1502719311",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Beta releases are not covered by Drupal security advisories."
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "SqyD",
+                    "homepage": "https://www.drupal.org/user/106525"
+                },
+                {
+                    "name": "djbobbydrake",
+                    "homepage": "https://www.drupal.org/user/336378"
+                },
+                {
+                    "name": "nielsvm",
+                    "homepage": "https://www.drupal.org/user/163285"
+                }
+            ],
+            "description": "Processes the queue every time cron runs, recommended for most configurations.",
+            "homepage": "https://www.drupal.org/project/purge",
+            "support": {
+                "source": "https://git.drupalcode.org/project/purge"
+            }
+        },
+        {
+            "name": "drupal/purge_processor_lateruntime",
+            "version": "3.0.0-beta8",
+            "require": {
+                "drupal/core": "~8.0",
+                "drupal/purge": "self.version"
+            },
+            "type": "metapackage",
+            "extra": {
+                "branch-alias": {
+                    "dev-3.x": "3.x-dev"
+                },
+                "drupal": {
+                    "version": "8.x-3.0-beta8",
+                    "datestamp": "1502719311",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Beta releases are not covered by Drupal security advisories."
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "SqyD",
+                    "homepage": "https://www.drupal.org/user/106525"
+                },
+                {
+                    "name": "djbobbydrake",
+                    "homepage": "https://www.drupal.org/user/336378"
+                },
+                {
+                    "name": "nielsvm",
+                    "homepage": "https://www.drupal.org/user/163285"
+                }
+            ],
+            "description": "Process the queue on every request, this is only recommended on high latency configurations.",
+            "homepage": "https://www.drupal.org/project/purge",
+            "support": {
+                "source": "https://git.drupalcode.org/project/purge"
+            }
+        },
+        {
+            "name": "drupal/purge_queuer_coretags",
+            "version": "3.0.0-beta8",
+            "require": {
+                "drupal/core": "~8.0",
+                "drupal/purge": "self.version"
+            },
+            "type": "metapackage",
+            "extra": {
+                "branch-alias": {
+                    "dev-3.x": "3.x-dev"
+                },
+                "drupal": {
+                    "version": "8.x-3.0-beta8",
+                    "datestamp": "1502719311",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Beta releases are not covered by Drupal security advisories."
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "SqyD",
+                    "homepage": "https://www.drupal.org/user/106525"
+                },
+                {
+                    "name": "djbobbydrake",
+                    "homepage": "https://www.drupal.org/user/336378"
+                },
+                {
+                    "name": "nielsvm",
+                    "homepage": "https://www.drupal.org/user/163285"
+                }
+            ],
+            "description": "Queues every tag that Drupal invalidates internally.",
+            "homepage": "https://www.drupal.org/project/purge",
+            "support": {
+                "source": "https://git.drupalcode.org/project/purge"
             }
         },
         {
@@ -12306,6 +12597,7 @@
     "minimum-stability": "dev",
     "stability-flags": {
         "acquia/acsf-tools": 20,
+        "drupal/acquia_purge": 10,
         "drupal/entity_embed": 20,
         "drupal/page_manager": 10,
         "drupal/viewsreference": 20,

--- a/config/splits/cgov_config_split_setup/.htaccess
+++ b/config/splits/cgov_config_split_setup/.htaccess
@@ -1,0 +1,24 @@
+# Deny all requests from Apache 2.4+.
+<IfModule mod_authz_core.c>
+  Require all denied
+</IfModule>
+
+# Deny all requests from Apache 2.0-2.2.
+<IfModule !mod_authz_core.c>
+  Deny from all
+</IfModule>
+
+# Turn off all options we don't need.
+Options -Indexes -ExecCGI -Includes -MultiViews
+
+# Set the catch-all handler to prevent scripts from being executed.
+SetHandler Drupal_Security_Do_Not_Remove_See_SA_2006_006
+<Files *>
+  # Override the handler again if we're run later in the evaluation list.
+  SetHandler Drupal_Security_Do_Not_Remove_See_SA_2013_003
+</Files>
+
+# If we know how to do it safely, disable the PHP engine entirely.
+<IfModule mod_php5.c>
+  php_flag engine off
+</IfModule>

--- a/config/splits/cgov_config_split_setup/config_split.config_split.cgov_article_split.yml
+++ b/config/splits/cgov_config_split_setup/config_split.config_split.cgov_article_split.yml
@@ -1,0 +1,27 @@
+uuid: 7bf92bab-8a3a-4e62-aea3-bcc2e587ee66
+langcode: en
+status: false
+dependencies: {  }
+id: cgov_article_split
+label: 'CGov Article Split'
+description: 'Defines configuration required for CGov Article.'
+folder: ./profiles/custom/cgov_site/modules/custom/cgov_article/config/install
+module: {  }
+theme: {  }
+blacklist: {  }
+graylist:
+  - field.storage.node.field_article_body
+  - field.storage.paragraph.field_body_section_content
+  - field.storage.paragraph.field_body_section_heading
+  - language.content_settings.node.cgov_article
+  - node.type.cgov_article
+  - paragraphs.paragraphs_type.body_section
+  - pathauto.pattern.article_url
+  - node.type.cgov_article
+  - '*.cgov_article.*'
+  - 'core.entity_form_display.paragraph.body_section.*'
+  - 'core.entity_view_display.paragraph.body_section.*'
+  - 'field.field.paragraph.body_section.*'
+graylist_dependents: false
+graylist_skip_equal: false
+weight: 0

--- a/config/splits/cgov_config_split_setup/config_split.config_split.cgov_cache_split.yml
+++ b/config/splits/cgov_config_split_setup/config_split.config_split.cgov_cache_split.yml
@@ -1,0 +1,25 @@
+uuid: b77a9619-0611-46b5-a249-929903dc9bcd
+langcode: en
+status: false
+dependencies: {  }
+_core:
+  default_config_hash: 4sJS2mGP7L9ryEMwzAszOpOf_E05jqL-dz8GP96gGBA
+id: cgov_cache_split
+label: 'CGov Cache Split'
+description: 'Defines caching and purging configurations. '
+folder: ./profiles/custom/cgov_site/modules/custom/cgov_cache/config/install
+module:
+  acquia_purge: 0
+  purge: 0
+  purge_drush: 0
+  purge_processor_cron: 0
+  purge_processor_lateruntime: 0
+  purge_queuer_coretags: 0
+  purge_ui: 0
+theme: {  }
+blacklist:
+  - system.performance
+graylist: {  }
+graylist_dependents: true
+graylist_skip_equal: true
+weight: 0

--- a/config/splits/cgov_config_split_setup/config_split.config_split.cgov_config_split_setup.yml
+++ b/config/splits/cgov_config_split_setup/config_split.config_split.cgov_config_split_setup.yml
@@ -1,0 +1,16 @@
+uuid: f0d1136c-9b94-4661-b157-73fdc3269097
+langcode: en
+status: true
+dependencies: {  }
+id: cgov_config_split_setup
+label: 'CGov Config Split Setup'
+description: 'Defines a split that will manage optional splits. '
+folder: ../config/splits/cgov_config_split_setup
+module: {  }
+theme: {  }
+blacklist:
+  - 'config_split.*'
+graylist: {  }
+graylist_dependents: true
+graylist_skip_equal: true
+weight: 0

--- a/docroot/profiles/custom/cgov_site/cgov_site.info.yml
+++ b/docroot/profiles/custom/cgov_site/cgov_site.info.yml
@@ -68,6 +68,8 @@ install:
   - admin_toolbar_tools
   - admin_toolbar_links_access_filter
   # other
+  - config_split
+  - config_filter
   - yaml_content
   - twig_tweak
   - address

--- a/docroot/profiles/custom/cgov_site/cgov_site.install
+++ b/docroot/profiles/custom/cgov_site/cgov_site.install
@@ -19,4 +19,7 @@ function cgov_site_install() {
   // Install proper language negotiation even if English only.
   $siteHelper->installLanguageNegotiation();
 
+  // Import split of splits  after install is complete.
+  drush_invoke_process('@self', 'csim', ['cgov_config_split_setup']);
+
 }

--- a/docroot/profiles/custom/cgov_site/config/install/config_split.config_split.cgov_config_split_setup.yml
+++ b/docroot/profiles/custom/cgov_site/config/install/config_split.config_split.cgov_config_split_setup.yml
@@ -1,0 +1,16 @@
+uuid: f0d1136c-9b94-4661-b157-73fdc3269097
+langcode: en
+status: true
+dependencies: {  }
+id: cgov_config_split_setup
+label: 'CGov Config Split Setup'
+description: 'Defines a split that will manage optional splits. '
+folder: ../config/splits/cgov_config_split_setup
+module: {  }
+theme: {  }
+blacklist:
+  - 'config_split.*'
+graylist: {  }
+graylist_dependents: true
+graylist_skip_equal: true
+weight: 0

--- a/docroot/profiles/custom/cgov_site/drush.services.yml
+++ b/docroot/profiles/custom/cgov_site/drush.services.yml
@@ -1,0 +1,6 @@
+services:
+  cgov_site.commands:
+    class: \Drupal\cgov_site\Commands\CgovSiteCommands
+    arguments: ['@config_split.cli', "@config.manager", "@config.storage", "@config.storage.sync"]
+    tags:
+      - { name: drush.command }

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/cgov_article.services.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/cgov_article.services.yml
@@ -1,0 +1,5 @@
+services:
+  cgov_article.overrider:
+    class: \Drupal\cgov_article\CgovArticleConfigOverride
+    tags:
+      - {name: config.factory.override, priority: 5}

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/.htaccess
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/.htaccess
@@ -1,0 +1,24 @@
+# Deny all requests from Apache 2.4+.
+<IfModule mod_authz_core.c>
+  Require all denied
+</IfModule>
+
+# Deny all requests from Apache 2.0-2.2.
+<IfModule !mod_authz_core.c>
+  Deny from all
+</IfModule>
+
+# Turn off all options we don't need.
+Options -Indexes -ExecCGI -Includes -MultiViews
+
+# Set the catch-all handler to prevent scripts from being executed.
+SetHandler Drupal_Security_Do_Not_Remove_See_SA_2006_006
+<Files *>
+  # Override the handler again if we're run later in the evaluation list.
+  SetHandler Drupal_Security_Do_Not_Remove_See_SA_2013_003
+</Files>
+
+# If we know how to do it safely, disable the PHP engine entirely.
+<IfModule mod_php5.c>
+  php_flag engine off
+</IfModule>

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/core.base_field_override.node.cgov_article.promote.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/core.base_field_override.node.cgov_article.promote.yml
@@ -1,8 +1,11 @@
+uuid: 16e8cbc9-f8f3-4041-8236-db3466efdbdc
 langcode: en
 status: true
 dependencies:
   config:
     - node.type.cgov_article
+_core:
+  default_config_hash: Seum2hyK7XVgYMiP9A0sWXDRH_mti87p3MlXlV5469k
 id: node.cgov_article.promote
 field_name: promote
 entity_type: node

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/core.base_field_override.node.cgov_article.status.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/core.base_field_override.node.cgov_article.status.yml
@@ -1,8 +1,11 @@
+uuid: 7fcb35c4-87e5-4b39-a1c0-d7a4fc9b6499
 langcode: en
 status: true
 dependencies:
   config:
     - node.type.cgov_article
+_core:
+  default_config_hash: narwqVTI4aDOVukiweTVM6y6vwhTREJSu8prV4k-r0U
 id: node.cgov_article.status
 field_name: status
 entity_type: node

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/core.base_field_override.node.cgov_article.title.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/core.base_field_override.node.cgov_article.title.yml
@@ -1,8 +1,11 @@
+uuid: 277bf062-057d-45aa-a5b5-2f6551955d22
 langcode: en
 status: true
 dependencies:
   config:
     - node.type.cgov_article
+_core:
+  default_config_hash: hubM4Zl-tSxmVV-HCp-LUqPaXiY_-ZotHqPC4VPanGU
 id: node.cgov_article.title
 field_name: title
 entity_type: node

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/core.entity_form_display.node.cgov_article.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/core.entity_form_display.node.cgov_article.default.yml
@@ -1,3 +1,4 @@
+uuid: 2c35ab4c-c032-4dd6-871e-a581efa87e69
 langcode: en
 status: true
 dependencies:
@@ -24,17 +25,17 @@ dependencies:
     - field.field.node.cgov_article.field_short_title
     - field.field.node.cgov_article.field_site_section
     - node.type.cgov_article
-    - workflows.workflow.editorial_workflow
   enforced:
     module:
       - cgov_core
   module:
-    - content_moderation
     - datetime
     - entity_browser
     - paragraphs_asymmetric_translation_widgets
     - path
     - text
+_core:
+  default_config_hash: KzNJZVSqtGygfSvdjp0hCs6qP2DfHorfK4XNRR5cpO8
 id: node.cgov_article.default
 targetEntityType: node
 bundle: cgov_article

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/core.entity_form_display.paragraph.body_section.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/core.entity_form_display.paragraph.body_section.default.yml
@@ -1,3 +1,4 @@
+uuid: 894d70b0-54a0-456a-8c62-8f190b93089a
 langcode: en
 status: true
 dependencies:
@@ -7,6 +8,8 @@ dependencies:
     - paragraphs.paragraphs_type.body_section
   module:
     - text
+_core:
+  default_config_hash: gl-uqomPwFhCipC4BN8TP00soHKUXzCqYoY9jQOOliw
 id: paragraph.body_section.default
 targetEntityType: paragraph
 bundle: body_section

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/core.entity_view_display.node.cgov_article.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/core.entity_view_display.node.cgov_article.default.yml
@@ -1,3 +1,4 @@
+uuid: 25a74a3a-a5f5-4196-8580-e61e3cfd38e5
 langcode: en
 status: true
 dependencies:
@@ -32,6 +33,8 @@ dependencies:
     - options
     - text
     - user
+_core:
+  default_config_hash: frL0o4hnX3tnX4QU7Q3gqvl6zwwjEv4aTip4C-pSakM
 id: node.cgov_article.default
 targetEntityType: node
 bundle: cgov_article

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/core.entity_view_display.node.cgov_article.embedded_feature_card.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/core.entity_view_display.node.cgov_article.embedded_feature_card.yml
@@ -1,3 +1,4 @@
+uuid: d24085f1-942b-4017-9d68-097edc30f9df
 langcode: en
 status: true
 dependencies:
@@ -18,15 +19,16 @@ dependencies:
     - field.field.node.cgov_article.field_list_description
     - field.field.node.cgov_article.field_page_description
     - field.field.node.cgov_article.field_pretty_url
+    - field.field.node.cgov_article.field_public_use
     - field.field.node.cgov_article.field_related_resources
     - field.field.node.cgov_article.field_search_engine_restrictions
     - field.field.node.cgov_article.field_short_title
     - field.field.node.cgov_article.field_site_section
     - node.type.cgov_article
   module:
-    - cgov_core
-    - options
     - user
+_core:
+  default_config_hash: EhO5C71ntVA77imiX0ZCCO7KwGUOxB8VETBDK2sg9V4
 id: node.cgov_article.embedded_feature_card
 targetEntityType: node
 bundle: cgov_article

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/core.entity_view_display.node.cgov_article.embedded_feature_card_no_image.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/core.entity_view_display.node.cgov_article.embedded_feature_card_no_image.yml
@@ -1,3 +1,4 @@
+uuid: 90d4a841-ce52-49cd-b39a-f343c2d3d90d
 langcode: en
 status: true
 dependencies:
@@ -18,15 +19,16 @@ dependencies:
     - field.field.node.cgov_article.field_list_description
     - field.field.node.cgov_article.field_page_description
     - field.field.node.cgov_article.field_pretty_url
+    - field.field.node.cgov_article.field_public_use
     - field.field.node.cgov_article.field_related_resources
     - field.field.node.cgov_article.field_search_engine_restrictions
     - field.field.node.cgov_article.field_short_title
     - field.field.node.cgov_article.field_site_section
     - node.type.cgov_article
   module:
-    - cgov_core
-    - options
     - user
+_core:
+  default_config_hash: 8yhNiz3T9yuWawtX8daU6-6UH0JqE6y4Q7mgqmFe0t8
 id: node.cgov_article.embedded_feature_card_no_image
 targetEntityType: node
 bundle: cgov_article

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/core.entity_view_display.node.cgov_article.feature_card_image.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/core.entity_view_display.node.cgov_article.feature_card_image.yml
@@ -1,3 +1,4 @@
+uuid: 3d9308e5-a2c8-4a5c-853a-a5c0ec5fad78
 langcode: en
 status: true
 dependencies:
@@ -18,15 +19,16 @@ dependencies:
     - field.field.node.cgov_article.field_list_description
     - field.field.node.cgov_article.field_page_description
     - field.field.node.cgov_article.field_pretty_url
+    - field.field.node.cgov_article.field_public_use
     - field.field.node.cgov_article.field_related_resources
     - field.field.node.cgov_article.field_search_engine_restrictions
     - field.field.node.cgov_article.field_short_title
     - field.field.node.cgov_article.field_site_section
     - node.type.cgov_article
   module:
-    - cgov_core
-    - options
     - user
+_core:
+  default_config_hash: ayVntQTOiEcbb6sXrXSSru08ngOcUrkthF6SvfCzeE4
 id: node.cgov_article.feature_card_image
 targetEntityType: node
 bundle: cgov_article
@@ -51,17 +53,16 @@ content:
       link: false
     third_party_settings: {  }
 hidden:
-  field_feature_card_description: true
-  field_card_title: true
-  field_short_title: true
   content_moderation_control: true
   field_article_body: true
   field_browser_title: true
+  field_card_title: true
   field_citation: true
   field_date_display_mode: true
   field_date_posted: true
   field_date_reviewed: true
   field_date_updated: true
+  field_feature_card_description: true
   field_intro_text: true
   field_list_description: true
   field_page_description: true
@@ -69,6 +70,7 @@ hidden:
   field_public_use: true
   field_related_resources: true
   field_search_engine_restrictions: true
+  field_short_title: true
   field_site_section: true
   langcode: true
   links: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/core.entity_view_display.node.cgov_article.full.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/core.entity_view_display.node.cgov_article.full.yml
@@ -1,3 +1,4 @@
+uuid: 09c2d963-febb-46c5-938b-df656c5611b1
 langcode: en
 status: true
 dependencies:
@@ -30,6 +31,8 @@ dependencies:
     - options
     - text
     - user
+_core:
+  default_config_hash: k39jSTCZVfFlqYZgkE9T-xiWsXzdmSsqQCcnOHdVwmk
 id: node.cgov_article.full
 targetEntityType: node
 bundle: cgov_article

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/core.entity_view_display.node.cgov_article.link.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/core.entity_view_display.node.cgov_article.link.yml
@@ -1,3 +1,4 @@
+uuid: 0176c855-2cda-4578-ac8a-f1cf01dfbde0
 langcode: en
 status: true
 dependencies:
@@ -29,6 +30,8 @@ dependencies:
       - cgov_core
   module:
     - user
+_core:
+  default_config_hash: 1oh7NqpN63BAfTZuk7Anx6_GwRxlKemRwFhROAttl3U
 id: node.cgov_article.link
 targetEntityType: node
 bundle: cgov_article

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/core.entity_view_display.node.cgov_article.teaser.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/core.entity_view_display.node.cgov_article.teaser.yml
@@ -1,3 +1,4 @@
+uuid: 3f1e57a7-14e6-46be-bee5-670511425936
 langcode: en
 status: true
 dependencies:
@@ -7,21 +8,27 @@ dependencies:
     - field.field.node.cgov_article.field_browser_title
     - field.field.node.cgov_article.field_card_title
     - field.field.node.cgov_article.field_citation
-    - field.field.node.cgov_article.field_intro_text
     - field.field.node.cgov_article.field_date_display_mode
     - field.field.node.cgov_article.field_date_posted
     - field.field.node.cgov_article.field_date_reviewed
     - field.field.node.cgov_article.field_date_updated
     - field.field.node.cgov_article.field_feature_card_description
+    - field.field.node.cgov_article.field_image_article
+    - field.field.node.cgov_article.field_image_promotional
+    - field.field.node.cgov_article.field_intro_text
     - field.field.node.cgov_article.field_list_description
     - field.field.node.cgov_article.field_page_description
     - field.field.node.cgov_article.field_pretty_url
+    - field.field.node.cgov_article.field_public_use
     - field.field.node.cgov_article.field_related_resources
+    - field.field.node.cgov_article.field_search_engine_restrictions
     - field.field.node.cgov_article.field_short_title
     - field.field.node.cgov_article.field_site_section
     - node.type.cgov_article
   module:
     - user
+_core:
+  default_config_hash: lMFhqeRvlJgK8ENd5d7xWMwpw943lJzxFP1Raf-j1tg
 id: node.cgov_article.teaser
 targetEntityType: node
 bundle: cgov_article
@@ -38,16 +45,20 @@ hidden:
   field_browser_title: true
   field_card_title: true
   field_citation: true
-  field_intro_text: true
   field_date_display_mode: true
   field_date_posted: true
   field_date_reviewed: true
   field_date_updated: true
   field_feature_card_description: true
+  field_image_article: true
+  field_image_promotional: true
+  field_intro_text: true
   field_list_description: true
   field_page_description: true
   field_pretty_url: true
+  field_public_use: true
   field_related_resources: true
+  field_search_engine_restrictions: true
   field_short_title: true
   field_site_section: true
   langcode: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/core.entity_view_display.node.cgov_article.thumbnail_card_image.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/core.entity_view_display.node.cgov_article.thumbnail_card_image.yml
@@ -1,3 +1,4 @@
+uuid: 39ddc85b-aac6-41c1-91b5-d154ff9ec6eb
 langcode: en
 status: true
 dependencies:
@@ -26,6 +27,8 @@ dependencies:
     - node.type.cgov_article
   module:
     - user
+_core:
+  default_config_hash: XsUYbdkztghGSD8Gtd70sZjP0fDzDlN_5Kbu2o4pleM
 id: node.cgov_article.thumbnail_card_image
 targetEntityType: node
 bundle: cgov_article
@@ -50,12 +53,10 @@ content:
       link: false
     third_party_settings: {  }
 hidden:
-  field_card_title: true
-  field_short_title: true
-  field_list_description: true
   content_moderation_control: true
   field_article_body: true
   field_browser_title: true
+  field_card_title: true
   field_citation: true
   field_date_display_mode: true
   field_date_posted: true
@@ -63,11 +64,13 @@ hidden:
   field_date_updated: true
   field_feature_card_description: true
   field_intro_text: true
+  field_list_description: true
   field_page_description: true
   field_pretty_url: true
   field_public_use: true
   field_related_resources: true
   field_search_engine_restrictions: true
+  field_short_title: true
   field_site_section: true
   langcode: true
   links: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/core.entity_view_display.paragraph.body_section.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/core.entity_view_display.paragraph.body_section.default.yml
@@ -1,3 +1,4 @@
+uuid: fc123dcb-0fa5-4599-a0f8-fff39d46d888
 langcode: en
 status: true
 dependencies:
@@ -7,6 +8,8 @@ dependencies:
     - paragraphs.paragraphs_type.body_section
   module:
     - text
+_core:
+  default_config_hash: TkXflBj-CTDOUOFbYQ8LHIySg161cSMbIcvubmb4W7Y
 id: paragraph.body_section.default
 targetEntityType: paragraph
 bundle: body_section

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/field.field.node.cgov_article.field_article_body.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/field.field.node.cgov_article.field_article_body.yml
@@ -1,3 +1,4 @@
+uuid: d7065981-8a6c-46c0-8bbf-b8c684396e89
 langcode: en
 status: true
 dependencies:
@@ -7,6 +8,8 @@ dependencies:
     - paragraphs.paragraphs_type.body_section
   module:
     - entity_reference_revisions
+_core:
+  default_config_hash: uIwNZ79fiIhb5xteX7o-lKxK2pQjRGYCKAClpU6z9e0
 id: node.cgov_article.field_article_body
 field_name: field_article_body
 entity_type: node

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/field.field.node.cgov_article.field_browser_title.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/field.field.node.cgov_article.field_browser_title.yml
@@ -1,9 +1,12 @@
+uuid: 3b1bf8b0-904d-43e6-b2a7-bd3d5c1d64e0
 langcode: en
 status: true
 dependencies:
   config:
     - field.storage.node.field_browser_title
     - node.type.cgov_article
+_core:
+  default_config_hash: P5e2TFW0OvzqX5ENPRriUQD9bGH0_uIyIWAd9y8VX4E
 id: node.cgov_article.field_browser_title
 field_name: field_browser_title
 entity_type: node

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/field.field.node.cgov_article.field_card_title.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/field.field.node.cgov_article.field_card_title.yml
@@ -1,9 +1,12 @@
+uuid: dbde46d5-9a07-4841-a0ba-2b2c4d62f6b6
 langcode: en
 status: true
 dependencies:
   config:
     - field.storage.node.field_card_title
     - node.type.cgov_article
+_core:
+  default_config_hash: vmosQXJOzBNO_UaYsvXVqPOvdlQ4srdUylbhUzyAA1M
 id: node.cgov_article.field_card_title
 field_name: field_card_title
 entity_type: node

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/field.field.node.cgov_article.field_citation.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/field.field.node.cgov_article.field_citation.yml
@@ -1,3 +1,4 @@
+uuid: 8774cb40-4456-4335-ba0d-c80c8fca4a8b
 langcode: en
 status: true
 dependencies:
@@ -7,6 +8,8 @@ dependencies:
     - paragraphs.paragraphs_type.cgov_citation
   module:
     - entity_reference_revisions
+_core:
+  default_config_hash: F8I2bLBscguwb82leKFgsfVhTuEOYA5g8-GoJEsP3uM
 id: node.cgov_article.field_citation
 field_name: field_citation
 entity_type: node

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/field.field.node.cgov_article.field_date_display_mode.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/field.field.node.cgov_article.field_date_display_mode.yml
@@ -1,3 +1,4 @@
+uuid: 9324c15f-ddce-4d5b-800a-2ae992657e79
 langcode: en
 status: true
 dependencies:
@@ -6,6 +7,8 @@ dependencies:
     - node.type.cgov_article
   module:
     - options
+_core:
+  default_config_hash: v31I0hSgfH-aawtHhGrGfk-L7q20Iu_GkFqL_ftQois
 id: node.cgov_article.field_date_display_mode
 field_name: field_date_display_mode
 entity_type: node

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/field.field.node.cgov_article.field_date_posted.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/field.field.node.cgov_article.field_date_posted.yml
@@ -1,3 +1,4 @@
+uuid: beaf4f6d-5fe4-4b90-9ac7-577df72cf3b2
 langcode: en
 status: true
 dependencies:
@@ -6,6 +7,8 @@ dependencies:
     - node.type.cgov_article
   module:
     - datetime
+_core:
+  default_config_hash: h7KKoU95jASprRWvd_VX_gH9WC78r9xW6pom1oWH4O4
 id: node.cgov_article.field_date_posted
 field_name: field_date_posted
 entity_type: node

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/field.field.node.cgov_article.field_date_reviewed.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/field.field.node.cgov_article.field_date_reviewed.yml
@@ -1,3 +1,4 @@
+uuid: e0a75e60-2841-4129-8617-8a21bd0d3e37
 langcode: en
 status: true
 dependencies:
@@ -6,6 +7,8 @@ dependencies:
     - node.type.cgov_article
   module:
     - datetime
+_core:
+  default_config_hash: 4WDJE79jkkWdbfH168Gk-If2SIL0l08PvveMUM3-Uak
 id: node.cgov_article.field_date_reviewed
 field_name: field_date_reviewed
 entity_type: node

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/field.field.node.cgov_article.field_date_updated.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/field.field.node.cgov_article.field_date_updated.yml
@@ -1,3 +1,4 @@
+uuid: bbb6c304-154e-48db-af5d-ddd202273b95
 langcode: en
 status: true
 dependencies:
@@ -6,6 +7,8 @@ dependencies:
     - node.type.cgov_article
   module:
     - datetime
+_core:
+  default_config_hash: xYNjP_l4Mj3PHKnDOswOF-JxzlEBXtenrqqY4nGYX2M
 id: node.cgov_article.field_date_updated
 field_name: field_date_updated
 entity_type: node

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/field.field.node.cgov_article.field_feature_card_description.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/field.field.node.cgov_article.field_feature_card_description.yml
@@ -1,9 +1,12 @@
+uuid: 7ba42156-655e-4fd8-9b08-c65e809312d8
 langcode: en
 status: true
 dependencies:
   config:
     - field.storage.node.field_feature_card_description
     - node.type.cgov_article
+_core:
+  default_config_hash: DKxcc_XraPicGWw3i5LRLumLBF93TjtmBVFI3M8Uht8
 id: node.cgov_article.field_feature_card_description
 field_name: field_feature_card_description
 entity_type: node

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/field.field.node.cgov_article.field_image_article.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/field.field.node.cgov_article.field_image_article.yml
@@ -1,3 +1,4 @@
+uuid: 4243652f-59cb-469c-bdf7-83a8bfb69655
 langcode: en
 status: true
 dependencies:
@@ -5,6 +6,8 @@ dependencies:
     - field.storage.node.field_image_article
     - media.type.cgov_image
     - node.type.cgov_article
+_core:
+  default_config_hash: hkW1budm4zBfr6qbMWMBkTBUVwG130KG13EYRRq_SAU
 id: node.cgov_article.field_image_article
 field_name: field_image_article
 entity_type: node

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/field.field.node.cgov_article.field_image_promotional.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/field.field.node.cgov_article.field_image_promotional.yml
@@ -1,3 +1,4 @@
+uuid: d7349276-4bcd-45ee-95ea-be62ba93a967
 langcode: en
 status: true
 dependencies:
@@ -5,6 +6,8 @@ dependencies:
     - field.storage.node.field_image_promotional
     - media.type.cgov_image
     - node.type.cgov_article
+_core:
+  default_config_hash: Ix_VVwD7woI5HWgPEY9_AjPcxMB8TDzuJ_gn3oe3Hmw
 id: node.cgov_article.field_image_promotional
 field_name: field_image_promotional
 entity_type: node

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/field.field.node.cgov_article.field_intro_text.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/field.field.node.cgov_article.field_intro_text.yml
@@ -1,3 +1,4 @@
+uuid: 25501722-2877-4b8a-b7ab-f8d97a87a4e3
 langcode: en
 status: true
 dependencies:
@@ -6,6 +7,8 @@ dependencies:
     - node.type.cgov_article
   module:
     - text
+_core:
+  default_config_hash: FzFzqiedbyzJrktyVWjh8XKuSotXiDGPWVS0CWzjU9c
 id: node.cgov_article.field_intro_text
 field_name: field_intro_text
 entity_type: node

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/field.field.node.cgov_article.field_list_description.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/field.field.node.cgov_article.field_list_description.yml
@@ -1,9 +1,12 @@
+uuid: cca9e582-406a-4fa9-bdad-ed7d76c11480
 langcode: en
 status: true
 dependencies:
   config:
     - field.storage.node.field_list_description
     - node.type.cgov_article
+_core:
+  default_config_hash: kPW_SsEZaKoxhTfCbcjbNdF_yCAtXbenA1-FguPiW9g
 id: node.cgov_article.field_list_description
 field_name: field_list_description
 entity_type: node

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/field.field.node.cgov_article.field_page_description.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/field.field.node.cgov_article.field_page_description.yml
@@ -1,9 +1,12 @@
+uuid: 0f6a7a49-3133-4de2-a5ee-42e5e845b495
 langcode: en
 status: true
 dependencies:
   config:
     - field.storage.node.field_page_description
     - node.type.cgov_article
+_core:
+  default_config_hash: 80hC2Y0UPwfOVhqSrpNngUALPuW32-2sqoT3CEiD-5o
 id: node.cgov_article.field_page_description
 field_name: field_page_description
 entity_type: node

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/field.field.node.cgov_article.field_pretty_url.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/field.field.node.cgov_article.field_pretty_url.yml
@@ -1,9 +1,12 @@
+uuid: a0bc8a87-e2db-43b6-a7f0-5e1746b78ab3
 langcode: en
 status: true
 dependencies:
   config:
     - field.storage.node.field_pretty_url
     - node.type.cgov_article
+_core:
+  default_config_hash: FHW81RtQ5SpDcy1qIE9gkgBQqU5TFDHs3QPZGdC5Vj8
 id: node.cgov_article.field_pretty_url
 field_name: field_pretty_url
 entity_type: node

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/field.field.node.cgov_article.field_public_use.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/field.field.node.cgov_article.field_public_use.yml
@@ -1,14 +1,17 @@
+uuid: b23f1c04-5da5-4283-a40c-5e663a5668e2
 langcode: en
 status: true
 dependencies:
   config:
     - field.storage.node.field_public_use
     - node.type.cgov_article
-  module:
-    - options
   enforced:
     module:
-    - cgov_core
+      - cgov_core
+  module:
+    - options
+_core:
+  default_config_hash: jKyL7YYPp1BymRfSJy2ZIzDvMTGNoaoYSW_Sf3mMh84
 id: node.cgov_article.field_public_use
 field_name: field_public_use
 entity_type: node

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/field.field.node.cgov_article.field_related_resources.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/field.field.node.cgov_article.field_related_resources.yml
@@ -1,3 +1,4 @@
+uuid: 2fea2d34-45fa-4b8d-977d-1fdac81e31fd
 langcode: en
 status: true
 dependencies:
@@ -8,6 +9,8 @@ dependencies:
     - paragraphs.paragraphs_type.cgov_internal_link
   module:
     - entity_reference_revisions
+_core:
+  default_config_hash: CoxlOQ91GEeZpwmCIg0V0LgCtxLsbyDvCJlU2ug_e_A
 id: node.cgov_article.field_related_resources
 field_name: field_related_resources
 entity_type: node

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/field.field.node.cgov_article.field_search_engine_restrictions.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/field.field.node.cgov_article.field_search_engine_restrictions.yml
@@ -1,14 +1,17 @@
+uuid: 79439ee2-63a8-4aa4-8f2a-44a4971d823b
 langcode: en
 status: true
 dependencies:
   config:
     - field.storage.node.field_search_engine_restrictions
     - node.type.cgov_article
-  module:
-    - options
   enforced:
     module:
-    - cgov_core
+      - cgov_core
+  module:
+    - options
+_core:
+  default_config_hash: i8jY-ENfJ6umEKLkbl9nIWQ9VCd84zrxnQJ3gwGeQI0
 id: node.cgov_article.field_search_engine_restrictions
 field_name: field_search_engine_restrictions
 entity_type: node

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/field.field.node.cgov_article.field_short_title.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/field.field.node.cgov_article.field_short_title.yml
@@ -1,9 +1,12 @@
+uuid: 5e68a7ea-3780-4351-8db3-3bf7130ce789
 langcode: en
 status: true
 dependencies:
   config:
     - field.storage.node.field_short_title
     - node.type.cgov_article
+_core:
+  default_config_hash: 5Zikpw6V8-30jD36IOHO9SWvITLZsUD7T3kCUrFERO0
 id: node.cgov_article.field_short_title
 field_name: field_short_title
 entity_type: node

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/field.field.node.cgov_article.field_site_section.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/field.field.node.cgov_article.field_site_section.yml
@@ -1,3 +1,4 @@
+uuid: 0d7969f1-89df-4c1c-8b40-efa864056648
 langcode: en
 status: true
 dependencies:
@@ -5,6 +6,8 @@ dependencies:
     - field.storage.node.field_site_section
     - node.type.cgov_article
     - taxonomy.vocabulary.cgov_site_sections
+_core:
+  default_config_hash: xpIe1EHkMD7UHwCuiReXMTPbIgGELLR8qYwhppgehHM
 id: node.cgov_article.field_site_section
 field_name: field_site_section
 entity_type: node

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/field.field.paragraph.body_section.field_body_section_content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/field.field.paragraph.body_section.field_body_section_content.yml
@@ -1,3 +1,4 @@
+uuid: 54872d9e-9a06-4b4e-9bb9-05a319b6fb51
 langcode: en
 status: true
 dependencies:
@@ -6,6 +7,8 @@ dependencies:
     - paragraphs.paragraphs_type.body_section
   module:
     - text
+_core:
+  default_config_hash: IkpnCn7Q2sFEduRgsCg_nUDn1sPAkWa59XNiTv--NK8
 id: paragraph.body_section.field_body_section_content
 field_name: field_body_section_content
 entity_type: paragraph

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/field.field.paragraph.body_section.field_body_section_heading.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/field.field.paragraph.body_section.field_body_section_heading.yml
@@ -1,3 +1,4 @@
+uuid: 1e8fa6f6-f6d0-4d82-b9a0-05b7e47d6155
 langcode: en
 status: true
 dependencies:
@@ -6,6 +7,8 @@ dependencies:
     - paragraphs.paragraphs_type.body_section
   module:
     - text
+_core:
+  default_config_hash: ckHxiL9Rqn2vv2MzMOut2_PsOG6_QgVg-yLV4SHIpHU
 id: paragraph.body_section.field_body_section_heading
 field_name: field_body_section_heading
 entity_type: paragraph

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/field.storage.node.field_article_body.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/field.storage.node.field_article_body.yml
@@ -1,3 +1,4 @@
+uuid: 776ed3fa-b7b4-4e63-8fe5-25cac5029805
 langcode: en
 status: true
 dependencies:
@@ -5,6 +6,8 @@ dependencies:
     - entity_reference_revisions
     - node
     - paragraphs
+_core:
+  default_config_hash: 4-RBMncXBcQWsTRULwt9Hz7TNNX4JPVXmtuLBESRBBg
 id: node.field_article_body
 field_name: field_article_body
 entity_type: node

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/field.storage.paragraph.field_body_section_content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/field.storage.paragraph.field_body_section_content.yml
@@ -1,9 +1,12 @@
+uuid: 22bd55f1-fe75-47e2-9fcd-9b3635127a8b
 langcode: en
 status: true
 dependencies:
   module:
     - paragraphs
     - text
+_core:
+  default_config_hash: UTuftmVWe7mjHV9bV9ptmTJ7Z1-MLULNle4QRVQUi-o
 id: paragraph.field_body_section_content
 field_name: field_body_section_content
 entity_type: paragraph

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/field.storage.paragraph.field_body_section_heading.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/field.storage.paragraph.field_body_section_heading.yml
@@ -1,14 +1,17 @@
+uuid: 76d40c53-c97a-45a7-8f18-51c7302a210b
 langcode: en
 status: true
 dependencies:
   module:
     - paragraphs
     - text
+_core:
+  default_config_hash: B7nvfHoeONFp29ZzmK2h-cKL3NW2Jm62TfxO_lWozaI
 id: paragraph.field_body_section_heading
 field_name: field_body_section_heading
 entity_type: paragraph
 type: text_long
-settings: { }
+settings: {  }
 module: text
 locked: false
 cardinality: 1

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/language.content_settings.node.cgov_article.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/language.content_settings.node.cgov_article.yml
@@ -1,3 +1,4 @@
+uuid: f37fd099-668b-4dd4-9af7-e194d2b9601c
 langcode: en
 status: true
 dependencies:
@@ -10,6 +11,8 @@ third_party_settings:
     enabled: true
     bundle_settings:
       untranslatable_fields_hide: '1'
+_core:
+  default_config_hash: AMyO2e-ZnlMF_B9f-DrzQgWbMJWOMYdv00ibaboQE24
 id: node.cgov_article
 target_entity_type_id: node
 target_bundle: cgov_article

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/language/es/core.base_field_override.node.cgov_article.promote.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/language/es/core.base_field_override.node.cgov_article.promote.yml
@@ -1,0 +1,4 @@
+label: 'Promocionado a la página principal'
+settings:
+  on_label: Activado
+  off_label: Desactivado

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/language/es/core.base_field_override.node.cgov_article.status.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/language/es/core.base_field_override.node.cgov_article.status.yml
@@ -1,0 +1,4 @@
+label: Publicado
+settings:
+  on_label: Activado
+  off_label: Desactivado

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/language/es/field.field.node.cgov_article.field_article_body.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/language/es/field.field.node.cgov_article.field_article_body.yml
@@ -1,0 +1,1 @@
+label: Cuerpo

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/language/es/field.field.paragraph.body_section.field_body_section_content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/language/es/field.field.paragraph.body_section.field_body_section_content.yml
@@ -1,0 +1,1 @@
+label: Contenido

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/language/es/field.field.paragraph.body_section.field_body_section_heading.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/language/es/field.field.paragraph.body_section.field_body_section_heading.yml
@@ -1,0 +1,1 @@
+label: Encabezado

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/node.type.cgov_article.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/node.type.cgov_article.yml
@@ -1,6 +1,9 @@
+uuid: 95e4f4d1-db49-45cb-8fd8-7b3458dd1402
 langcode: en
 status: true
 dependencies: {  }
+_core:
+  default_config_hash: knovRA04im1VFD-9RxCdrXJnDu7XaKlMde5uLRNbasw
 name: Article
 type: cgov_article
 description: 'An information-rich content page that supports some structured information, like citations and inline feature cards. This content is likely to be useful to other websites/parties.'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/paragraphs.paragraphs_type.body_section.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/paragraphs.paragraphs_type.body_section.yml
@@ -1,6 +1,9 @@
+uuid: b8e829dc-a3fa-4666-bc3f-6fd0e6cc6429
 langcode: en
 status: true
 dependencies: {  }
+_core:
+  default_config_hash: QnjTGc1bw-vafVD8hvWFZP7YCOpTfTXtRuIDS3ogyLQ
 id: body_section
 label: 'Body Section'
 icon_uuid: null

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/pathauto.pattern.article_url.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/pathauto.pattern.article_url.yml
@@ -1,8 +1,11 @@
+uuid: ace01b35-e6e3-4739-9c5a-5e23211c28f8
 langcode: en
 status: true
 dependencies:
   module:
     - node
+_core:
+  default_config_hash: Nk97VQqbkf6jQuSR5aUtf6Xyc3CV67Xq36hczH-NPSE
 id: article_url
 label: 'Article URL'
 type: 'canonical_entities:node'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/src/CgovArticleConfigOverride.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/src/CgovArticleConfigOverride.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Drupal\cgov_article;
+
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Config\ConfigFactoryOverrideInterface;
+use Drupal\Core\Config\StorageInterface;
+
+/**
+ * Configuration Override for CGov Article.
+ */
+class CgovArticleConfigOverride implements ConfigFactoryOverrideInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function loadOverrides($names) {
+    $overrides = [];
+    if (in_array('config_split.config_split.cgov_article_split', $names)) {
+      $overrides['config_split.config_split.cgov_article_split']['status'] = TRUE;
+    }
+    return $overrides;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheSuffix() {
+    return 'CGovArticleConfigOverride';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheableMetadata($name) {
+    return new CacheableMetadata();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function createConfigObject($name, $collection = StorageInterface::DEFAULT_COLLECTION) {
+    return NULL;
+  }
+
+}

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cache/cgov_cache.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cache/cgov_cache.info.yml
@@ -1,0 +1,6 @@
+name: 'Cgov Cache'
+type: module
+description: 'Cancer.gov Cache configuration module.'
+package: 'CGov Digital Platform'
+core: 8.x
+hidden: false

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cache/cgov_cache.services.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cache/cgov_cache.services.yml
@@ -1,0 +1,5 @@
+services:
+  cgov_cache.overrider:
+    class: \Drupal\cgov_cache\CgovCacheConfigOverride
+    tags:
+      - {name: config.factory.override, priority: 5}

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cache/config/install/.htaccess
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cache/config/install/.htaccess
@@ -1,0 +1,24 @@
+# Deny all requests from Apache 2.4+.
+<IfModule mod_authz_core.c>
+  Require all denied
+</IfModule>
+
+# Deny all requests from Apache 2.0-2.2.
+<IfModule !mod_authz_core.c>
+  Deny from all
+</IfModule>
+
+# Turn off all options we don't need.
+Options -Indexes -ExecCGI -Includes -MultiViews
+
+# Set the catch-all handler to prevent scripts from being executed.
+SetHandler Drupal_Security_Do_Not_Remove_See_SA_2006_006
+<Files *>
+  # Override the handler again if we're run later in the evaluation list.
+  SetHandler Drupal_Security_Do_Not_Remove_See_SA_2013_003
+</Files>
+
+# If we know how to do it safely, disable the PHP engine entirely.
+<IfModule mod_php5.c>
+  php_flag engine off
+</IfModule>

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cache/config/install/system.performance.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cache/config/install/system.performance.yml
@@ -1,0 +1,17 @@
+cache:
+  page:
+    max_age: 0
+css:
+  preprocess: true
+  gzip: true
+fast_404:
+  enabled: true
+  paths: '/\.(?:txt|png|gif|jpe?g|css|js|ico|swf|flv|cgi|bat|pl|dll|exe|asp)$/i'
+  exclude_paths: '/\/(?:styles|imagecache)\//'
+  html: '<!DOCTYPE html><html><head><title>404 Not Found</title></head><body><h1>Not Found</h1><p>The requested URL "@path" was not found on this server.</p></body></html>'
+js:
+  preprocess: true
+  gzip: true
+stale_file_threshold: 2592000
+_core:
+  default_config_hash: b2cssrj-lOmATIbdehfCqfCFgVR0qCdxxWhwqa2KBVQ

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cache/src/CgovCacheConfigOverride.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cache/src/CgovCacheConfigOverride.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Drupal\cgov_cache;
+
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Config\ConfigFactoryOverrideInterface;
+use Drupal\Core\Config\StorageInterface;
+
+/**
+ * Configuration Override for CGov Article.
+ */
+class CgovCacheConfigOverride implements ConfigFactoryOverrideInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function loadOverrides($names) {
+    $overrides = [];
+    if (in_array('config_split.config_split.cgov_cache_split', $names)) {
+      $overrides['config_split.config_split.cgov_cache_split']['status'] = TRUE;
+    }
+    return $overrides;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheSuffix() {
+    return 'CGovArticleConfigOverride';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheableMetadata($name) {
+    return new CacheableMetadata();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function createConfigObject($name, $collection = StorageInterface::DEFAULT_COLLECTION) {
+    return NULL;
+  }
+
+}

--- a/docroot/profiles/custom/cgov_site/src/Commands/CgovSiteCommands.php
+++ b/docroot/profiles/custom/cgov_site/src/Commands/CgovSiteCommands.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Drupal\cgov_site\Commands;
+
+use Drupal\config_split\ConfigSplitCliService;
+use Drupal\Core\Config\ConfigManagerInterface;
+use Drupal\Core\Config\StorageInterface;
+use Drush\Commands\DrushCommands;
+
+/**
+ * Class CgovSiteCommands.
+ *
+ * This is the Drush 9 command.
+ *
+ * @package Drupal\cgov_site\Commands
+ */
+class CgovSiteCommands extends DrushCommands {
+
+  /**
+   * The interoperability cli service.
+   *
+   * @var \Drupal\config_split\ConfigSplitCliService
+   */
+  protected $cliService;
+
+  /**
+   * Drupal\Core\Config\ConfigManager definition.
+   *
+   * @var \Drupal\Core\Config\ConfigManager
+   */
+  protected $configManager;
+
+  /**
+   * Active Config Storage.
+   *
+   * @var \Drupal\Core\Config\StorageInterface
+   */
+  protected $activeStorage;
+
+  /**
+   * Sync Config Storage.
+   *
+   * @var \Drupal\Core\Config\StorageInterface
+   */
+  protected $syncStorage;
+
+  /**
+   * CgovSiteCommands constructor.
+   *
+   * @param \Drupal\config_split\ConfigSplitCliService $cliService
+   *   The CLI service which allows interoperability.
+   * @param \Drupal\cgov_site\Commands\ConfigManagerInterface $config_manager
+   *   The config manager.
+   * @param \Drupal\cgov_site\Commands\StorageInterface $active_storage
+   *   The active storage service.
+   * @param \Drupal\cgov_site\Commands\StorageInterface $sync_storage
+   *   The sync storage service.
+   */
+  public function __construct(
+    ConfigSplitCliService $cliService,
+    ConfigManagerInterface $config_manager,
+    StorageInterface $active_storage,
+    StorageInterface $sync_storage) {
+
+    $this->cliService = $cliService;
+    $this->configManager = $config_manager;
+    $this->activeStorage = $active_storage;
+    $this->syncStorage = $sync_storage;
+  }
+
+  /**
+   * Loops through and imports all active splits.
+   *
+   * @command cgov:config-split-import-all
+   * @aliases cgov-csia
+   * @usage cgov-csia
+   *   Imports all active configuration splits.
+   */
+  public function cgovImportAllActiveSplits() {
+    // Import config split configurations.
+    foreach ($this->syncStorage->listAll('config_split.config_split.') as $name) {
+      $this->activeStorage->write($name, $this->syncStorage->read($name));
+      $this->output()->writeln('Configuration successfully imported for ' . $name . '.');
+    }
+
+    // Import all configurations.
+    foreach ($this->syncStorage->listAll('config_split.config_split.') as $name) {
+      // Load config split name.
+      $config_name = explode('.', $name);
+      $split_name = $config_name[2];
+
+      // Determine if this split is active (including overrides):
+      $is_active = $this->configManager->getConfigFactory()->get($name)->get('status');
+      if ($is_active) {
+        $this->cliService->ioImport($split_name, $this->io(), 'dt');
+        $this->output()->writeln('Split configurations successfully imported for ' . $split_name . '.');
+      }
+    }
+
+  }
+
+}


### PR DESCRIPTION
# Description
This PR sets up the initial caching/purge configurations for Acquia environments as well as implements config split and outlines what the process would look like.
- Adds Acquia Purge module to composer.
- Enables acquia_purge and dependencies in install profile.
- Configures purgers and cache config.

# Testing Steps
TBD

# Config Split Implementation (Conditional Configuration)
- Adds a config split to the base profile install that will register and install a "Split of Splits". 
- The "Split of Splits" will contain split configurations for each split in the website. 
-- Splits related to modules will be disabled by default. Modules will be responsible for enabling these splits through a ConfigurationOverride functionality. 
-- Examples of this in the cgov_cache and cgov_article modules.

**Split Configuration & Explanation**
- Splits are configured to map configuration to the config/install directory of the module they are controlled by. `cgov_article_split -> cgov_article/config/install`
-- Mapping the config to the install directory is very important because a split's configuration is not imported on install or enable of a split - it is imported on a configuration import (deploy). 
-- Since the configuration is also mapped as a configuration split, deployments will automatically import configuration on installs when a `cgov-csia` command is run (See below)
-- **IMPORTANT No configuration can be manually added to the config/install directory that has a split mapped to it without it being a part of the split.**
- Configuration can be managed (imported/exported) using drush config commands specific to the split. `drush csex cgov_cache_configuration` or imported individually with `drush csim cgov_cache_configuration`

**Custom Drush Command - cgov-csia**
Usage: 
`drush cgov-csia` - Imports all active split configurations. 
Reasoning: 
Since we are not utilizing normal configuration import on this project, a new drush command that only imports configuration splits is important. OOTB the only options available are to import splits by name (individually). This command is meant to provide flexibility/scalability of this architecture.


### TODO:
2. Discuss Config Split implementation

# Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally with my changes
- [x] Any update hooks or scripts required to make my functionality work are included