### PR TITLE
Page options issues

### DIFF
--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Services/PageOptionsManager.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Services/PageOptionsManager.php
@@ -28,13 +28,6 @@ class PageOptionsManager implements PageOptionsManagerInterface {
    * @var array
    */
   private static $nodeOptions = [
-    'cgov_home_landing' => [
-      'print',
-      'email',
-      'facebook',
-      'twitter',
-      'pinterest',
-    ],
     'cgov_article' => [
       'resize',
       'print',
@@ -44,6 +37,7 @@ class PageOptionsManager implements PageOptionsManagerInterface {
       'pinterest',
     ],
     'cgov_cancer_center' => [
+      'resize',
       'print',
       'email',
       'facebook',
@@ -51,13 +45,7 @@ class PageOptionsManager implements PageOptionsManagerInterface {
       'pinterest',
     ],
     'cgov_biography' => [
-      'print',
-      'email',
-      'facebook',
-      'twitter',
-      'pinterest',
-    ],
-    'cgov_event' => [
+      'resize',
       'print',
       'email',
       'facebook',
@@ -73,9 +61,65 @@ class PageOptionsManager implements PageOptionsManagerInterface {
       'pinterest',
     ],
     'cgov_blog_series' => [
+      'print',
+      'email',
+      'facebook',
+      'twitter',
+      'pinterest',
+    ],
+    'cgov_cancer_research' => [
       'resize',
+      'print',
+      'email',
+      'facebook',
+      'twitter',
+      'pinterest',
+    ],
+    'cgov_cthp' => [
+      'print',
+      'email',
+      'facebook',
+      'twitter',
+      'pinterest',
+    ],
+    'cgov_event' => [
+      'resize',
+      'print',
+      'email',
+      'facebook',
+      'twitter',
+      'pinterest',
+    ],
+    'cgov_home_landing' => [
+      'print',
+      'email',
+      'facebook',
+      'twitter',
+      'pinterest',
     ],
     'cgov_infographic' => [
+      'print',
+      'email',
+      'facebook',
+      'twitter',
+      'pinterest',
+    ],
+    'cgov_mini_landing' => [
+      'print',
+      'email',
+      'facebook',
+      'twitter',
+      'pinterest',
+    ],
+    'cgov_press_release' => [
+      'resize',
+      'print',
+      'email',
+      'facebook',
+      'twitter',
+      'pinterest',
+    ],
+    'cgov_video' => [
       'print',
       'email',
       'facebook',
@@ -92,21 +136,6 @@ class PageOptionsManager implements PageOptionsManagerInterface {
     ],
     'pdq_drug_information_summary' => [
       'resize',
-      'print',
-      'email',
-      'facebook',
-      'twitter',
-      'pinterest',
-    ],
-    'cgov_cthp' => [
-      'resize',
-      'print',
-      'email',
-      'facebook',
-      'twitter',
-      'pinterest',
-    ],
-    'cgov_cancer_research' => [
       'print',
       'email',
       'facebook',

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/entrypoints/blogSeries/BlogSeries.scss
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/entrypoints/blogSeries/BlogSeries.scss
@@ -25,3 +25,27 @@
   }
 }
 
+#blogPageOptionsOuterContainer{
+  display:none;
+
+  @include bp(large-up) {
+    display:block;
+
+    .page-options-container {
+      top: 0;
+    }
+  }
+}
+
+#blogPageOptionsInnerContainer{
+  display:block;
+  
+  .page-options-container {
+    position: relative;
+    top: 0;
+  }
+
+  @include bp(large-up) {
+    display:none;
+  }
+}

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/entrypoints/homelanding/Homelanding.scss
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/entrypoints/homelanding/Homelanding.scss
@@ -676,4 +676,17 @@ parent accordion in all breakpoints. */
   }
 }
 
+/* Ticket-#1538 Page options are not right aligned at tablet breakpoint and no margin \
+*  on the left of page options at mobile breakpoint
+*   TODO: In the case of the spanish HOME PAGE, the page options should be floated left
+*/
+@include bp(medium) {
+  #PageOptionsControl1 {
+    ul {
+      float: right;
+    }
+  }
+
+}
+
 /********************* END Home Page Styles ******************************************/

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/block/page_options/block--page-options.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/block/page_options/block--page-options.html.twig
@@ -1,7 +1,11 @@
 <div class="page-options-container">
   <!-- PAGE OPTIONS -->
