### PR TITLE
Ticket-1444: two column list display is not appearing correctly

### DIFF
--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/home_landing/paragraph--cgov-column-two.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/home_landing/paragraph--cgov-column-two.html.twig
@@ -1,4 +1,4 @@
-<div class="row paragraph-col-two flex-columns">
+<div class="row">
     <div class="large-8 columns card gutter">
       {{ content.field_main_contents }}
     </div>


### PR DESCRIPTION
Closes #1444 :
Removed the flex-columns class which doesn't exist on prod

<img width="1106" alt="Screen Shot 2019-04-12 at 12 39 36 PM" src="https://user-images.githubusercontent.com/45469809/56052946-b0ea6a00-5d20-11e9-8e05-a3bd55e69d96.png">
