### PR TITLE
Add metatag submodules, cgov_metatag, config exclusions, field storage

### DIFF
--- a/docroot/lib/CgovPlatform/Tests/CgovSchemaExclusions.php
+++ b/docroot/lib/CgovPlatform/Tests/CgovSchemaExclusions.php
@@ -12,6 +12,9 @@ class CgovSchemaExclusions {
    *
    * @var string[]
    */
-  public static $configSchemaCheckerExclusions = [];
+  public static $configSchemaCheckerExclusions = [
+    'metatag.metatag_defaults.global',
+    'metatag.metatag_defaults.node',
+  ];
 
 }

--- a/docroot/profiles/custom/cgov_site/cgov_site.info.yml
+++ b/docroot/profiles/custom/cgov_site/cgov_site.info.yml
@@ -46,6 +46,7 @@ install:
   - cgov_file
   - cgov_home_landing
   - cgov_content_block
+  - cgov_metatag
   - cgov_press_release
   - cgov_site_section
   - cgov_video
@@ -88,6 +89,10 @@ install:
   - ctools
   - entity_browser
   - adobe_dtm
+  - metatag_dc
+  - metatag_dc_advanced
+  - metatag_open_graph
+  - metatag_twitter_cards
 themes:
   - cgov_common
   - cgov_admin

--- a/docroot/profiles/custom/cgov_site/config/install/metatag.metatag_defaults.global.yml
+++ b/docroot/profiles/custom/cgov_site/config/install/metatag.metatag_defaults.global.yml
@@ -1,0 +1,13 @@
+langcode: en
+status: true
+dependencies: {  }
+id: global
+label: Global
+tags:
+  canonical_url: '[current-page:url]'
+  title: '[cgov_tokens:cgov-title] - [site:name]'
+  dcterms_coverage: 'nciglobal,ncienterprise'
+  og_site_name: 'National Cancer Institute'
+  og_type: Website
+  og_url: '[current-page:url]'
+  twitter_cards_type: summary

--- a/docroot/profiles/custom/cgov_site/config/install/metatag.metatag_defaults.media.yml
+++ b/docroot/profiles/custom/cgov_site/config/install/metatag.metatag_defaults.media.yml
@@ -1,0 +1,6 @@
+langcode: en
+status: true
+dependencies: {  }
+id: media
+label: Media
+tags: {  }

--- a/docroot/profiles/custom/cgov_site/config/install/metatag.metatag_defaults.node.yml
+++ b/docroot/profiles/custom/cgov_site/config/install/metatag.metatag_defaults.node.yml
@@ -1,0 +1,12 @@
+langcode: en
+status: true
+dependencies: {  }
+id: node
+label: Content
+tags:
+  canonical_url: '[node:url]'
+  content_language: '[node:langcode]'
+  description: '[node:field_page_description:value]'
+  title: '[cgov_tokens:cgov-title] - [site:name]'
+  og_description: '[node:field_page_description:value]'
+  og_title: '[node:field_short_title:value]'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/core.entity_form_display.node.cgov_article.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/core.entity_form_display.node.cgov_article.default.yml
@@ -16,6 +16,7 @@ dependencies:
     - field.field.node.cgov_article.field_image_promotional
     - field.field.node.cgov_article.field_intro_text
     - field.field.node.cgov_article.field_list_description
+    - field.field.node.cgov_article.field_meta_tags
     - field.field.node.cgov_article.field_page_description
     - field.field.node.cgov_article.field_pretty_url
     - field.field.node.cgov_article.field_public_use
@@ -275,5 +276,6 @@ content:
     region: content
     third_party_settings: {  }
 hidden:
+  field_meta_tags: true
   promote: true
   sticky: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/core.entity_view_display.node.cgov_article.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/core.entity_view_display.node.cgov_article.default.yml
@@ -15,6 +15,7 @@ dependencies:
     - field.field.node.cgov_article.field_image_promotional
     - field.field.node.cgov_article.field_intro_text
     - field.field.node.cgov_article.field_list_description
+    - field.field.node.cgov_article.field_meta_tags
     - field.field.node.cgov_article.field_page_description
     - field.field.node.cgov_article.field_pretty_url
     - field.field.node.cgov_article.field_public_use
@@ -204,4 +205,5 @@ content:
 hidden:
   field_image_promotional: true
   field_public_use: true
+  field_meta_tags: true
   langcode: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/field.field.node.cgov_article.field_meta_tags.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/field.field.node.cgov_article.field_meta_tags.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_meta_tags
+    - node.type.cgov_article
+  module:
+    - metatag
+id: node.cgov_article.field_meta_tags
+field_name: field_meta_tags
+entity_type: node
+bundle: cgov_article
+label: 'Meta Tags'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: metatag

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/metatag.metatag_defaults.node__cgov_article.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/metatag.metatag_defaults.node__cgov_article.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+id: node__cgov_article
+label: 'Content: Article'
+tags:
+  dcterms_type: cgvArticle

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_biography/config/install/field.field.node.cgov_biography.field_meta_tags.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_biography/config/install/field.field.node.cgov_biography.field_meta_tags.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_meta_tags
+    - node.type.cgov_biography
+  module:
+    - metatag
+id: node.cgov_biography.field_meta_tags
+field_name: field_meta_tags
+entity_type: node
+bundle: cgov_biography
+label: 'Meta Tags'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: metatag

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_biography/config/install/metatag.metatag_defaults.node__cgov_biography.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_biography/config/install/metatag.metatag_defaults.node__cgov_biography.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+id: node__cgov_biography
+label: 'Content: Biography'
+tags:
+  dcterms_type: cgvBiography

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/config/install/field.field.node.cgov_blog_post.field_meta_tags.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/config/install/field.field.node.cgov_blog_post.field_meta_tags.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_meta_tags
+    - node.type.cgov_blog_post
+  module:
+    - metatag
+id: node.cgov_blog_post.field_meta_tags
+field_name: field_meta_tags
+entity_type: node
+bundle: cgov_blog_post
+label: 'Meta Tags'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: metatag

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/config/install/field.field.node.cgov_blog_series.field_meta_tags.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/config/install/field.field.node.cgov_blog_series.field_meta_tags.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_meta_tags
+    - node.type.cgov_blog_series
+  module:
+    - metatag
+id: node.cgov_blog_series.field_meta_tags
+field_name: field_meta_tags
+entity_type: node
+bundle: cgov_blog_series
+label: 'Meta Tags'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: metatag

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/config/install/metatag.metatag_defaults.node__cgov_blog_post.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/config/install/metatag.metatag_defaults.node__cgov_blog_post.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+id: node__cgov_blog_post
+label: 'Content: Blog Post'
+tags:
+  dcterms_type: cgvBlogPost

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/config/install/metatag.metatag_defaults.node__cgov_blog_series.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/config/install/metatag.metatag_defaults.node__cgov_blog_series.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+id: node__cgov_blog_series
+label: 'Content: Blog Series'
+tags:
+  dcterms_type: cgvBlogSeries

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_center/config/install/field.field.node.cgov_cancer_center.field_meta_tags.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_center/config/install/field.field.node.cgov_cancer_center.field_meta_tags.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_meta_tags
+    - node.type.cgov_cancer_center
+  module:
+    - metatag
+id: node.cgov_cancer_center.field_meta_tags
+field_name: field_meta_tags
+entity_type: node
+bundle: cgov_cancer_center
+label: 'Meta Tags'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: metatag

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_center/config/install/metatag.metatag_defaults.node__cgov_cancer_center.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_center/config/install/metatag.metatag_defaults.node__cgov_cancer_center.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+id: node__cgov_cancer_center
+label: 'Content: Cancer Center'
+tags:
+  dcterms_type: cgvCancerCenter

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_research/config/install/core.entity_form_display.node.cgov_cancer_research.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_research/config/install/core.entity_form_display.node.cgov_cancer_research.default.yml
@@ -2,7 +2,6 @@ langcode: en
 status: true
 dependencies:
   config:
-    - entity_browser.browser.cgov_image_browser
     - entity_browser.browser.cgov_site_section_browser
     - field.field.node.cgov_cancer_research.body
     - field.field.node.cgov_cancer_research.field_browser_title
@@ -14,6 +13,7 @@ dependencies:
     - field.field.node.cgov_cancer_research.field_feature_card_description
     - field.field.node.cgov_cancer_research.field_image_promotional
     - field.field.node.cgov_cancer_research.field_list_description
+    - field.field.node.cgov_cancer_research.field_meta_tags
     - field.field.node.cgov_cancer_research.field_page_description
     - field.field.node.cgov_cancer_research.field_pretty_url
     - field.field.node.cgov_cancer_research.field_search_engine_restrictions
@@ -21,12 +21,11 @@ dependencies:
     - field.field.node.cgov_cancer_research.field_short_title
     - field.field.node.cgov_cancer_research.field_site_section
     - node.type.cgov_cancer_research
-    - workflows.workflow.editorial_workflow
   module:
     - content_moderation
     - datetime
     - entity_browser
