### PR TITLE
Add templates for HHS syndication theme

### DIFF
--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/article/node--cgov-article--hhs-syndication.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/article/node--cgov-article--hhs-syndication.html.twig
@@ -1,0 +1,17 @@
+{#
+/**
+ * @file
+ * Theme override for HHS Syndication of cancer.gov Articles.
+ *
+ * This is a stripped-down version of the body, restricted to the
+ * information in the article. The bundle and theme names are embedded
+ * in the template's file name to ensure that this overriding template
+ * is selected.
+ */
+#}
+<h1>{{ node.label }}</h1>
+<div id="cgvBody">
+  {{ content.field_image_article }}
+  {{ content.field_intro_text }}
+  {{ content.field_article_body }}
+</div>

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/pdq/node--pdq-cancer-information-summary--hhs-syndication.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/pdq/node--pdq-cancer-information-summary--hhs-syndication.html.twig
@@ -1,0 +1,17 @@
+{#
+/**
+ * @file
+ * Theme override for HHS Syndication of Cancer Information Summaries.
+ *
+ * This is a stripped-down version of the body, restricted to the
+ * information in the summary. The bundle and theme names are embedded
+ * in the template's file name to ensure that this overriding template
+ * is selected.
+ */
+#}
+<h1>{{- node.label -}}</h1>
+<div id="cgvBody">
+  <div class="summary-sections">
+    {{ content.field_summary_sections }}
+  </div>
+</div>

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/layout/html--node--syndication.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/layout/html--node--syndication.html.twig
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html{{ html_attributes }}>
+  <head>
+    <meta charset="utf-8">
+    {% if syndication_keywords %}
+      <meta name="keywords" content="{{ syndication_keywords }}">
+    {% endif %}
+    {% if syndication_description %}
+      <meta name="description" content="{{ syndication_description }}">
+    {% endif %}
+    <link rel="canonical" href="{{ syndication_canonical }}">
+  </head>
+  <body>
+    <div class="syndicate">
+      {{ page.content }}
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
Here are the syndication templates Bryan requested be folded into `develop`. Note that they won't do anything without the `hhs_syndication` field and the other bits to connect the field to content types or do the massaging to hook up with the theme. The closest ticket I can find to link this to is the syndication epic (#598). I haven't run the unit tests locally, since all I'm adding are decoupled templates, so if this fails in the pipeline, `develop` should fail as well (he says, ducking).