### PR TITLE
(#1504) Make a homepage yml and make it work

### DIFF
--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_site_section/cgov_site_section.module
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_site_section/cgov_site_section.module
@@ -109,6 +109,16 @@ function cgov_site_section_taxonomy_term_update(EntityInterface $entity) {
   if ($entity->bundle() !== 'cgov_site_sections') {
     return;
   }
+
+  // We only set the front page for English nodes without a parent.
+  // NOTE: this does not account for the case when the root becomes a
+  // child of another node. It is possible, but the amount of complexity
+  // that check would add is not worth it.
+  // NOTE2: target_id can be an int and it can be a string.
+  if ($entity->parent->target_id == 0 && $entity->langcode->value === 'en') {
+    _cgov_site_section_attempt_set_front_page($entity);
+  }
+
   // TODO: This comparison should be done somewhere else and less messy.
   // Do not do unnessesary updates, so only cascade if a change was
   // made to a significant field.
@@ -138,6 +148,39 @@ function cgov_site_section_taxonomy_term_update(EntityInterface $entity) {
   // TODO: Figure out how to get pathauto to update all the aliases using
   // pathauto. To do it here is A) too slow, and B) fraught with
   // issue regarding workflow and the various entity types we would have to hit.
+}
+
+/**
+ * Set the front page if conditions are right.
+ *
+ * @param \Drupal\Core\Entity\EntityInterface $site_section
+ *   The site section.
+ */
+function _cgov_site_section_attempt_set_front_page(EntityInterface $site_section) {
+  /*
+   * If it has no landing page, then we need to exit.
+   *
+   * NOTE: We do not care about its published state as taxonomy does not have
+   * workflow yet. So when the landing page is set, then it updates the live
+   * site immediately. The assumption is that the home page will be published
+   * either before, or right after. If we checked the published state, and
+   * skipped updating it if the target was unpublished, then we would have to
+   * have an update hook for node checking if it is a landing then updating
+   * the section. That is too convoluted.
+   */
+  $home_page_id = $site_section->field_landing_page->target_id;
+  if ($home_page_id === NULL) {
+    return;
+  }
+
+  // Set the front page.
+  $config = \Drupal::configFactory()->getEditable('system.site');
+  $front_page = "/node/${home_page_id}";
+  // Only save if we need to change it.
+  if ($front_page !== $config->get('page.front')) {
+    $config->set('page.front', $front_page)->save();
+  }
+
 }
 
 /**

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_site_section/cgov_site_section.services.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_site_section/cgov_site_section.services.yml
@@ -1,0 +1,6 @@
+services:
+  cgov_site_section.path_processor:
+    class: Drupal\cgov_site_section\FixHomeUrlAliasOutboundPathProcessor
+    tags:
+      - { name: path_processor_outbound, priority: 400 }
+    arguments: ['@config.factory']

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_site_section/src/FixHomeUrlAliasOutboundPathProcessor.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_site_section/src/FixHomeUrlAliasOutboundPathProcessor.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Drupal\cgov_site_section;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\PathProcessor\OutboundPathProcessorInterface;
+use Drupal\Core\Render\BubbleableMetadata;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Outbound path processor to fix home aliases that are generated as /-0.
+ *
+ * This needs to fire BEFORE the alias processor.
+ *
+ * PathAuto is generating our home alias as /-0, because / is special. This
+ * processor will attempt to rewrite that to '/'. Since we know the entity
+ * with an alias of /-0 should also be set as a front page based on our code,
+ * this should not be an issue rewriting the alias outbound, but ignoring
+ * inbound handling. (As Drupal will take care of mapping '/' to what is set
+ * for the front page)
+ *
+ * One IMPORTANT thing to note: All URLs pass through these gates. Therefore
+ * we should only replace if we are 100% sure it is the front-page. Even if
+ * the URL is /-0, that does not mean it is set to the front page. We don't
+ * want to break working pages and we don't want it to blowup if an assumption
+ * is not met.
+ */
+class FixHomeUrlAliasOutboundPathProcessor implements OutboundPathProcessorInterface {
+
+  /**
+   * Constructs a FixHomeUrlAliasOutboundPathProcessor object.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config
+   *   A config factory for retrieving the site front page configuration.
+   */
+  public function __construct(ConfigFactoryInterface $config) {
+    $this->config = $config;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function processOutbound($path, &$options = [], Request $request = NULL, BubbleableMetadata $bubbleable_metadata = NULL) {
+    // Get the route for the front page.
+    $front_path = $this->config->get('system.site')->get('page.front');
+
+    // There is no front page, so bail.
+    if (empty($front_path)) {
+      return $path;
+    }
+
+    if ($front_path === $path) {
+      return '/';
+    }
+    else {
+      return $path;
+    }
+  }
+
+}

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/100_home.content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/100_home.content.yml
@@ -1,0 +1,337 @@
+- entity: "node"
+  type: "cgov_home_landing"
+  langcode: en
+  status: 1
+  moderation_state:
+    value: 'published'
+  title: "Home Page"
+  title__ES:
+      value: "Spanish Home Page"
+  field_page_description:
+    value: "Accurate, up-to-date, comprehensive cancer information from the U.S. government's principal agency for cancer research."
+  field_page_description__ES:
+    value: "Información del Instituto Nacional del Cáncer sobre el tratamiento, la prevención, los exámenes de detección, la genética y las causas del cáncer, así como formas de hacer frente a la enfermedad."
+  field_short_title:
+    value: "Comprehensive Cancer Information"
+  field_short_title__ES:
+    value: "Cáncer en español"
+  field_browser_title:
+    value: "Comprehensive Cancer Information"
+  field_browser_title__ES:
+    value: "Cáncer en español"
+  field_site_section:
+    - '#process':
+        callback: 'reference'
+        args:
+          - 'taxonomy_term'
+          - vid: 'cgov_site_sections'
+            computed_path: '/'
+            langcode: 'en'
+  field_site_section__ES:
+    - '#process':
+        callback: 'reference'
+        args:
+          - 'taxonomy_term'
+          - vid: 'cgov_site_sections'
+            computed_path: '/'
+            langcode: 'es'
+  ### English Contents
+  field_landing_contents:
+    ######## Begin Feature Row ###########
+    - entity: 'paragraph'
+      type: "cgov_primary_feature_row"
+      field_container_heading:
+        - value: "Featured Content"
+      field_row_cards:
+        - entity: 'paragraph'
+          type: "cgov_card_internal"
+          field_featured_item:
+            - target_type: 'node'
+              '#process':
+                callback: 'reference'
+                args:
+                  - 'node'
+                  - type: 'cgov_article'
+                    title: 'Feelings and Cancer'
+        - entity: 'paragraph'
+          type: "cgov_card_internal"
+          field_override_card_title:
+            - value: 'Overridden Title'
+          field_override_card_description:
+            - value: 'Overridden description'
+          field_featured_item:
+            - target_type: 'node'
+              '#process':
+                callback: 'reference'
+                args:
+                  - 'node'
+                  - type: 'cgov_article'
+                    title: 'Feelings and Cancer'
+        - entity: 'paragraph'
+          type: "cgov_card_external"
+          field_override_card_title:
+            - value: 'External Card Title'
+          field_override_card_description:
+            - value: 'External Card Description'
+          field_override_image_promotional:
+            - target_type: 'media'
+              '#process':
+                callback: 'reference'
+                args:
+                  - 'media'
+                  - bundle: 'cgov_image'
+                    name: 'Find a Clinical Trial'
+          field_featured_url:
+            - uri: 'https://www.google.com'
+      ## Cards here
+    ######## End Feature Row ###########
+    ######## Begin Guide Row ###########
+    - entity: 'paragraph'
+      type: "cgov_guide_row"
+      field_container_heading:
+        - value: "Your Guide to Cancer"
+      field_guide_cards:
+        - entity: 'paragraph'
+          type: "cgov_content_block"
+          field_content_heading:
+            - value: "Cancer Basics"
+          field_html_content:
+            - format: "full_html"
+              value: |
+                <ul>
+                  <li><a class="arrow-link" href="/about-cancer/understanding/what-is-cancer" title="">What Is Cancer</a></li>
+                  <li><a class="arrow-link" href="/about-cancer/causes-prevention" title="">Causes &#38; Prevention</a></li>
+                  <li><a class="arrow-link" href="/about-cancer/causes-prevention/risk" title="">Risk Factors</a></li>
+                  <li><a class="arrow-link" href="/about-cancer/screening" title="">Screening</a></li>
+                </ul>
+        - entity: 'paragraph'
+          type: "cgov_content_block"
+          field_content_heading:
+            - value: "Newly Diagnosed"
+          field_html_content:
+            - format: "full_html"
+              value: |
+                <ul>
+                  <li><a class="arrow-link" href="/about-cancer/diagnosis-staging" title="">Diagnosis &amp; Staging</a></li>
+                  <li><a class="arrow-link" href="/about-cancer/diagnosis-staging/prognosis" title="">Prognosis</a></li>
+                  <li><a class="arrow-link" href="/about-cancer/diagnosis-staging/symptoms" title="">Symptoms</a></li>
+                  <li><a class="arrow-link" href="/about-cancer/coping" title="">Coping with Cancer</a></li>
+                  <li><a class="arrow-link" href="/about-cancer/managing-care/services" title="">Find a Doctor or Treatment Facility</a></li>
+                </ul>
+        - entity: 'paragraph'
+          type: "cgov_content_block"
+          field_content_heading:
+            - value: "Treatment"
+          field_html_content:
+            - format: "full_html"
+              value: |
+                <ul>
+                  <li><a class="arrow-link" href="/about-cancer/treatment/types" title="">Types of Treatment</a></li>
+                  <li><a class="arrow-link" href="/about-cancer/treatment/side-effects" title="">Side Effects</a></li>
+                  <li><a class="arrow-link" href="/about-cancer/treatment/clinical-trials" title="">Clinical Trials Information for Patients and Caregivers</a></li>
+                  <li><a class="arrow-link" href="/about-cancer/treatment/drugs" title="">Cancer Drugs</a></li>
+                  <li><a class="arrow-link" href="/about-cancer/treatment/cam" title="">Complementary &amp; Alternative Medicine</a></li>
+                </ul>
+                <p><a class="arrow-link" href="/about-cancer/treatment" title="">Learn more about treatment</a></p>
+    ######## End Guide Row ###########
+    ######## Begin Secondary Card Row ###########
+    - entity: 'paragraph'
+      type: "cgov_secondary_feature_row"
+      field_row_cards:
+        - entity: 'paragraph'
+          type: "cgov_card_external"
+          field_override_card_title:
+            - value: 'External Card Title'
+          field_override_card_description:
+            - value: 'External Card Description'
+          field_override_image_promotional:
+            - target_type: 'media'
+              '#process':
+                callback: 'reference'
+                args:
+                  - 'media'
+                  - bundle: 'cgov_image'
+                    name: 'Find a Clinical Trial'
+          field_featured_url:
+            - uri: 'https://www.google.com'
+        - entity: 'paragraph'
+          type: "cgov_card_internal"
+          field_featured_item:
+            - target_type: 'node'
+              '#process':
+                callback: 'reference'
+                args:
+                  - 'node'
+                  - type: 'cgov_article'
+                    title: 'Feelings and Cancer'
+        - entity: 'paragraph'
+          type: "cgov_card_internal"
+          field_override_card_title:
+            - value: 'Overridden Title'
+          field_override_card_description:
+            - value: 'Overridden description'
+          field_featured_item:
+            - target_type: 'node'
+              '#process':
+                callback: 'reference'
+                args:
+                  - 'node'
+                  - type: 'cgov_article'
+                    title: 'Feelings and Cancer'
+    ######## End Secondary Card Row ###########
+
+    ######## MULTIMEDIA Row ##############
+    - entity: 'paragraph'
+      type: "cgov_multimedia_row"
+      field_mm_media_item:
+        - target_type: 'media'
+          '#process':
+            callback: 'reference'
+            args:
+              - 'media'
+              - bundle: 'cgov_video'
+                name: 'Colorectal Cancer Screening: What to Expect'
+      field_mm_feature_card:
+        - entity: 'paragraph'
+          type: "cgov_card_internal"
+          field_featured_item:
+            - target_type: 'node'
+              '#process':
+                callback: 'reference'
+                args:
+                  - 'node'
+                  - type: 'cgov_article'
+                    title: 'Feelings and Cancer'
+    ######### End MM Row ##############
+    ######## Begin Thumbnail List ##############
+    - entity: 'paragraph'
+      type: "cgov_list"
+      field_list_item_style:
+        value: list_item_title_desc_image
+      field_list_items:
+        - entity: 'paragraph'
+          type: "cgov_internal_link"
+          field_override_title:
+            - value: 'Overridden Title'
+          field_override_list_description:
+            - value: 'Overridden description'
+          field_internal_link:
+            - target_type: 'node'
+              '#process':
+                callback: 'reference'
+                args:
+                  - 'node'
+                  - type: 'cgov_article'
+                    title: 'Feelings and Cancer'
+        - entity: 'paragraph'
+          type: "cgov_external_link"
+          field_override_title:
+            - value: 'External Card Title'
+          field_override_list_description:
+            - value: 'External Card Description'
+          field_override_image_promotional:
+            - target_type: 'media'
+              '#process':
+                callback: 'reference'
+                args:
+                  - 'media'
+                  - bundle: 'cgov_image'
+                    name: 'Find a Clinical Trial'
+          field_external_link:
+            - uri: 'https://www.google.com'
+        - entity: 'paragraph'
+          type: "cgov_internal_link"
+          field_internal_link:
+            - target_type: 'node'
+              '#process':
+                callback: 'reference'
+                args:
+                  - 'node'
+                  - type: 'cgov_article'
+                    title: 'Feelings and Cancer'
+        - entity: 'paragraph'
+          type: "cgov_internal_link"
+          field_override_title:
+            - value: 'Overridden Title'
+          field_override_list_description:
+            - value: 'Overridden description'
+          field_internal_link:
+            - target_type: 'node'
+              '#process':
+                callback: 'reference'
+                args:
+                  - 'node'
+                  - type: 'cgov_article'
+                    title: 'Feelings and Cancer'
+    ######## End Thumbnail List ##############
+  ## SPANISH CONTENTS HERE
+  field_landing_contents__ES:
+    ######## Begin Feature Row ###########
+    - entity: 'paragraph'
+      type: "cgov_primary_feature_row"
+      field_container_heading:
+        - value: "Contenido especial"
+      ## Cards here
+    ######## End Feature Row ###########
+    ######## Begin Guide Row ###########
+    - entity: 'paragraph'
+      type: "cgov_guide_row"
+      field_container_heading:
+        - value: "Su guía de información del cáncer"
+      field_guide_cards:
+        - entity: 'paragraph'
+          type: "cgov_card_raw_html"
+          field_raw_html:
+            - format: "raw_html"
+              value: |
+                <div class="contentid-1100555 slot-item first-SI equalheight large-4 columns card gutter">
+                  <h2>
+                    Aspectos básicos del cáncer
+                  </h2>
+                  <ul>
+                  <li><a class="arrow-link" href="/espanol/cancer/naturaleza/que-es" title="">&iquest;Qu&eacute; es el c&aacute;ncer?</a></li>
+                  <li><a class="arrow-link" href="/espanol/cancer/causas-prevencion" title="">Causas y prevenci&oacute;n</a></li>
+                  <li><a class="arrow-link" href="/espanol/cancer/causas-prevencion/riesgo" title="">Factores de riesgo</a></li>
+                  <li><a class="arrow-link" href="/espanol/cancer/deteccion" title="">Detecci&oacute;n</a></li>
+                  </ul>
+                </div>
+        - entity: 'paragraph'
+          type: "cgov_card_raw_html"
+          field_raw_html:
+            - format: "raw_html"
+              value: |
+                <div class="contentid-1100554 slot-item equalheight large-4 columns card gutter">
+                  <h2>
+                    Recién diagnosticado
+                  </h2>
+                  <ul>
+                    <li><a class="arrow-link" href="/espanol/cancer/diagnostico-estadificacion" title="">Diagn&oacute;stico y estadificaci&oacute;n</a></li>
+                    <li><a class="arrow-link" href="/espanol/cancer/diagnostico-estadificacion/pronostico" title="">Pron&oacute;stico</a></li>
+                    <li><a class="arrow-link" href="/espanol/cancer/diagnostico-estadificacion/sintomas" title="">S&iacute;ntomas</a></li>
+                    <li><a class="arrow-link" href="/espanol/cancer/sobrellevar" title="">C&oacute;mo hacer frente al c&aacute;ncer</a></li>
+                    <li><a class="arrow-link" href="/espanol/cancer/manejo-del-cancer/servicios" title="">Encuentre a un doctor o centro de tratamiento</a></li>
+                  </ul>
+                </div>
+        - entity: 'paragraph'
+          type: "cgov_card_raw_html"
+          field_raw_html:
+            - format: "raw_html"
+              value: |
+                <div class="contentid-936298 slot-item last-SI equalheight large-4 columns card gutter">
+                  <h2>
+                    Tratamiento
+                  </h2>
+                  <ul>
+                    <li><a class="arrow-link" href="/espanol/cancer/tratamiento/tipos" title="">Tipos de tratamiento</a></li>
+                    <li><a href="/espanol/cancer/tratamiento/efectos-secundarios" class="arrow-link" title="">Efectos secundarios</a></li>
+                    <li><a href="/espanol/cancer/tratamiento/estudios-clinicos" class="arrow-link" title="">Gu&iacute;a para entender y participar en estudios cl&iacute;nicos</a></li>
+                    <li><a href="/espanol/cancer/tratamiento/medicamentos" class="arrow-link" title="">Medicamentos para el c&aacute;ncer</a></li>
+                    <li><a href="/espanol/cancer/tratamiento/mca" class="arrow-link sys_folderid=" title="">Medicina complementaria y alternativa</a></li>
+                    <li><a href="/espanol/cancer/tratamiento" class="arrow-link" title="">Aprenda m&aacute;s sobre el tratamiento</a></li>
+                    </ul>
+                </div>
+    ######## End Guide Row ###########
+    ######## Begin Secondary Card Row ###########
+    - entity: 'paragraph'
+      type: "cgov_secondary_feature_row"
+    ######## End Secondary Card Row ###########


### PR DESCRIPTION
## ODE: http://ncigovcdode123.prod.acquia-sites.com/

## Testing Notes
* A "homepage" should appear at when you go to http://ncigovcdode123.prod.acquia-sites.com/
* The http://ncigovcdode123.prod.acquia-sites.com/user/login url should still work
* When you edit the English home site section and change the landing page, http://ncigovcdode123.prod.acquia-sites.com/ should point to the new page.
   * NOTE: You *should* change the existing landing page's SiteSection/Pretty to reflect it is not the homepage first. This update will not change the Landing Page's site section, nor pretty url. All it does is makes this page the system's front page, and makes sure the URLs pointing to that node display as /.
* Aliases for the content has a site section of "Home" and an empty pretty url will still be generated as `/-0`. This should not show up on the front-end. Places to test:
   * Link It
   * Lists
   * Cards
* The URLs in the head metadata should not show `/-0` anywhere either.


Closes #1504 