### PR TITLE
OTP migration edge case handling.

### DIFF
--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/article/field--field-article-body.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/article/field--field-article-body.html.twig
@@ -27,9 +27,18 @@
     </ul>
   </nav>
 {% endif %}
+{# Paragraphs with only one section will not be wrapped in sections and not draw OTP. #}
+{# However, in the course of migrating, there may be instances where a single paragraph has a full article body with
+multiple sections expecting OTP to be drawn by the javascript method. The legacy method is still supported with OTP in
+Common.js #}
 {% for item in items %}
-  {# The Paragraphs template renders the <section> tag. #}
-  {{ item.content }}
+  {% if items | length > 1 %}
+    <section>
+  {% endif %}
+    {{ item.content }}
+  {% if items | length > 1 %}
+    </section>
+  {% endif %}
 {% endfor %}
 {% if items | length > 1 %}
   </div>

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/article/paragraph--body-section.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/article/paragraph--body-section.html.twig
@@ -8,13 +8,11 @@
  * nav displays - based on the wrapping container.
  */
 #}
-<section>
-  {% if content.field_body_section_heading['#items'].getValue() %}
-    {# TODO: Determine how to deal with headings that are H3s #}
-    {# Set the id to a clean version of the section heading for OTP links. #}
-    <h2 id="{{ content.field_body_section_heading['#items'][0].value | clean_id }}">
-      {{- content.field_body_section_heading -}}
-    </h2>
-  {% endif %}
-  {{ content.field_body_section_content }}
-</section>
+{% if content.field_body_section_heading['#items'].getValue() %}
+  {# TODO: Determine how to deal with headings that are H3s #}
+  {# Set the id to a clean version of the section heading for OTP links. #}
+  <h2 id="{{ content.field_body_section_heading['#items'][0].value | clean_id }}">
+    {{- content.field_body_section_heading -}}
+  </h2>
+{% endif %}
+{{ content.field_body_section_content }}


### PR DESCRIPTION
In the new system, OTP is drawn through twig. In the old system, it's done by NCI.page.js. Migrated articles may not be correctly transformed into the new paragraphs and instead be dumped raw into a  single paragraph. That edge case needs to be handled. NCI.page.js still runs and will correctly draw the OTP when the twig template fails to do so.

ODE: http://ncigovcdode82.prod.acquia-sites.com