### PR TITLE
Add Cgov Schema Exclusion library.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -81,7 +81,8 @@
             "load.environment.php"
         ],
         "psr-4": {
-            "Acquia\\Blt\\Custom\\": "blt/src/"
+            "Acquia\\Blt\\Custom\\": "blt/src/",
+            "CgovPlatform\\Tests\\": "docroot/lib/CgovPlatform/Tests/"
         }
     },
     "scripts": {

--- a/docroot/lib/CgovPlatform/Tests/CgovSchemaExclusions.php
+++ b/docroot/lib/CgovPlatform/Tests/CgovSchemaExclusions.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace CGovPlatform\Tests;
+
+/**
+ * A custom class containing schema exclusions test cases.
+ */
+class CgovSchemaExclusions {
+
+  /**
+   * An array of config object names that are excluded from schema checking.
+   *
+   * @var string[]
+   */
+  public static $configSchemaCheckerExclusions = [];
+
+}

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/tests/src/Kernel/RolesTest.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/tests/src/Kernel/RolesTest.php
@@ -3,6 +3,7 @@
 namespace Drupal\Tests\cgov_core\Kernel;
 
 use Drupal\KernelTests\KernelTestBase;
+use CgovPlatform\Tests\CgovSchemaExclusions;
 
 /**
  * Tests the my custom service.
@@ -51,6 +52,7 @@ class RolesTest extends KernelTestBase {
    * {@inheritdoc}
    */
   public function setUp() {
+    static::$configSchemaCheckerExclusions = CgovSchemaExclusions::$configSchemaCheckerExclusions;
     parent::setup();
     $this->installEntitySchema('block_content');
     $this->installEntitySchema('content_moderation_state');

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/tests/src/Kernel/TestKernelTest.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/tests/src/Kernel/TestKernelTest.php
@@ -3,6 +3,7 @@
 namespace Drupal\Tests\cgov_core\Kernel;
 
 use Drupal\KernelTests\KernelTestBase;
+use CgovPlatform\Tests\CgovSchemaExclusions;
 
 /**
  * Tests node body field storage.
@@ -24,6 +25,7 @@ class TestKernelTest extends KernelTestBase {
    * Sets up the test environment.
    */
   protected function setUp() {
+    static::$configSchemaCheckerExclusions = CgovSchemaExclusions::$configSchemaCheckerExclusions;
     parent::setUp();
     $this->installSchema('system', 'sequences');
     // Necessary for module uninstall.

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/tests/src/Kernel/WorkflowTest.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/tests/src/Kernel/WorkflowTest.php
@@ -7,6 +7,7 @@ use Drupal\language\Entity\ConfigurableLanguage;
 use Drupal\node\Entity\NodeType;
 use Drupal\Tests\node\Traits\NodeCreationTrait;
 use Drupal\Tests\user\Traits\UserCreationTrait;
+use CgovPlatform\Tests\CgovSchemaExclusions;
 
 /**
  * Ensure that cgov_site workflows conform to requirements.
@@ -73,6 +74,7 @@ class WorkflowTest extends KernelTestBase {
    * {@inheritdoc}
    */
   protected function setUp() {
+    static::$configSchemaCheckerExclusions = CgovSchemaExclusions::$configSchemaCheckerExclusions;
     parent::setUp();
     $this->installEntitySchema('content_moderation_state');
     $this->installEntitySchema('node');

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/tests/src/Functional/ApiTest.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/tests/src/Functional/ApiTest.php
@@ -5,6 +5,7 @@ namespace Drupal\Tests\pdq_cancer_information_summary\Functional;
 use Drupal\Core\Url;
 use Drupal\taxonomy\Entity\Term;
 use Drupal\Tests\BrowserTestBase;
+use CgovPlatform\Tests\CgovSchemaExclusions;
 
 /**
  * Verify publication of PDQ Cancer Information Summaries.
@@ -116,6 +117,7 @@ class ApiTest extends BrowserTestBase {
    * {@inheritdoc}
    */
   public function setUp() {
+    static::$configSchemaCheckerExclusions = CgovSchemaExclusions::$configSchemaCheckerExclusions;
     parent::setUp();
 
     // Build the URLs for the API requests.

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/tests/src/Functional/PDQCancerSummaryTest.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/tests/src/Functional/PDQCancerSummaryTest.php
@@ -4,6 +4,7 @@ namespace Drupal\Tests\cgov_site\Functional;
 
 use Drupal\Tests\SchemaCheckTestTrait;
 use Drupal\Tests\BrowserTestBase;
+use CgovPlatform\Tests\CgovSchemaExclusions;
 
 /**
  * Tests Functionality of the PDQ Cancer Information Summary content type.
@@ -49,6 +50,7 @@ class PDQCancerSummaryTest extends BrowserTestBase {
    * {@inheritdoc}
    */
   public function setUp() {
+    static::$configSchemaCheckerExclusions = CgovSchemaExclusions::$configSchemaCheckerExclusions;
     parent::setUp();
 
     // Create admin user and login.

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_drug_information_summary/tests/src/Functional/ApiTest.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_drug_information_summary/tests/src/Functional/ApiTest.php
@@ -4,6 +4,7 @@ namespace Drupal\Tests\pdq_drug_information_summary\Functional;
 
 use Drupal\Core\Url;
 use Drupal\Tests\BrowserTestBase;
+use CgovPlatform\Tests\CgovSchemaExclusions;
 
 /**
  * Verify publication of PDQ Drug Information Summaries.
@@ -77,6 +78,7 @@ class ApiTest extends BrowserTestBase {
    * {@inheritdoc}
    */
   public function setUp() {
+    static::$configSchemaCheckerExclusions = CgovSchemaExclusions::$configSchemaCheckerExclusions;
     parent::setUp();
 
     // Build the URLs for the API requests.

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_drug_information_summary/tests/src/Functional/PDQDrugSummaryTest.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_drug_information_summary/tests/src/Functional/PDQDrugSummaryTest.php
@@ -4,6 +4,7 @@ namespace Drupal\Tests\cgov_site\Functional;
 
 use Drupal\Tests\SchemaCheckTestTrait;
 use Drupal\Tests\BrowserTestBase;
+use CgovPlatform\Tests\CgovSchemaExclusions;
 
 /**
  * Tests Functionality of the PDQ Drug Information Summary content type.
@@ -44,6 +45,7 @@ class PDQDrugSummaryTest extends BrowserTestBase {
    * {@inheritdoc}
    */
   public function setUp() {
+    static::$configSchemaCheckerExclusions = CgovSchemaExclusions::$configSchemaCheckerExclusions;
     parent::setUp();
 
     // Create admin user and login.

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_glossifier/tests/src/Functional/ApiTest.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_glossifier/tests/src/Functional/ApiTest.php
@@ -4,6 +4,7 @@ namespace Drupal\Tests\pdq_glossifier\Functional;
 
 use Drupal\Core\Url;
 use Drupal\Tests\BrowserTestBase;
+use CgovPlatform\Tests\CgovSchemaExclusions;
 
 /**
  * Verify correct behavior of the PDQ Glossifier service.
@@ -196,6 +197,7 @@ class ApiTest extends BrowserTestBase {
    * {@inheritdoc}
    */
   public function setUp() {
+    static::$configSchemaCheckerExclusions = CgovSchemaExclusions::$configSchemaCheckerExclusions;
     parent::setUp();
 
     // Build the URL for the API requests.

--- a/docroot/profiles/custom/cgov_site/tests/src/Functional/CgovSiteTest.php
+++ b/docroot/profiles/custom/cgov_site/tests/src/Functional/CgovSiteTest.php
@@ -4,6 +4,7 @@ namespace Drupal\Tests\cgov_site\Functional;
 
 use Drupal\Tests\SchemaCheckTestTrait;
 use Drupal\Tests\BrowserTestBase;
+use CgovPlatform\Tests\CgovSchemaExclusions;
 
 /**
  * Tests CGOV_SITE installation profile expectations are being met.
@@ -23,6 +24,14 @@ class CgovSiteTest extends BrowserTestBase {
    * @var \Drupal\user\UserInterface
    */
   protected $adminUser;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp() {
+    static::$configSchemaCheckerExclusions = CgovSchemaExclusions::$configSchemaCheckerExclusions;
+    parent::setUp();
+  }
 
   /**
    * Tests cgov_site installation profile.

--- a/docroot/profiles/custom/cgov_site/tests/src/Functional/PdqNodeTypeTest.php
+++ b/docroot/profiles/custom/cgov_site/tests/src/Functional/PdqNodeTypeTest.php
@@ -5,6 +5,7 @@ namespace Drupal\Tests\node\Functional;
 use Drupal\node\Entity\NodeType;
 use Drupal\Tests\system\Functional\Menu\AssertBreadcrumbTrait;
 use Drupal\Tests\system\Functional\Cache\AssertPageCacheContextsAndTagsTrait;
+use CgovPlatform\Tests\CgovSchemaExclusions;
 
 /**
  * Ensures the PDQ content types are correctly configured.
@@ -43,6 +44,14 @@ class PdqNodeTypeTest extends NodeTestBase {
   private $contentTypes = [
     'pdq_cancer_information_summary',
   ];
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp() {
+    static::$configSchemaCheckerExclusions = CgovSchemaExclusions::$configSchemaCheckerExclusions;
+    parent::setUp();
+  }
 
   /**
    * Ensures that node type functions (node_type_get_*) work correctly.


### PR DESCRIPTION
Closes #1367 

Adds the schema exclusion library. Currently the list of items to exclude is empty as they will be added  in the necessary modules PR.