### PR TITLE
Biography page display issues

### DIFF
--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/biography/field--field-linkedin-handle.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/biography/field--field-linkedin-handle.html.twig
@@ -1,5 +1,5 @@
 {% for item in items %}
-    <a href="http://www.linkedin.com/in/{{- item.content -}}" class="profile-social-link linkedin">
+    <a href="http://www.linkedin.com/in/{{- item.content -}}" class="profile-social-link linkedin no-exit-notification">
         <i class="icon" aria-hidden="true"></i>
         <span class="show-for-sr">Connect with me on LinkedIn</span>
     </a>

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/biography/field--field-scientific-publications.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/biography/field--field-scientific-publications.html.twig
@@ -1,5 +1,5 @@
 {% for item in items %}
-    <a href="{{- item.content -}}" class="profile-social-link publications">
+    <a href="{{- item.content -}}" class="profile-social-link publications no-exit-notification">
         <i class="icon publications" aria-hidden="true"></i>
         <span class="show-for-sr">View my </span>
         <span>Scientific Publications</span>

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/biography/field--field-title.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/biography/field--field-title.html.twig
@@ -1,3 +1,5 @@
-{% for item in items %}
-  <div class="profile-title">{{ item.content }}</div>
-{% endfor %}
+<div class="profile-titles">
+  {% for item in items %}
+    <div class="profile-title">{{ item.content }}</div>
+  {% endfor %}
+</div>

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/biography/field--field-twitter-handle.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/biography/field--field-twitter-handle.html.twig
@@ -1,5 +1,5 @@
 {% for item in items %}
-    <a href="http://www.twitter.com/{{- item.content -}}" class="profile-social-link twitter">
+    <a href="http://www.twitter.com/{{- item.content -}}" class="profile-social-link twitter no-exit-notification">
         <i class="icon" aria-hidden="true"></i>
         <span class="show-for-sr">Follow me on Twitter</span>
     </a>

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/biography/node--cgov-biography--full.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/biography/node--cgov-biography--full.html.twig
@@ -23,18 +23,22 @@
 
               {% if content.field_org_name_1|field_value or content.field_org_name_2|field_value %}
                 <div class="profile-orgs">
-                  {% if content.field_org_url_1|field_value %}
-                    <a href="{{- content.field_org_url_1|field_value -}}" class="profile-org">{{ content.field_org_name_1 }}</a>
-                  {% else %}
-                    <div class="profile-org">{{ content.field_org_name_1 }}</div>
-                  {% endif %}
+                  <div class="profile-org">
+                    {% if content.field_org_url_1|field_value %}
+                      <a href="{{- content.field_org_url_1|field_value -}}">{{ content.field_org_name_1 }}</a>
+                    {% else %}
+                      {{ content.field_org_name_1 }}
+                    {% endif %}
+                  </div>
 
                   {% if content.field_org_name_2|field_value %}
-                    {% if content.field_org_url_2|field_value %}
-                      <a href="{{- content.field_org_url_2|field_value -}}" class="profile-org">{{ content.field_org_name_2 }}</a>
-                    {% else %}
-                      <div class="profile-org">{{ content.field_org_name_2 }}</div>
-                    {% endif %}
+                    <div class="profile-org">
+                      {% if content.field_org_url_2|field_value %}
+                        <a href="{{- content.field_org_url_2|field_value -}}">{{ content.field_org_name_2 }}</a>
+                      {% else %}
+                        {{ content.field_org_name_2 }}
+                      {% endif %}
+                    </div>
                   {% endif %}
                 </div>
               {% endif %}

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/src/styles/_profile-panel.scss
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/src/styles/_profile-panel.scss
@@ -40,20 +40,18 @@
     .profile-title {
       font-size: 18px;
       line-height: 1.33;
-      margin-bottom: 1.25em;
+
+      &:last-of-type{
+        margin-bottom: 1.25em;
+      }
+      
     }
     
-    .profile-orgs {
+    .profile-orgs, 
+    .profile-titles {
       margin-bottom: 1.25em;
     }
 
-    .profile-org {
-      display: inline-block;
-      
-      &:not(:last-child) {
-        margin-bottom: 15px;
-      }
-    }
 
     p {
       font-size: 16px;


### PR DESCRIPTION
Closes #1470 , #1469 , #1471 .

(#1470) Biography: multiple organizations with shorter
names moving to single line

(#1471) Biography- spacing between multiple titles
regrouped titles to be like orgs applying margin to bottom of group.  New grouping and spacing approved by design

(#1469) Biography: disable external link icons in top profile card