-    - paragraphs_asymmetric_translation_widgets
+    - paragraphs
     - path
     - text
 id: node.cgov_cancer_research.default
@@ -45,7 +44,7 @@ content:
     region: content
   created:
     type: datetime_timestamp
-    weight: 25
+    weight: 23
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -66,25 +65,25 @@ content:
     type: string_textfield
     region: content
   field_date_display_mode:
-    weight: 17
+    weight: 16
     settings: {  }
     third_party_settings: {  }
     type: options_buttons
     region: content
   field_date_posted:
-    weight: 14
+    weight: 13
     settings: {  }
     third_party_settings: {  }
     type: datetime_default
     region: content
   field_date_reviewed:
-    weight: 16
+    weight: 15
     settings: {  }
     third_party_settings: {  }
     type: datetime_default
     region: content
   field_date_updated:
-    weight: 15
+    weight: 14
     settings: {  }
     third_party_settings: {  }
     type: datetime_default
@@ -98,7 +97,7 @@ content:
     type: string_textfield
     region: content
   field_image_promotional:
-    weight: 13
+    weight: 12
     settings:
       entity_browser: cgov_image_browser
       field_widget_display: rendered_entity
@@ -137,7 +136,7 @@ content:
     type: string_textfield
     region: content
   field_search_engine_restrictions:
-    weight: 18
+    weight: 17
     settings: {  }
     third_party_settings: {  }
     type: options_select
@@ -161,6 +160,7 @@ content:
       placeholder: ''
     third_party_settings: {  }
     type: string_textfield
+    region: content
   field_site_section:
     weight: 8
     settings:
@@ -184,13 +184,13 @@ content:
     third_party_settings: {  }
   moderation_state:
     type: moderation_state_default
-    weight: 19
+    weight: 18
     settings: {  }
     region: content
     third_party_settings: {  }
   path:
     type: path
-    weight: 20
+    weight: 19
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -198,7 +198,7 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 21
+    weight: 20
     region: content
     third_party_settings: {  }
   title:
@@ -210,19 +210,25 @@ content:
       placeholder: ''
     third_party_settings: {  }
   translation:
-    weight: 22
+    weight: 21
     region: content
     settings: {  }
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 23
+    weight: 22
     settings:
       match_operator: CONTAINS
       size: 60
       placeholder: ''
     region: content
     third_party_settings: {  }
+  url_redirects:
+    weight: 24
+    region: content
+    settings: {  }
+    third_party_settings: {  }
 hidden:
+  field_meta_tags: true
   promote: true
   sticky: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_research/config/install/core.entity_view_display.node.cgov_cancer_research.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_research/config/install/core.entity_view_display.node.cgov_cancer_research.default.yml
@@ -12,6 +12,7 @@ dependencies:
     - field.field.node.cgov_cancer_research.field_feature_card_description
     - field.field.node.cgov_cancer_research.field_image_promotional
     - field.field.node.cgov_cancer_research.field_list_description
+    - field.field.node.cgov_cancer_research.field_meta_tags
     - field.field.node.cgov_cancer_research.field_page_description
     - field.field.node.cgov_cancer_research.field_pretty_url
     - field.field.node.cgov_cancer_research.field_search_engine_restrictions
@@ -22,6 +23,7 @@ dependencies:
   module:
     - datetime
     - entity_reference_revisions
+    - metatag
     - options
     - text
     - user
@@ -114,6 +116,13 @@ content:
     settings: {  }
     third_party_settings: {  }
     type: basic_string
+    region: content
+  field_meta_tags:
+    weight: 21
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: metatag_empty_formatter
     region: content
   field_page_description:
     weight: 13

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_research/config/install/core.entity_view_display.node.cgov_cancer_research.embedded_feature_card.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_research/config/install/core.entity_view_display.node.cgov_cancer_research.embedded_feature_card.yml
@@ -13,6 +13,7 @@ dependencies:
     - field.field.node.cgov_cancer_research.field_feature_card_description
     - field.field.node.cgov_cancer_research.field_image_promotional
     - field.field.node.cgov_cancer_research.field_list_description
+    - field.field.node.cgov_cancer_research.field_meta_tags
     - field.field.node.cgov_cancer_research.field_page_description
     - field.field.node.cgov_cancer_research.field_pretty_url
     - field.field.node.cgov_cancer_research.field_search_engine_restrictions
@@ -21,7 +22,6 @@ dependencies:
     - field.field.node.cgov_cancer_research.field_site_section
     - node.type.cgov_cancer_research
   module:
-    - cgov_core
     - user
 id: node.cgov_cancer_research.embedded_feature_card
 targetEntityType: node
@@ -70,6 +70,7 @@ hidden:
   field_date_reviewed: true
   field_date_updated: true
   field_list_description: true
+  field_meta_tags: true
   field_page_description: true
   field_pretty_url: true
   field_search_engine_restrictions: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_research/config/install/core.entity_view_display.node.cgov_cancer_research.embedded_feature_card_no_image.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_research/config/install/core.entity_view_display.node.cgov_cancer_research.embedded_feature_card_no_image.yml
@@ -13,6 +13,7 @@ dependencies:
     - field.field.node.cgov_cancer_research.field_feature_card_description
     - field.field.node.cgov_cancer_research.field_image_promotional
     - field.field.node.cgov_cancer_research.field_list_description
+    - field.field.node.cgov_cancer_research.field_meta_tags
     - field.field.node.cgov_cancer_research.field_page_description
     - field.field.node.cgov_cancer_research.field_pretty_url
     - field.field.node.cgov_cancer_research.field_search_engine_restrictions
@@ -21,7 +22,6 @@ dependencies:
     - field.field.node.cgov_cancer_research.field_site_section
     - node.type.cgov_cancer_research
   module:
-    - cgov_core
     - user
 id: node.cgov_cancer_research.embedded_feature_card_no_image
 targetEntityType: node
@@ -62,6 +62,7 @@ hidden:
   field_date_updated: true
   field_image_promotional: true
   field_list_description: true
+  field_meta_tags: true
   field_page_description: true
   field_pretty_url: true
   field_search_engine_restrictions: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_research/config/install/core.entity_view_display.node.cgov_cancer_research.feature_card_image.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_research/config/install/core.entity_view_display.node.cgov_cancer_research.feature_card_image.yml
@@ -13,6 +13,7 @@ dependencies:
     - field.field.node.cgov_cancer_research.field_feature_card_description
     - field.field.node.cgov_cancer_research.field_image_promotional
     - field.field.node.cgov_cancer_research.field_list_description
+    - field.field.node.cgov_cancer_research.field_meta_tags
     - field.field.node.cgov_cancer_research.field_page_description
     - field.field.node.cgov_cancer_research.field_pretty_url
     - field.field.node.cgov_cancer_research.field_search_engine_restrictions
@@ -21,7 +22,6 @@ dependencies:
     - field.field.node.cgov_cancer_research.field_site_section
     - node.type.cgov_cancer_research
   module:
-    - cgov_core
     - user
 id: node.cgov_cancer_research.feature_card_image
 targetEntityType: node
@@ -48,6 +48,7 @@ hidden:
   field_date_updated: true
   field_feature_card_description: true
   field_list_description: true
+  field_meta_tags: true
   field_page_description: true
   field_pretty_url: true
   field_search_engine_restrictions: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_research/config/install/core.entity_view_display.node.cgov_cancer_research.full.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_research/config/install/core.entity_view_display.node.cgov_cancer_research.full.yml
@@ -13,6 +13,7 @@ dependencies:
     - field.field.node.cgov_cancer_research.field_feature_card_description
     - field.field.node.cgov_cancer_research.field_image_promotional
     - field.field.node.cgov_cancer_research.field_list_description
+    - field.field.node.cgov_cancer_research.field_meta_tags
     - field.field.node.cgov_cancer_research.field_page_description
     - field.field.node.cgov_cancer_research.field_pretty_url
     - field.field.node.cgov_cancer_research.field_search_engine_restrictions
@@ -21,9 +22,7 @@ dependencies:
     - field.field.node.cgov_cancer_research.field_site_section
     - node.type.cgov_cancer_research
   module:
-    - cgov_core
     - entity_reference_revisions
-    - options
     - text
     - user
 id: node.cgov_cancer_research.full
@@ -66,6 +65,7 @@ hidden:
   field_feature_card_description: true
   field_image_promotional: true
   field_list_description: true
+  field_meta_tags: true
   field_page_description: true
   field_pretty_url: true
   field_search_engine_restrictions: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_research/config/install/core.entity_view_display.node.cgov_cancer_research.teaser.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_research/config/install/core.entity_view_display.node.cgov_cancer_research.teaser.yml
@@ -13,6 +13,7 @@ dependencies:
     - field.field.node.cgov_cancer_research.field_feature_card_description
     - field.field.node.cgov_cancer_research.field_image_promotional
     - field.field.node.cgov_cancer_research.field_list_description
