### PR TITLE
(#1606) Content Type specific references to be updated for CTHP

### DIFF
--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/entrypoints/cthp/CTHP.scss
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/entrypoints/cthp/CTHP.scss
@@ -122,6 +122,11 @@
       margin-left: -30px;
       margin-right: -30px;
     }
+
+    .ui-accordion-content {
+      margin-left: -12px;
+		  margin-right: -12px;
+    }
   }
 
   .cardBody {
@@ -240,8 +245,9 @@
   p {
     margin-top: 2px;
     margin-bottom: 2px;
+    
     a {
-      display: block;
+      display: inline-block;
       padding-left: 0.9375em;
     }
   }
@@ -256,7 +262,7 @@
 .more-info-list ul li:before,
 .cthp-pdq-label ul li:before,
 .cardBody ul li:before,
-.cardBody p a:before {
+.cardBody p a:not(.icon-exit-notification):before {
   content: "\2022";
   display: inline-block;
   position: relative;


### PR DESCRIPTION
Closes #1606 .

Moved one piece of this ticket onto #1589 where by DOM manipulation can be avoided in exitDisclaimer.js and handled in the templates for external feature cards.

Styles that were previously targeted to . cgvcancertypehome and are now scoped via CTHP stylesheet.

ODE: http://ncigovcdode129.prod.acquia-sites.com/types/breast