-  {# TODO: Add back in support for home and landing "large-5 columns" #}
-  <div id="PageOptionsControl1" class="page-options no-resize">
+  {% set classlist = _context.configuration.additionalClasses 
+      ? "page-options no-resize #{_context.configuration.additionalClasses}" 
+      : "page-options no-resize" 
+  %}
+
+  <div id="PageOptionsControl1" class="{{ classlist }}">
       <ul>
         {% if content.options.resize %}
           <li class="page-options--resize">

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/blog/node--cgov-blog-series--full.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/blog/node--cgov-blog-series--full.html.twig
@@ -30,6 +30,10 @@
         </div>
       {% endif %}
     </div>
+    <div id="blogPageOptionsInnerContainer">
+      {{ drupal_block('page_options') }}
+    </div>
+    
     <div id="cgvBody">
       <div class="slot-item first-SI">
         {% if not (get.topic or get.year) %}

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/blog/page--cgov-blog-series.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/blog/page--cgov-blog-series.html.twig
@@ -52,7 +52,9 @@
       <div class="large-12 columns">
         <div class="row">
           {{ page.breadcrumb }}
-          {{ drupal_block('page_options') }}
+          <div id="blogPageOptionsOuterContainer">
+            {{ drupal_block('page_options') }}
+          </div>
         </div> <!-- END "row" -->
       </div> <!-- END "large-12 columns" -->
       <div class="row">

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/home_landing/node--cgov-home-landing--full.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/home_landing/node--cgov-home-landing--full.html.twig
@@ -10,7 +10,8 @@
     <h1>{{ node.label }}</h1>
     <!-- END PAGE TITLE -->
   </div>
-  {{ drupal_block('page_options') }}
+
+  {{ drupal_block('page_options', {additionalClasses: 'large-5 columns'}) }}
 </div>
 {# End Title Row#}
 

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/pdq/node--pdq-drug-information-summary--full.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/pdq/node--pdq-drug-information-summary--full.html.twig
@@ -1,0 +1,34 @@
+{{ attach_library('cgov_common/pdq') }}
+{% import '@cgov_common/content_page_macros.twig' as contentPageMacros %}
+<!-- ********************************* BEGIN Page Content ********************************** -->
+
+<article>
+  <div class="resize-content">
+    <h1>{{- node.label -}}</h1>
+    {{ drupal_block('page_options') }}
+    <div id="cgvBody">
+      
+        <div>
+            <a href="javascript:void(0)"
+                class="CDR_audiofile"
+                data-pathname="/PublishedContent/Media/CDR/Media/{{- content.field_pdq_audio_id -}}.mp3">
+                <span class="hidden">listen</span>
+            </a>
+            &nbsp;{{ content.field_pdq_pronunciation_key }}
+        </div>
+        <p>{{ content.field_page_description }}</p>
+
+        <div class="accordion">
+          {{ content.body }}
+        </div>
+
+    </div>
+  </div>
+
+  <footer class="article-footer">
+    {{- contentPageMacros.displayDates(node, content) -}}
+    {% if node.field_public_use.value == '1' %}
+      {{ drupal_region('public_use') }}
+    {% endif %}
+  </footer>
+</article>


### PR DESCRIPTION
Closes #1482 .

Page options not showing up for certain content types.  

- Added content types to page options manager
- fixed positioning of page options on homelanding pages
- added base template for DIS;  twig template was completely missing so added a rough template as a placeholder until work on ticket #1516 is completed