+    - field.field.node.cgov_cancer_research.field_meta_tags
     - field.field.node.cgov_cancer_research.field_page_description
     - field.field.node.cgov_cancer_research.field_pretty_url
     - field.field.node.cgov_cancer_research.field_search_engine_restrictions
@@ -54,9 +55,13 @@ hidden:
   field_date_reviewed: true
   field_date_updated: true
   field_feature_card_description: true
+  field_image_promotional: true
   field_list_description: true
+  field_meta_tags: true
   field_page_description: true
+  field_pretty_url: true
   field_search_engine_restrictions: true
   field_selected_research: true
   field_short_title: true
+  field_site_section: true
   langcode: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_research/config/install/core.entity_view_display.node.cgov_cancer_research.thumbnail_card_image.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_research/config/install/core.entity_view_display.node.cgov_cancer_research.thumbnail_card_image.yml
@@ -13,6 +13,7 @@ dependencies:
     - field.field.node.cgov_cancer_research.field_feature_card_description
     - field.field.node.cgov_cancer_research.field_image_promotional
     - field.field.node.cgov_cancer_research.field_list_description
+    - field.field.node.cgov_cancer_research.field_meta_tags
     - field.field.node.cgov_cancer_research.field_page_description
     - field.field.node.cgov_cancer_research.field_pretty_url
     - field.field.node.cgov_cancer_research.field_search_engine_restrictions
@@ -21,7 +22,6 @@ dependencies:
     - field.field.node.cgov_cancer_research.field_site_section
     - node.type.cgov_cancer_research
   module:
-    - cgov_core
     - user
 id: node.cgov_cancer_research.thumbnail_card_image
 targetEntityType: node
@@ -48,6 +48,7 @@ hidden:
   field_date_updated: true
   field_feature_card_description: true
   field_list_description: true
+  field_meta_tags: true
   field_page_description: true
   field_pretty_url: true
   field_search_engine_restrictions: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_research/config/install/field.field.node.cgov_cancer_research.field_meta_tags.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_research/config/install/field.field.node.cgov_cancer_research.field_meta_tags.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_meta_tags
+    - node.type.cgov_cancer_research
+  module:
+    - metatag
+id: node.cgov_cancer_research.field_meta_tags
+field_name: field_meta_tags
+entity_type: node
+bundle: cgov_cancer_research
+label: 'Meta Tags'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: metatag

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_research/config/install/metatag.metatag_defaults.node__cgov_cancer_research.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_research/config/install/metatag.metatag_defaults.node__cgov_cancer_research.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+id: node__cgov_cancer_research
+label: 'Content: Cancer Research List Page'
+tags:
+  dcterms_type: cgvCancerResearch

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.info.yml
@@ -13,9 +13,14 @@ dependencies:
   - entity_embed
   - field_ui
   - language
+  - metatag
+  - metatag_dc
+  - metatag_dc_advanced
+  - metatag_open_graph
+  - metatag_twitter_cards
   - page_manager_ui
   - panels
   - paragraphs_asymmetric_translation_widgets
+  - token_filter
   - views
   - workflows
