### PR TITLE
(#1534) Blog Categories - Page Title is not pulling category name

### DIFF
--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/src/Plugin/Block/BlogTopicTitle.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/src/Plugin/Block/BlogTopicTitle.php
@@ -11,12 +11,12 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * Provides a Featured Posts Block.
  *
  * @Block(
- *   id = "cgov_blog_topic_intro",
- *   admin_label = @Translation("Cgov Blog Category About"),
+ *   id = "cgov_blog_topic_title",
+ *   admin_label = @Translation("Cgov Blog Topic Name"),
  *   category = @Translation("Cgov Digital Platform"),
  * )
  */
-class BlogTopicIntro extends BlockBase implements ContainerFactoryPluginInterface {
+class BlogTopicTitle extends BlockBase implements ContainerFactoryPluginInterface {
 
   /**
    * The BlogManager object.
@@ -67,9 +67,9 @@ class BlogTopicIntro extends BlockBase implements ContainerFactoryPluginInterfac
    * {@inheritdoc}
    */
   public function build() {
-    $topic_intros = $this->getTopicIntros();
+    $topic_titles = $this->getTopicTitles();
     $build = [
-      '#topic_intros' => $topic_intros,
+      '#topic_titles' => $topic_titles,
     ];
     return $build;
   }
@@ -79,10 +79,10 @@ class BlogTopicIntro extends BlockBase implements ContainerFactoryPluginInterfac
    *
    * {@inheritdoc}
    */
-  private function getTopicIntros() {
+  private function getTopicTitles() {
     // Get all of the associated categories their description fields.
-    $intros = $this->blogManager->getSeriesTopicDescription();
-    return $intros;
+    $titles = $this->blogManager->getSeriesTopicTitle();
+    return $titles;
   }
 
 }

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/src/Services/BlogManager.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/src/Services/BlogManager.php
@@ -168,6 +168,8 @@ class BlogManager implements BlogManagerInterface {
 
   /**
    * Get Blog Series categories (topics).
+   *
+   * TODO: Rename *categories files & methods to *topics for consistency.
    */
   public function getSeriesCategories() {
     $categories = [];
@@ -188,20 +190,37 @@ class BlogManager implements BlogManagerInterface {
   }
 
   /**
-   * Get Blog Series category (topic) descriptions.
+   * Get Blog Series topic (category) descriptions.
    */
-  public function getSeriesCategoryDescription() {
-    $categories = $this->getSeriesCategories();
+  public function getSeriesTopicDescription() {
+    $topics = $this->getSeriesCategories();
     $descriptions = [];
 
     // Create an array of categories that match the owner Blog Series.
-    foreach ($categories as $cat) {
-      $tid = $cat->tid;
+    foreach ($topics as $topic) {
+      $tid = $topic->tid;
       $url = $this->getTaxonomyStorage()->load($tid)->field_pretty_url->value;
       $desc = $this->getTaxonomyStorage()->load($tid)->description->value;
       $descriptions[$url] = $desc;
     }
     return $descriptions;
+  }
+
+  /**
+   * Get Blog Series topic (category) names.
+   */
+  public function getSeriesTopicTitle() {
+    $topics = $this->getSeriesCategories();
+    $names = [];
+
+    // Create an array of categories that match the owner Blog Series.
+    foreach ($topics as $topic) {
+      $tid = $topic->tid;
+      $url = $this->getTaxonomyStorage()->load($tid)->field_pretty_url->value;
+      $name = $this->getTaxonomyStorage()->load($tid)->getName();
+      $names[$url] = $name;
+    }
+    return $names;
   }
 
   /**

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/cgov_common.theme
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/cgov_common.theme
@@ -85,6 +85,6 @@ function cgov_common_preprocess_node(&$variables) {
 
   // Add any parameter values to the $variables get property.
   foreach ($params as $param) {
-    $variables['get'][$param] = isset($_GET[$param]) ? $_GET[$param] : '';
+    $variables['get'][$param] = $_GET[$param] ?? '';
   }
 }

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/blog/block--cgov-blog-topic-title.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/blog/block--cgov-blog-topic-title.html.twig
@@ -1,0 +1,7 @@
+{% if content['#topic_titles']|length > 0 %}
+  {% for url, title in content['#topic_titles'] %}
+    {% if (title|length > 0) and url == label %}
+      {{ title }}
+    {% endif %}
+  {% endfor %}
+{% endif %}

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/blog/blog_macros.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/blog/blog_macros.twig
@@ -61,6 +61,35 @@
 {% endmacro %}
 
 {# 
+ # Draw the title for a given Blog Series. Prepend the month/year to the title if 
+ # this is a Blog Archive page. Prepend the category name if this is a Blog Category 
+ # page.
+ #
+ # @param string month (numerical value) 
+ # @param string year
+ # @param string topic
+ # @param string blog_name
+ #}
+{% macro drawBlogSeriesTitle(month, year, topic, blog_name) %}
+  <h1>
+    <span>
+      {% if (month and year) %}
+        {{ _self.transformMonthName(month) }}
+      {% endif %}
+      {% if year %}
+        {{ year }} - 
+      {% endif %}
+      {% if topic %}
+        {{ drupal_block('cgov_blog_topic_title', {label: topic}) }} - 
+      {% endif %}
+      {% if (blog_name) %}
+        {{ blog_name }}
+      {% endif %}
+    </span>
+  </h1>
+{% endmacro %}
+
+{# 
  # Get long month name.
  # @param string month
  #}

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/blog/node--cgov-blog-series--full.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/blog/node--cgov-blog-series--full.html.twig
@@ -12,17 +12,7 @@
   {% endif %}
 
   <div class="resize-content">
-    <h1>
-      {% if (get.month and get.year) %}
-        {{ blogMacros.transformMonthName(get.month) }}
-      {% endif %}
-      {% if get.year %}
-        {{ get.year }} - 
-      {% endif %}
-      {% if node.label %}
-        {{ node.label }}
-      {% endif %}
-    </h1>
+    {{ blogMacros.drawBlogSeriesTitle(get.month, get.year, get.topic, node.label) }}
     <div id="nvcgSubTitle">
       {% if node.field_feedburner_url.value|length > 0 %}
         <div class="subscribeRSS">


### PR DESCRIPTION
* Draw topic name as part of title on category pages
* Moved series title block into blog_macros.twig