### PR TITLE
Add and enable the taxonomy manager module.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,6 +51,7 @@
         "drupal/pathauto": "^1.3",
         "drupal/seckit": "^1.1",
         "drupal/shield": "^1.2",
+        "drupal/taxonomy_manager": "^1.0@alpha",
         "drupal/token": "^1.5",
         "drupal/token_filter": "^1.1",
         "drupal/twig_field_value": "^1.2",
@@ -191,6 +192,9 @@
             },
             "drupal/token_filter":{
                 "3036541: Missing token_filter schema file": "https://www.drupal.org/files/issues/2019-03-04/3036541-2-token_filter_schema.patch"
+            },
+            "drupal/taxonomy_manager":{
+                "3048613: Invalid type in schema configuration": "https://www.drupal.org/files/issues/2019-04-16/3048613-2.patch"
             }
         },
         "drupal-scaffold": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "16d342330848e9eb7e619b6f8535bf71",
+    "content-hash": "909e8687a190c2f95ec24673dc80c920",
     "packages": [
         {
             "name": "acquia/acsf-tools",
@@ -4777,6 +4777,70 @@
             "homepage": "https://www.drupal.org/project/shield",
             "support": {
                 "source": "http://cgit.drupalcode.org/shield"
+            }
+        },
+        {
+            "name": "drupal/taxonomy_manager",
+            "version": "1.0.0-alpha2",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/taxonomy_manager.git",
+                "reference": "8.x-1.0-alpha2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/taxonomy_manager-8.x-1.0-alpha2.zip",
+                "reference": "8.x-1.0-alpha2",
+                "shasum": "7becfad1cad0d26f471b8e097afcadde94a9f266"
+            },
+            "require": {
+                "drupal/core": "*"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                },
+                "drupal": {
+                    "version": "8.x-1.0-alpha2",
+                    "datestamp": "1538074980",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Alpha releases are not covered by Drupal security advisories."
+                    }
+                },
+                "patches_applied": {
+                    "3048613: Invalid type in schema configuration": "https://www.drupal.org/files/issues/2019-04-16/3048613-2.patch"
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "Matthias Hutterer (mpdonadio)",
+                    "homepage": "https://www.drupal.org/u/mh86",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "joaogarin",
+                    "homepage": "https://www.drupal.org/user/612814"
+                },
+                {
+                    "name": "kalinchernev",
+                    "homepage": "https://www.drupal.org/user/231185"
+                },
+                {
+                    "name": "mh86",
+                    "homepage": "https://www.drupal.org/user/59747"
+                }
+            ],
+            "description": "Taxonomy_Manager provides a powerful interface for managing taxonomies via a tree view.",
+            "homepage": "https://drupal.org/project/taxonomy_manager",
+            "support": {
+                "source": "http://cgit.drupalcode.org/taxonomy_manager",
+                "issues": "https://drupal.org/project/issues/taxonomy_manager"
             }
         },
         {
@@ -12308,6 +12372,7 @@
         "acquia/acsf-tools": 20,
         "drupal/entity_embed": 20,
         "drupal/page_manager": 10,
+        "drupal/taxonomy_manager": 15,
         "drupal/viewsreference": 20,
         "drupal/yaml_content": 20,
         "sensiolabs-de/deprecation-detector": 20

--- a/docroot/profiles/custom/cgov_site/cgov_site.info.yml
+++ b/docroot/profiles/custom/cgov_site/cgov_site.info.yml
@@ -81,6 +81,7 @@ install:
   - entity_browser
   - migrate_plus
   - migrate_tools
+  - taxonomy_manager 
 themes:
   - cgov_common
   - cgov_admin


### PR DESCRIPTION
Closes #1413

* Adds and enables the Taxonomy Manager module ( e.g:  for Site Sections)

Technical Note: This required a patch in order for the config