-  - token_filter

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/config/install/field.storage.node.field_meta_tags.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/config/install/field.storage.node.field_meta_tags.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - metatag
+    - node
+id: node.field_meta_tags
+field_name: field_meta_tags
+entity_type: node
+type: metatag
+settings: {  }
+module: metatag
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/tests/src/Kernel/FieldStorage/CGovFieldStorageTest.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/tests/src/Kernel/FieldStorage/CGovFieldStorageTest.php
@@ -47,6 +47,7 @@ class CGovFieldStorageTest extends KernelTestBase {
     'entity_reference_revisions',
     'paragraphs',
     'editor',
+    'metatag',
   ];
 
   /**

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/tests/src/Kernel/RolesTest.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/tests/src/Kernel/RolesTest.php
@@ -46,6 +46,7 @@ class RolesTest extends KernelTestBase {
     'token',
     'token_filter',
     'editor',
+    'metatag',
   ];
 
   /**
@@ -85,6 +86,7 @@ class RolesTest extends KernelTestBase {
       'token',
       'token_filter',
       'editor',
+      'metatag',
     ]);
   }
 

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/tests/src/Kernel/TestKernelTest.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/tests/src/Kernel/TestKernelTest.php
@@ -18,7 +18,7 @@ class TestKernelTest extends KernelTestBase {
    * @var array
    */
   public static $modules = ['user', 'system', 'field', 'node',
-    'text', 'filter', 'taxonomy',
+    'text', 'filter', 'taxonomy', 'metatag',
   ];
 
   /**
@@ -33,7 +33,7 @@ class TestKernelTest extends KernelTestBase {
     $this->installEntitySchema('user');
     $this->installEntitySchema('node');
     $this->installEntitySchema('taxonomy_term');
-    $this->installConfig(['field', 'node']);
+    $this->installConfig(['field', 'node', 'metatag']);
   }
 
   /**

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/tests/src/Kernel/WorkflowTest.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/tests/src/Kernel/WorkflowTest.php
@@ -54,6 +54,7 @@ class WorkflowTest extends KernelTestBase {
     'block',
     'block_content',
     'editor',
+    'metatag',
   ];
 
   /**
@@ -107,6 +108,7 @@ class WorkflowTest extends KernelTestBase {
       'block',
       'block_content',
       'editor',
+      'metatag',
     ]);
     $this->installSchema('system', ['sequences']);
     $this->installSchema('node', ['node_access']);

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/core.entity_form_display.node.cgov_cthp.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/core.entity_form_display.node.cgov_cthp.default.yml
@@ -3,7 +3,6 @@ status: true
 dependencies:
   config:
     - entity_browser.browser.cgov_site_section_browser
-    - entity_browser.browser.cgov_image_browser
     - field.field.node.cgov_cthp.field_audience
     - field.field.node.cgov_cthp.field_audience_toggle
     - field.field.node.cgov_cthp.field_browser_title
@@ -12,23 +11,21 @@ dependencies:
     - field.field.node.cgov_cthp.field_feature_card_description
     - field.field.node.cgov_cthp.field_image_promotional
     - field.field.node.cgov_cthp.field_list_description
+    - field.field.node.cgov_cthp.field_meta_tags
     - field.field.node.cgov_cthp.field_page_description
     - field.field.node.cgov_cthp.field_pretty_url
     - field.field.node.cgov_cthp.field_search_engine_restrictions
     - field.field.node.cgov_cthp.field_short_title
     - field.field.node.cgov_cthp.field_site_section
     - node.type.cgov_cthp
-    - workflows.workflow.editorial_workflow
   enforced:
     module:
       - cgov_core
   module:
     - content_moderation
-    - datetime
     - entity_browser
     - paragraphs
     - path
-    - text
 id: node.cgov_cthp.default
 targetEntityType: node
 bundle: cgov_cthp
@@ -211,6 +208,12 @@ content:
       placeholder: ''
     region: content
     third_party_settings: {  }
+  url_redirects:
+    weight: 21
+    region: content
+    settings: {  }
+    third_party_settings: {  }
 hidden:
+  field_meta_tags: true
   promote: true
   sticky: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/core.entity_view_display.node.cgov_cthp.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/core.entity_view_display.node.cgov_cthp.default.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.node.cgov_cthp.field_feature_card_description
     - field.field.node.cgov_cthp.field_image_promotional
     - field.field.node.cgov_cthp.field_list_description
+    - field.field.node.cgov_cthp.field_meta_tags
     - field.field.node.cgov_cthp.field_page_description
     - field.field.node.cgov_cthp.field_pretty_url
     - field.field.node.cgov_cthp.field_search_engine_restrictions
@@ -20,10 +21,9 @@ dependencies:
     module:
       - cgov_core
   module:
-    - datetime
     - entity_reference_revisions
+    - metatag
     - options
-    - text
     - user
 id: node.cgov_cthp.default
 targetEntityType: node
@@ -99,6 +99,13 @@ content:
     settings: {  }
     third_party_settings: {  }
     type: basic_string
+    region: content
+  field_meta_tags:
+    weight: 14
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: metatag_empty_formatter
     region: content
   field_page_description:
     weight: 5

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/core.entity_view_display.node.cgov_cthp.embedded_feature_card.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/core.entity_view_display.node.cgov_cthp.embedded_feature_card.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.node.cgov_cthp.field_feature_card_description
     - field.field.node.cgov_cthp.field_image_promotional
     - field.field.node.cgov_cthp.field_list_description
+    - field.field.node.cgov_cthp.field_meta_tags
     - field.field.node.cgov_cthp.field_page_description
     - field.field.node.cgov_cthp.field_pretty_url
     - field.field.node.cgov_cthp.field_search_engine_restrictions
@@ -18,8 +19,6 @@ dependencies:
     - field.field.node.cgov_cthp.field_site_section
     - node.type.cgov_cthp
   module:
-    - cgov_core
-    - options
     - user
 id: node.cgov_cthp.embedded_feature_card
 targetEntityType: node
@@ -66,6 +65,7 @@ hidden:
   field_browser_title: true
   field_cthp_cards: true
   field_list_description: true
+  field_meta_tags: true
   field_page_description: true
   field_pretty_url: true
   field_search_engine_restrictions: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/core.entity_view_display.node.cgov_cthp.embedded_feature_card_no_image.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/core.entity_view_display.node.cgov_cthp.embedded_feature_card_no_image.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.node.cgov_cthp.field_feature_card_description
     - field.field.node.cgov_cthp.field_image_promotional
     - field.field.node.cgov_cthp.field_list_description
+    - field.field.node.cgov_cthp.field_meta_tags
     - field.field.node.cgov_cthp.field_page_description
     - field.field.node.cgov_cthp.field_pretty_url
     - field.field.node.cgov_cthp.field_search_engine_restrictions
@@ -18,8 +19,6 @@ dependencies:
     - field.field.node.cgov_cthp.field_site_section
     - node.type.cgov_cthp
   module:
-    - cgov_core
-    - options
     - user
 id: node.cgov_cthp.embedded_feature_card_no_image
 targetEntityType: node
@@ -58,6 +57,7 @@ hidden:
   field_cthp_cards: true
   field_image_promotional: true
   field_list_description: true
+  field_meta_tags: true
   field_page_description: true
   field_pretty_url: true
   field_search_engine_restrictions: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/core.entity_view_display.node.cgov_cthp.feature_card_image.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/core.entity_view_display.node.cgov_cthp.feature_card_image.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.node.cgov_cthp.field_feature_card_description
     - field.field.node.cgov_cthp.field_image_promotional
     - field.field.node.cgov_cthp.field_list_description
+    - field.field.node.cgov_cthp.field_meta_tags
     - field.field.node.cgov_cthp.field_page_description
     - field.field.node.cgov_cthp.field_pretty_url
     - field.field.node.cgov_cthp.field_search_engine_restrictions
@@ -18,8 +19,6 @@ dependencies:
     - field.field.node.cgov_cthp.field_site_section
     - node.type.cgov_cthp
   module:
-    - cgov_core
-    - options
     - user
 id: node.cgov_cthp.feature_card_image
 targetEntityType: node
@@ -53,6 +52,7 @@ hidden:
   field_cthp_cards: true
   field_feature_card_description: true
   field_list_description: true
+  field_meta_tags: true
   field_page_description: true
   field_pretty_url: true
   field_search_engine_restrictions: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/core.entity_view_display.node.cgov_cthp.full.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/core.entity_view_display.node.cgov_cthp.full.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.node.cgov_cthp.field_feature_card_description
     - field.field.node.cgov_cthp.field_image_promotional
     - field.field.node.cgov_cthp.field_list_description
+    - field.field.node.cgov_cthp.field_meta_tags
     - field.field.node.cgov_cthp.field_page_description
     - field.field.node.cgov_cthp.field_pretty_url
     - field.field.node.cgov_cthp.field_search_engine_restrictions
@@ -18,10 +19,8 @@ dependencies:
     - field.field.node.cgov_cthp.field_site_section
     - node.type.cgov_cthp
   module:
-    - cgov_core
     - entity_reference_revisions
     - options
-    - text
     - user
 id: node.cgov_cthp.full
 targetEntityType: node
@@ -120,6 +119,7 @@ content:
     settings: {  }
     third_party_settings: {  }
 hidden:
+  field_meta_tags: true
   field_pretty_url: true
   field_search_engine_restrictions: true
   field_site_section: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/core.entity_view_display.node.cgov_cthp.link.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/core.entity_view_display.node.cgov_cthp.link.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.node.cgov_cthp.field_feature_card_description
     - field.field.node.cgov_cthp.field_image_promotional
     - field.field.node.cgov_cthp.field_list_description
+    - field.field.node.cgov_cthp.field_meta_tags
     - field.field.node.cgov_cthp.field_page_description
     - field.field.node.cgov_cthp.field_pretty_url
     - field.field.node.cgov_cthp.field_search_engine_restrictions
@@ -59,6 +60,7 @@ hidden:
   field_cthp_cards: true
   field_feature_card_description: true
   field_image_promotional: true
+  field_meta_tags: true
   field_pretty_url: true
   field_search_engine_restrictions: true
   field_site_section: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/core.entity_view_display.node.cgov_cthp.panoramic_image.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/core.entity_view_display.node.cgov_cthp.panoramic_image.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.node.cgov_cthp.field_feature_card_description
     - field.field.node.cgov_cthp.field_image_promotional
     - field.field.node.cgov_cthp.field_list_description
+    - field.field.node.cgov_cthp.field_meta_tags
     - field.field.node.cgov_cthp.field_page_description
     - field.field.node.cgov_cthp.field_pretty_url
     - field.field.node.cgov_cthp.field_search_engine_restrictions
@@ -18,8 +19,6 @@ dependencies:
     - field.field.node.cgov_cthp.field_site_section
     - node.type.cgov_cthp
   module:
-    - cgov_core
-    - options
     - user
 id: node.cgov_cthp.panoramic_image
 targetEntityType: node
@@ -44,6 +43,7 @@ hidden:
   field_cthp_cards: true
   field_feature_card_description: true
   field_list_description: true
+  field_meta_tags: true
   field_page_description: true
   field_pretty_url: true
   field_search_engine_restrictions: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/core.entity_view_display.node.cgov_cthp.teaser.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/core.entity_view_display.node.cgov_cthp.teaser.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.node.cgov_cthp.field_feature_card_description
     - field.field.node.cgov_cthp.field_image_promotional
     - field.field.node.cgov_cthp.field_list_description
+    - field.field.node.cgov_cthp.field_meta_tags
     - field.field.node.cgov_cthp.field_page_description
     - field.field.node.cgov_cthp.field_pretty_url
     - field.field.node.cgov_cthp.field_search_engine_restrictions
@@ -39,6 +40,7 @@ hidden:
   field_feature_card_description: true
   field_image_promotional: true
   field_list_description: true
+  field_meta_tags: true
   field_page_description: true
   field_pretty_url: true
   field_search_engine_restrictions: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/core.entity_view_display.node.cgov_cthp.thumbnail_card_image.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/core.entity_view_display.node.cgov_cthp.thumbnail_card_image.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.node.cgov_cthp.field_feature_card_description
     - field.field.node.cgov_cthp.field_image_promotional
     - field.field.node.cgov_cthp.field_list_description
+    - field.field.node.cgov_cthp.field_meta_tags
     - field.field.node.cgov_cthp.field_page_description
     - field.field.node.cgov_cthp.field_pretty_url
     - field.field.node.cgov_cthp.field_search_engine_restrictions
@@ -33,15 +34,6 @@ content:
       view_mode: image_crop_thumbnail
       link: false
     third_party_settings: {  }
-  field_image_promotional:
-    type: entity_reference_entity_view
-    weight: 1
-    region: content
-    label: hidden
-    settings:
-      view_mode: image_crop_thumbnail
-      link: false
-    third_party_settings: {  }
 hidden:
   content_moderation_control: true
   field_audience: true
@@ -51,6 +43,7 @@ hidden:
   field_cthp_cards: true
   field_feature_card_description: true
   field_list_description: true
+  field_meta_tags: true
   field_page_description: true
   field_pretty_url: true
   field_search_engine_restrictions: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/field.field.node.cgov_cthp.field_meta_tags.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/field.field.node.cgov_cthp.field_meta_tags.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_meta_tags
+    - node.type.cgov_cthp
+  module:
+    - metatag
+id: node.cgov_cthp.field_meta_tags
+field_name: field_meta_tags
+entity_type: node
+bundle: cgov_cthp
+label: 'Meta Tags'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: metatag

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/metatag.metatag_defaults.node__cgov_cthp.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/metatag.metatag_defaults.node__cgov_cthp.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+id: node__cgov_cthp
+label: 'Content: Cancer Type Homepage'
+tags:
+  dcterms_type: cgvCancerTypeHome

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_event/config/install/field.field.node.cgov_event.field_meta_tags.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_event/config/install/field.field.node.cgov_event.field_meta_tags.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_meta_tags
+    - node.type.cgov_event
+  module:
+    - metatag
+id: node.cgov_event.field_meta_tags
+field_name: field_meta_tags
+entity_type: node
+bundle: cgov_event
+label: 'Meta Tags'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: metatag

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_event/config/install/metatag.metatag_defaults.node__cgov_event.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_event/config/install/metatag.metatag_defaults.node__cgov_event.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+id: node__cgov_event
+label: 'Content: Event'
+tags:
+  dcterms_type: cgvEvent

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/config/install/field.field.node.cgov_home_landing.field_meta_tags.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/config/install/field.field.node.cgov_home_landing.field_meta_tags.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_meta_tags
+    - node.type.cgov_home_landing
+  module:
+    - metatag
+id: node.cgov_home_landing.field_meta_tags
+field_name: field_meta_tags
+entity_type: node
+bundle: cgov_home_landing
+label: 'Meta Tags'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: metatag

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/config/install/field.field.node.cgov_mini_landing.field_meta_tags.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/config/install/field.field.node.cgov_mini_landing.field_meta_tags.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_meta_tags
+    - node.type.cgov_mini_landing
+  module:
+    - metatag
+id: node.cgov_mini_landing.field_meta_tags
+field_name: field_meta_tags
+entity_type: node
+bundle: cgov_mini_landing
+label: 'Meta Tags'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: metatag

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/config/install/metatag.metatag_defaults.node__cgov_home_landing.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/config/install/metatag.metatag_defaults.node__cgov_home_landing.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+id: node__cgov_home_landing
+label: 'Content: Home and Landing'
+tags:
+  dcterms_type: cgvHomeLanding

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/config/install/metatag.metatag_defaults.node__cgov_mini_landing.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/config/install/metatag.metatag_defaults.node__cgov_mini_landing.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+id: node__cgov_mini_landing
+label: 'Content: Mini Landing Page'
+tags:
+  dcterms_type: cgvMiniLanding

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_image/tests/src/Kernel/CgovImageFieldStorageTest.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_image/tests/src/Kernel/CgovImageFieldStorageTest.php
@@ -7,6 +7,7 @@ use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\node\Entity\NodeType;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\node\NodeTypeInterface;
+use CgovPlatform\Tests\CgovSchemaExclusions;
 
 /**
  * Base class which does most of the work for field storage tests.
@@ -23,7 +24,7 @@ class CgovImageFieldStorageTest extends KernelTestBase {
     'crop', 'image_widget_crop', 'workflows', 'content_moderation', 'entity_browser', 'embed',
     'entity_embed', 'paragraphs', 'taxonomy', 'language', 'content_translation', 'media',
     'image', 'views', 'cgov_media', 'cgov_image', 'block_content', 'paragraphs',
-    'entity_reference_revisions',
+    'entity_reference_revisions', 'metatag',
   ];
 
   /**
@@ -74,6 +75,7 @@ class CgovImageFieldStorageTest extends KernelTestBase {
    * Sets up the test environment.
    */
   protected function setUp() {
+    static::$configSchemaCheckerExclusions = CgovSchemaExclusions::$configSchemaCheckerExclusions;
     parent::setUp();
     $this->installSchema('system', 'sequences');
     // Necessary for module uninstall.

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_infographic/config/install/core.entity_form_display.media.cgov_infographic.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_infographic/config/install/core.entity_form_display.media.cgov_infographic.default.yml
@@ -2,6 +2,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - entity_browser.browser.cgov_site_section_browser
     - field.field.media.cgov_infographic.body
     - field.field.media.cgov_infographic.field_accessible_version
     - field.field.media.cgov_infographic.field_browser_title
@@ -15,6 +16,7 @@ dependencies:
     - field.field.media.cgov_infographic.field_infographic
     - field.field.media.cgov_infographic.field_list_description
     - field.field.media.cgov_infographic.field_meta_description
+    - field.field.media.cgov_infographic.field_meta_tags
     - field.field.media.cgov_infographic.field_pretty_url
     - field.field.media.cgov_infographic.field_public_use
     - field.field.media.cgov_infographic.field_search_engine_restrictions
@@ -28,7 +30,6 @@ dependencies:
     - datetime
     - entity_browser
     - image
-    - path
     - text
 id: media.cgov_infographic.default
 targetEntityType: media
@@ -93,12 +94,12 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_feature_card_description:
-    type: string_textarea
+    type: string_textfield
     weight: 9
     region: content
     settings:
-      rows: 5
       placeholder: ''
+      size: 60
     third_party_settings: {  }
   field_image_promotional:
     type: entity_browser_entity_reference
@@ -190,7 +191,7 @@ content:
     third_party_settings: {  }
   moderation_state:
     type: moderation_state_default
-    weight: 25
+    weight: 22
     settings: {  }
     region: content
     third_party_settings: {  }
@@ -206,15 +207,16 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 24
+    weight: 21
     region: content
     third_party_settings: {  }
   translation:
-    weight: 23
+    weight: 20
     region: content
     settings: {  }
     third_party_settings: {  }
 hidden:
   created: true
+  field_meta_tags: true
   path: true
   uid: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_infographic/config/install/core.entity_view_display.media.cgov_infographic.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_infographic/config/install/core.entity_view_display.media.cgov_infographic.default.yml
@@ -15,6 +15,7 @@ dependencies:
     - field.field.media.cgov_infographic.field_infographic
     - field.field.media.cgov_infographic.field_list_description
     - field.field.media.cgov_infographic.field_meta_description
+    - field.field.media.cgov_infographic.field_meta_tags
     - field.field.media.cgov_infographic.field_pretty_url
     - field.field.media.cgov_infographic.field_public_use
     - field.field.media.cgov_infographic.field_search_engine_restrictions
@@ -24,6 +25,7 @@ dependencies:
     - media.type.cgov_infographic
   module:
     - image
+    - metatag
     - user
 id: media.cgov_infographic.default
 targetEntityType: media
@@ -53,6 +55,13 @@ content:
       image_link: ''
     third_party_settings: {  }
     type: image
+    region: content
+  field_meta_tags:
+    weight: 7
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: metatag_empty_formatter
     region: content
   thumbnail:
     type: image

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_infographic/config/install/core.entity_view_display.media.cgov_infographic.full.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_infographic/config/install/core.entity_view_display.media.cgov_infographic.full.yml
@@ -16,6 +16,7 @@ dependencies:
     - field.field.media.cgov_infographic.field_infographic
     - field.field.media.cgov_infographic.field_list_description
     - field.field.media.cgov_infographic.field_meta_description
+    - field.field.media.cgov_infographic.field_meta_tags
     - field.field.media.cgov_infographic.field_pretty_url
     - field.field.media.cgov_infographic.field_public_use
     - field.field.media.cgov_infographic.field_search_engine_restrictions
@@ -132,6 +133,7 @@ hidden:
   field_image_promotional: true
   field_list_description: true
   field_meta_description: true
+  field_meta_tags: true
   field_pretty_url: true
   field_public_use: true
   field_search_engine_restrictions: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_infographic/config/install/core.entity_view_display.media.cgov_infographic.infographic_display_article_large.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_infographic/config/install/core.entity_view_display.media.cgov_infographic.infographic_display_article_large.yml
@@ -16,6 +16,7 @@ dependencies:
     - field.field.media.cgov_infographic.field_infographic
     - field.field.media.cgov_infographic.field_list_description
     - field.field.media.cgov_infographic.field_meta_description
+    - field.field.media.cgov_infographic.field_meta_tags
     - field.field.media.cgov_infographic.field_pretty_url
     - field.field.media.cgov_infographic.field_public_use
     - field.field.media.cgov_infographic.field_search_engine_restrictions
@@ -51,6 +52,7 @@ hidden:
   field_infographic: true
   field_list_description: true
   field_meta_description: true
+  field_meta_tags: true
   field_pretty_url: true
   field_public_use: true
   field_search_engine_restrictions: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_infographic/config/install/core.entity_view_display.media.cgov_infographic.infographic_display_article_medium.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_infographic/config/install/core.entity_view_display.media.cgov_infographic.infographic_display_article_medium.yml
@@ -16,6 +16,7 @@ dependencies:
     - field.field.media.cgov_infographic.field_infographic
     - field.field.media.cgov_infographic.field_list_description
     - field.field.media.cgov_infographic.field_meta_description
+    - field.field.media.cgov_infographic.field_meta_tags
     - field.field.media.cgov_infographic.field_pretty_url
     - field.field.media.cgov_infographic.field_public_use
     - field.field.media.cgov_infographic.field_search_engine_restrictions
@@ -51,6 +52,7 @@ hidden:
   field_infographic: true
   field_list_description: true
   field_meta_description: true
+  field_meta_tags: true
   field_pretty_url: true
   field_public_use: true
   field_search_engine_restrictions: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_infographic/config/install/core.entity_view_display.media.cgov_infographic.multimedia_card.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_infographic/config/install/core.entity_view_display.media.cgov_infographic.multimedia_card.yml
@@ -16,6 +16,7 @@ dependencies:
     - field.field.media.cgov_infographic.field_infographic
     - field.field.media.cgov_infographic.field_list_description
     - field.field.media.cgov_infographic.field_meta_description
+    - field.field.media.cgov_infographic.field_meta_tags
     - field.field.media.cgov_infographic.field_pretty_url
     - field.field.media.cgov_infographic.field_public_use
     - field.field.media.cgov_infographic.field_search_engine_restrictions
@@ -73,6 +74,7 @@ hidden:
   field_infographic: true
   field_list_description: true
   field_meta_description: true
+  field_meta_tags: true
   field_pretty_url: true
   field_public_use: true
   field_search_engine_restrictions: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_infographic/config/install/field.field.media.cgov_infographic.field_meta_tags.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_infographic/config/install/field.field.media.cgov_infographic.field_meta_tags.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_meta_tags
+    - media.type.cgov_infographic
+  module:
+    - metatag
+id: media.cgov_infographic.field_meta_tags
+field_name: field_meta_tags
+entity_type: media
+bundle: cgov_infographic
+label: 'Meta Tags'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: metatag

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_infographic/config/install/metatag.metatag_defaults.media__cgov_infographic.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_infographic/config/install/metatag.metatag_defaults.media__cgov_infographic.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+id: media__cgov_infographic
+label: 'Media: Infographic'
+tags:
+  dcterms_type: cgvInfographic

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_media/config/install/field.storage.media.field_meta_tags.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_media/config/install/field.storage.media.field_meta_tags.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+    - metatag
+id: media.field_meta_tags
+field_name: field_meta_tags
+entity_type: media
+type: metatag
+settings: {  }
+module: metatag
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_media/tests/src/Kernel/CgovMediaFieldStorageTest.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_media/tests/src/Kernel/CgovMediaFieldStorageTest.php
@@ -7,6 +7,7 @@ use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\media\Entity\MediaType;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\media\MediaTypeInterface;
+use CgovPlatform\Tests\CgovSchemaExclusions;
 
 /**
  * Base class which does most of the work for field storage tests.
@@ -23,7 +24,7 @@ class CgovMediaFieldStorageTest extends KernelTestBase {
     'datetime', 'options', 'workflows', 'content_moderation', 'language',
     'content_translation', 'media_test_source', 'cgov_media', 'taxonomy',
     'views', 'entity_browser', 'pathauto', 'token', 'ctools', 'paragraphs',
-    'entity_reference_revisions',
+    'entity_reference_revisions', 'metatag',
   ];
 
   /**
@@ -48,6 +49,7 @@ class CgovMediaFieldStorageTest extends KernelTestBase {
    * Sets up the test environment.
    */
   protected function setUp() {
+    static::$configSchemaCheckerExclusions = CgovSchemaExclusions::$configSchemaCheckerExclusions;
     parent::setUp();
     $this->installSchema('system', 'sequences');
     // Necessary for module uninstall.
@@ -62,7 +64,7 @@ class CgovMediaFieldStorageTest extends KernelTestBase {
     $this->installConfig([
       'field', 'media', 'file', 'language', 'content_translation',
       'views', 'entity_browser', 'media_test_source', 'cgov_media', 'pathauto',
-      'paragraphs', 'entity_reference_revisions',
+      'paragraphs', 'entity_reference_revisions', 'metatag',
     ]);
   }
 

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_metatag/cgov_metatag.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_metatag/cgov_metatag.info.yml
@@ -1,0 +1,6 @@
+name: 'Cgov Metatag'
+type: module
+description: 'Cancer.gov Metatag module.'
+package: 'CGov Digital Platform'
+core: 8.x
+hidden: false

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_metatag/cgov_metatag.module
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_metatag/cgov_metatag.module
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * @file
+ * The cgov_metata.module.
+ */
+
+/**
+ * Implements hook_entity_presave().
+ *
+ * Prior to saving a node, updates per node metatag values.
+ */
+function cgov_metatag_entity_presave($entity) {
+  $entityType = $entity->getEntityType()->id();
+  if ($entityType == 'node'|| $entityType == 'media') {
+    if ($entity->hasField('field_search_engine_restrictions') && $entity->hasField('field_meta_tags')) {
+
+      $restriction = $entity->get('field_search_engine_restrictions')->getValue();
+
+      if ($restriction[0]['value'] == 'IncludeSearch') {
+        // e.g 'robots' => 'noindex, nofollow, noarchive, nosnippet, noodp'.
+        $entity->set('field_meta_tags', serialize([
+          'robots' => 'index',
+        ]));
+      }
+      elseif ($restriction[0]['value'] == 'ExcludeSearch') {
+        $entity->set('field_meta_tags', serialize([
+          'robots' => 'noindex',
+        ]));
+      }
+    }
+  }
+}

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_metatag/cgov_metatag.tokens.inc
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_metatag/cgov_metatag.tokens.inc
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * @file
+ * Cgov metatag tokens.
+ */
+
+/**
+ * Implements hook_token_info().
+ */
+function cgov_metatag_token_info() {
+  $info = [];
+  $info['types']['cgov_tokens'] = ['name' => t('Cancer.gov Tokens'), 'description' => t('Cancer.gov Tokens')];
+
+  $info['tokens']['cgov_tokens']['cgov-title'] =
+    [
+      'name' => t('Cgov Title Meta Tag'),
+      'description' => t('The value to user for the title meta tag.'),
+    ];
+
+  return $info;
+}
+
+/**
+ * Implements hook_tokens().
+ */
+function cgov_metatag_tokens($type, $tokens, array $data, array $options, $bubbleable_metadata) {
+  $replacements = [];
+  if ($type == 'cgov_tokens') {
+    foreach ($tokens as $name => $original) {
+      switch ($name) {
+        case 'cgov-title':
+          $replacements[$original] = get_meta_title_token($data);
+          break;
+      }
+    }
+  }
+  return $replacements;
+}
+
+/**
+ * Retrieves the desired metatag title.
+ */
+function get_meta_title_token(array $data) {
+
+  if (!empty($data['node'])) {
+    $entity = $data['node'];
+  }
+  elseif (!empty($data['media'])) {
+    $entity = $data['media'];
+  }
+
+  $titleToken = "";
+  if (!empty($entity)) {
+    /* @var \Drupal\node\NodeInterface $node */
+
+    if ($entity->hasField('field_browser_title') && !$entity->get('field_browser_title')->isEmpty()) {
+      $titleToken = $entity->get('field_browser_title')->getValue()[0]['value'];
+    }
+    elseif ($entity->hasField('field_short_title') && !$entity->get('field_short_title')->isEmpty()) {
+      $titleToken = $entity->get('field_short_title')->getValue()[0]['value'];
+    }
+  }
+  return $titleToken;
+}

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/field.field.node.cgov_press_release.field_meta_tags.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/field.field.node.cgov_press_release.field_meta_tags.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_meta_tags
+    - node.type.cgov_press_release
+  module:
+    - metatag
+id: node.cgov_press_release.field_meta_tags
+field_name: field_meta_tags
+entity_type: node
+bundle: cgov_press_release
+label: 'Meta Tags'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: metatag

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/metatag.metatag_defaults.node__cgov_press_release.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/metatag.metatag_defaults.node__cgov_press_release.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+id: node__cgov_press_release
+label: 'Content: Press Release'
+tags:
+  dcterms_type: cgvPressRelease

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/core.entity_form_display.media.cgov_video.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/core.entity_form_display.media.cgov_video.default.yml
@@ -15,13 +15,14 @@ dependencies:
     - field.field.media.cgov_video.field_list_description
     - field.field.media.cgov_video.field_media_oembed_video
     - field.field.media.cgov_video.field_meta_description
+    - field.field.media.cgov_video.field_meta_tags
     - field.field.media.cgov_video.field_pretty_url
     - field.field.media.cgov_video.field_related_resources
     - field.field.media.cgov_video.field_search_engine_restrictions
     - field.field.media.cgov_video.field_short_title
     - field.field.media.cgov_video.field_site_section
     - media.type.cgov_video
-    - workflows.workflow.editorial_workflow
+    - workflows.workflow.image_workflow
   module:
     - content_moderation
     - datetime
@@ -226,4 +227,5 @@ content:
       placeholder: ''
     region: content
     third_party_settings: {  }
-hidden: {  }
+hidden:
+  field_meta_tags: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/core.entity_view_display.media.cgov_video.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/core.entity_view_display.media.cgov_video.default.yml
@@ -14,6 +14,7 @@ dependencies:
     - field.field.media.cgov_video.field_list_description
     - field.field.media.cgov_video.field_media_oembed_video
     - field.field.media.cgov_video.field_meta_description
+    - field.field.media.cgov_video.field_meta_tags
     - field.field.media.cgov_video.field_pretty_url
     - field.field.media.cgov_video.field_related_resources
     - field.field.media.cgov_video.field_search_engine_restrictions
@@ -24,6 +25,7 @@ dependencies:
     - cgov_core
     - image
     - media
+    - metatag
     - options
     - text
     - user
@@ -144,6 +146,13 @@ content:
       link_to_entity: false
     third_party_settings: {  }
     type: string
+    region: content
+  field_meta_tags:
+    weight: 25
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: metatag_empty_formatter
     region: content
   field_pretty_url:
     weight: 12

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/core.entity_view_display.media.cgov_video.entity_browser_selected_entity.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/core.entity_view_display.media.cgov_video.entity_browser_selected_entity.yml
@@ -14,7 +14,11 @@ dependencies:
     - field.field.media.cgov_video.field_feature_card_description
     - field.field.media.cgov_video.field_list_description
     - field.field.media.cgov_video.field_media_oembed_video
+    - field.field.media.cgov_video.field_meta_description
+    - field.field.media.cgov_video.field_meta_tags
     - field.field.media.cgov_video.field_pretty_url
+    - field.field.media.cgov_video.field_related_resources
+    - field.field.media.cgov_video.field_search_engine_restrictions
     - field.field.media.cgov_video.field_short_title
     - field.field.media.cgov_video.field_site_section
     - image.style.thumbnail
@@ -64,7 +68,11 @@ hidden:
   field_date_updated: true
   field_feature_card_description: true
   field_list_description: true
+  field_meta_description: true
+  field_meta_tags: true
   field_pretty_url: true
+  field_related_resources: true
+  field_search_engine_restrictions: true
   field_short_title: true
   field_site_section: true
   langcode: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/core.entity_view_display.media.cgov_video.full.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/core.entity_view_display.media.cgov_video.full.yml
@@ -14,7 +14,11 @@ dependencies:
     - field.field.media.cgov_video.field_feature_card_description
     - field.field.media.cgov_video.field_list_description
     - field.field.media.cgov_video.field_media_oembed_video
+    - field.field.media.cgov_video.field_meta_description
+    - field.field.media.cgov_video.field_meta_tags
     - field.field.media.cgov_video.field_pretty_url
+    - field.field.media.cgov_video.field_related_resources
+    - field.field.media.cgov_video.field_search_engine_restrictions
     - field.field.media.cgov_video.field_short_title
     - field.field.media.cgov_video.field_site_section
     - media.type.cgov_video
@@ -29,17 +33,17 @@ targetEntityType: media
 bundle: cgov_video
 mode: full
 content:
-  content_moderation_control:
-    weight: -20
-    settings: {  }
-    third_party_settings: {  }
-    region: content
   body:
     weight: 3
     label: hidden
     settings: {  }
     third_party_settings: {  }
     type: text_default
+    region: content
+  content_moderation_control:
+    weight: -20
+    settings: {  }
+    third_party_settings: {  }
     region: content
   field_caption:
     weight: 2
@@ -109,7 +113,11 @@ hidden:
   field_card_title: true
   field_feature_card_description: true
   field_list_description: true
+  field_meta_description: true
+  field_meta_tags: true
   field_pretty_url: true
+  field_related_resources: true
+  field_search_engine_restrictions: true
   field_short_title: true
   field_site_section: true
   langcode: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/core.entity_view_display.media.cgov_video.image_reference_field_form.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/core.entity_view_display.media.cgov_video.image_reference_field_form.yml
@@ -14,7 +14,11 @@ dependencies:
     - field.field.media.cgov_video.field_feature_card_description
     - field.field.media.cgov_video.field_list_description
     - field.field.media.cgov_video.field_media_oembed_video
+    - field.field.media.cgov_video.field_meta_description
+    - field.field.media.cgov_video.field_meta_tags
     - field.field.media.cgov_video.field_pretty_url
+    - field.field.media.cgov_video.field_related_resources
+    - field.field.media.cgov_video.field_search_engine_restrictions
     - field.field.media.cgov_video.field_short_title
     - field.field.media.cgov_video.field_site_section
     - media.type.cgov_video
@@ -176,5 +180,9 @@ content:
     settings: {  }
     third_party_settings: {  }
 hidden:
+  field_meta_description: true
+  field_meta_tags: true
+  field_related_resources: true
+  field_search_engine_restrictions: true
   langcode: true
   name: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/core.entity_view_display.media.cgov_video.multimedia_card.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/core.entity_view_display.media.cgov_video.multimedia_card.yml
@@ -14,7 +14,11 @@ dependencies:
     - field.field.media.cgov_video.field_feature_card_description
     - field.field.media.cgov_video.field_list_description
     - field.field.media.cgov_video.field_media_oembed_video
+    - field.field.media.cgov_video.field_meta_description
+    - field.field.media.cgov_video.field_meta_tags
     - field.field.media.cgov_video.field_pretty_url
+    - field.field.media.cgov_video.field_related_resources
+    - field.field.media.cgov_video.field_search_engine_restrictions
     - field.field.media.cgov_video.field_short_title
     - field.field.media.cgov_video.field_site_section
     - media.type.cgov_video
@@ -176,5 +180,9 @@ content:
     settings: {  }
     third_party_settings: {  }
 hidden:
+  field_meta_description: true
+  field_meta_tags: true
+  field_related_resources: true
+  field_search_engine_restrictions: true
   langcode: true
   name: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/core.entity_view_display.media.cgov_video.video_display_cthp_multimedia.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/core.entity_view_display.media.cgov_video.video_display_cthp_multimedia.yml
@@ -14,7 +14,11 @@ dependencies:
     - field.field.media.cgov_video.field_feature_card_description
     - field.field.media.cgov_video.field_list_description
     - field.field.media.cgov_video.field_media_oembed_video
+    - field.field.media.cgov_video.field_meta_description
+    - field.field.media.cgov_video.field_meta_tags
     - field.field.media.cgov_video.field_pretty_url
+    - field.field.media.cgov_video.field_related_resources
+    - field.field.media.cgov_video.field_search_engine_restrictions
     - field.field.media.cgov_video.field_short_title
     - field.field.media.cgov_video.field_site_section
     - media.type.cgov_video
@@ -58,8 +62,8 @@ content:
     region: content
     third_party_settings: {  }
 hidden:
-  created: true
   body: true
+  created: true
   field_browser_title: true
   field_card_title: true
   field_date_display_mode: true
@@ -68,7 +72,11 @@ hidden:
   field_date_updated: true
   field_feature_card_description: true
   field_list_description: true
+  field_meta_description: true
+  field_meta_tags: true
   field_pretty_url: true
+  field_related_resources: true
+  field_search_engine_restrictions: true
   field_short_title: true
   field_site_section: true
   langcode: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/core.entity_view_display.media.cgov_video.video_display_large_no_title.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/core.entity_view_display.media.cgov_video.video_display_large_no_title.yml
@@ -14,7 +14,11 @@ dependencies:
     - field.field.media.cgov_video.field_feature_card_description
     - field.field.media.cgov_video.field_list_description
     - field.field.media.cgov_video.field_media_oembed_video
+    - field.field.media.cgov_video.field_meta_description
+    - field.field.media.cgov_video.field_meta_tags
     - field.field.media.cgov_video.field_pretty_url
+    - field.field.media.cgov_video.field_related_resources
+    - field.field.media.cgov_video.field_search_engine_restrictions
     - field.field.media.cgov_video.field_short_title
     - field.field.media.cgov_video.field_site_section
     - media.type.cgov_video
@@ -58,8 +62,8 @@ content:
     region: content
     third_party_settings: {  }
 hidden:
-  created: true
   body: true
+  created: true
   field_browser_title: true
   field_card_title: true
   field_date_display_mode: true
@@ -68,7 +72,11 @@ hidden:
   field_date_updated: true
   field_feature_card_description: true
   field_list_description: true
+  field_meta_description: true
+  field_meta_tags: true
   field_pretty_url: true
+  field_related_resources: true
+  field_search_engine_restrictions: true
   field_short_title: true
   field_site_section: true
   langcode: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/core.entity_view_display.media.cgov_video.video_display_large_title.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/core.entity_view_display.media.cgov_video.video_display_large_title.yml
@@ -14,7 +14,11 @@ dependencies:
     - field.field.media.cgov_video.field_feature_card_description
     - field.field.media.cgov_video.field_list_description
     - field.field.media.cgov_video.field_media_oembed_video
+    - field.field.media.cgov_video.field_meta_description
+    - field.field.media.cgov_video.field_meta_tags
     - field.field.media.cgov_video.field_pretty_url
+    - field.field.media.cgov_video.field_related_resources
+    - field.field.media.cgov_video.field_search_engine_restrictions
     - field.field.media.cgov_video.field_short_title
     - field.field.media.cgov_video.field_site_section
     - media.type.cgov_video
@@ -66,8 +70,8 @@ content:
     region: content
     third_party_settings: {  }
 hidden:
-  created: true
   body: true
+  created: true
   field_browser_title: true
   field_card_title: true
   field_date_display_mode: true
@@ -76,7 +80,11 @@ hidden:
   field_date_updated: true
   field_feature_card_description: true
   field_list_description: true
+  field_meta_description: true
+  field_meta_tags: true
   field_pretty_url: true
+  field_related_resources: true
+  field_search_engine_restrictions: true
   field_short_title: true
   field_site_section: true
   langcode: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/core.entity_view_display.media.cgov_video.video_display_medium_no_title.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/core.entity_view_display.media.cgov_video.video_display_medium_no_title.yml
@@ -14,7 +14,11 @@ dependencies:
     - field.field.media.cgov_video.field_feature_card_description
     - field.field.media.cgov_video.field_list_description
     - field.field.media.cgov_video.field_media_oembed_video
+    - field.field.media.cgov_video.field_meta_description
+    - field.field.media.cgov_video.field_meta_tags
     - field.field.media.cgov_video.field_pretty_url
+    - field.field.media.cgov_video.field_related_resources
+    - field.field.media.cgov_video.field_search_engine_restrictions
     - field.field.media.cgov_video.field_short_title
     - field.field.media.cgov_video.field_site_section
     - media.type.cgov_video
@@ -58,8 +62,8 @@ content:
     region: content
     third_party_settings: {  }
 hidden:
-  created: true
   body: true
+  created: true
   field_browser_title: true
   field_card_title: true
   field_date_display_mode: true
@@ -68,7 +72,11 @@ hidden:
   field_date_updated: true
   field_feature_card_description: true
   field_list_description: true
+  field_meta_description: true
+  field_meta_tags: true
   field_pretty_url: true
+  field_related_resources: true
+  field_search_engine_restrictions: true
   field_short_title: true
   field_site_section: true
   langcode: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/core.entity_view_display.media.cgov_video.video_display_medium_title.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/core.entity_view_display.media.cgov_video.video_display_medium_title.yml
@@ -14,7 +14,11 @@ dependencies:
     - field.field.media.cgov_video.field_feature_card_description
     - field.field.media.cgov_video.field_list_description
     - field.field.media.cgov_video.field_media_oembed_video
+    - field.field.media.cgov_video.field_meta_description
+    - field.field.media.cgov_video.field_meta_tags
     - field.field.media.cgov_video.field_pretty_url
+    - field.field.media.cgov_video.field_related_resources
+    - field.field.media.cgov_video.field_search_engine_restrictions
     - field.field.media.cgov_video.field_short_title
     - field.field.media.cgov_video.field_site_section
     - media.type.cgov_video
@@ -66,8 +70,8 @@ content:
     region: content
     third_party_settings: {  }
 hidden:
-  created: true
   body: true
+  created: true
   field_browser_title: true
   field_card_title: true
   field_date_display_mode: true
@@ -76,7 +80,11 @@ hidden:
   field_date_updated: true
   field_feature_card_description: true
   field_list_description: true
+  field_meta_description: true
+  field_meta_tags: true
   field_pretty_url: true
+  field_related_resources: true
+  field_search_engine_restrictions: true
   field_short_title: true
   field_site_section: true
   langcode: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/core.entity_view_display.media.cgov_video.video_display_small_no_title.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/core.entity_view_display.media.cgov_video.video_display_small_no_title.yml
@@ -14,7 +14,11 @@ dependencies:
     - field.field.media.cgov_video.field_feature_card_description
     - field.field.media.cgov_video.field_list_description
     - field.field.media.cgov_video.field_media_oembed_video
+    - field.field.media.cgov_video.field_meta_description
+    - field.field.media.cgov_video.field_meta_tags
     - field.field.media.cgov_video.field_pretty_url
+    - field.field.media.cgov_video.field_related_resources
+    - field.field.media.cgov_video.field_search_engine_restrictions
     - field.field.media.cgov_video.field_short_title
     - field.field.media.cgov_video.field_site_section
     - media.type.cgov_video
@@ -58,8 +62,8 @@ content:
     region: content
     third_party_settings: {  }
 hidden:
-  created: true
   body: true
+  created: true
   field_browser_title: true
   field_card_title: true
   field_date_display_mode: true
@@ -68,7 +72,11 @@ hidden:
   field_date_updated: true
   field_feature_card_description: true
   field_list_description: true
+  field_meta_description: true
+  field_meta_tags: true
   field_pretty_url: true
+  field_related_resources: true
+  field_search_engine_restrictions: true
   field_short_title: true
   field_site_section: true
   langcode: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/core.entity_view_display.media.cgov_video.video_display_small_title.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/core.entity_view_display.media.cgov_video.video_display_small_title.yml
@@ -14,7 +14,11 @@ dependencies:
     - field.field.media.cgov_video.field_feature_card_description
     - field.field.media.cgov_video.field_list_description
     - field.field.media.cgov_video.field_media_oembed_video
+    - field.field.media.cgov_video.field_meta_description
+    - field.field.media.cgov_video.field_meta_tags
     - field.field.media.cgov_video.field_pretty_url
+    - field.field.media.cgov_video.field_related_resources
+    - field.field.media.cgov_video.field_search_engine_restrictions
     - field.field.media.cgov_video.field_short_title
     - field.field.media.cgov_video.field_site_section
     - media.type.cgov_video
@@ -66,8 +70,8 @@ content:
     region: content
     third_party_settings: {  }
 hidden:
-  created: true
   body: true
+  created: true
   field_browser_title: true
   field_card_title: true
   field_date_display_mode: true
@@ -76,7 +80,11 @@ hidden:
   field_date_updated: true
   field_feature_card_description: true
   field_list_description: true
+  field_meta_description: true
+  field_meta_tags: true
   field_pretty_url: true
+  field_related_resources: true
+  field_search_engine_restrictions: true
   field_short_title: true
   field_site_section: true
   langcode: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/field.field.media.cgov_video.field_meta_tags.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/field.field.media.cgov_video.field_meta_tags.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.field_meta_tags
+    - media.type.cgov_video
+  module:
+    - metatag
+id: media.cgov_video.field_meta_tags
+field_name: field_meta_tags
+entity_type: media
+bundle: cgov_video
+label: 'Meta Tags'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: metatag

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/metatag.metatag_defaults.media__cgov_video.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/metatag.metatag_defaults.media__cgov_video.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+id: media__cgov_video
+label: 'Media: Video'
+tags:
+  dcterms_type: cgvVideo

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/metatag.metatag_defaults.node__cgov_video.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/metatag.metatag_defaults.node__cgov_video.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+id: node__cgov_video
+label: 'Content: Video'
+tags:
+  dcterms_type: cgvVideo

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/field.field.node.pdq_cancer_information_summary.field_meta_tags.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/field.field.node.pdq_cancer_information_summary.field_meta_tags.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_meta_tags
+    - node.type.pdq_cancer_information_summary
+  module:
+    - metatag
+id: node.pdq_cancer_information_summary.field_meta_tags
+field_name: field_meta_tags
+entity_type: node
+bundle: pdq_cancer_information_summary
+label: 'Meta Tags'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: metatag

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/metatag.metatag_defaults.node__pdq_cancer_information_summary.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/metatag.metatag_defaults.node__pdq_cancer_information_summary.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+id: node__pdq_cancer_information_summary
+label: 'Content: PDQ Cancer Information Summary'
+tags:
+  dcterms_type:

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_core/tests/src/Kernel/FieldStorage/PDQFieldStorageTest.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_core/tests/src/Kernel/FieldStorage/PDQFieldStorageTest.php
@@ -20,7 +20,7 @@ class PDQFieldStorageTest extends KernelTestBase {
    */
   public static $modules = [
     'user', 'system', 'file', 'field', 'image', 'node', 'text', 'filter', 'datetime', 'options', 'workflows', 'content_moderation',
-    'language', 'content_translation', 'pdq_core', 'paragraphs', 'rest', 'serialization',
+    'language', 'content_translation', 'pdq_core', 'paragraphs', 'rest', 'serialization', 'metatag',
   ];
 
   /**

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_core/tests/src/Kernel/WorkflowTest.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_core/tests/src/Kernel/WorkflowTest.php
@@ -53,6 +53,7 @@ class WorkflowTest extends KernelTestBase {
     'token',
     'token_filter',
     'editor',
+    'metatag',
   ];
 
   /**
@@ -100,6 +101,7 @@ class WorkflowTest extends KernelTestBase {
       'token',
       'token_filter',
       'editor',
+      'metatag',
     ]);
     $this->installSchema('system', ['sequences']);
     $this->installSchema('node', ['node_access']);

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_drug_information_summary/config/install/field.field.node.pdq_drug_information_summary.field_meta_tags.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_drug_information_summary/config/install/field.field.node.pdq_drug_information_summary.field_meta_tags.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_meta_tags
+    - node.type.pdq_drug_information_summary
+  module:
+    - metatag
+id: node.pdq_drug_information_summary.field_meta_tags
+field_name: field_meta_tags
+entity_type: node
+bundle: pdq_drug_information_summary
+label: 'Meta Tags'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: metatag


### PR DESCRIPTION
**Adds and enables the following modules:** 
- cgov_metatag

**Enables the following sub modules:**
  - metatag_dc
  - metatag_dc_advanced
  - metatag_open_graph
  - metatag_twitter_cards

**Adds the following config checker exclusions:**
   'metatag.metatag_defaults.global',
    'metatag.metatag_defaults.node',

**Closes #185 by adding the following**
- [ ] Browser Title element
- [ ] Meta Description
- [ ] Search Engine Restrictions Logic.  (Adds no index tag based on the node field value)
NOTE: The S.E logic will only work for content types that have added a field of type metatag. **This PR adds it for article only.** When added for the remaining types, this logic will automatically work for them also.

**Closes #197 OpenGraph Tabs by adding the following:**
- [ ]  og:title
- [ ] og:description
- [ ]  og:type
- [ ] og:url
- [ ] og:sitename
- [ ] twitter:card

**Closes #195 HREF TAG**
- [ ]  (This HREF Lang functionality has actually been in develop for a while and just needs to be verified.)

**Partially addressing** #196
- [ ] Add dcterms.type for Article
Note: Each content type will need to add a field of type 'metatag' and  it's related configuration in the module for the tag to appear .