### PR TITLE
(#321) Output Page Metadata - DTM Analytics

### DIFF
--- a/docroot/profiles/custom/cgov_site/config/install/metatag.metatag_defaults.global.yml
+++ b/docroot/profiles/custom/cgov_site/config/install/metatag.metatag_defaults.global.yml
@@ -7,6 +7,9 @@ tags:
   canonical_url: '[current-page:url]'
   title: '[cgov_tokens:cgov-title] - [site:name]'
   dcterms_coverage: 'nciglobal,ncienterprise'
+  dcterms_type: nciHome
+  dcterms_subject: '[cgov_tokens:cgov-analytics-channel]'
+  dcterms_is_part_of: '[cgov_tokens:cgov-analytics-group]'
   og_site_name: 'National Cancer Institute'
   og_type: Website
   og_url: '[current-page:url]'

--- a/docroot/profiles/custom/cgov_site/config/install/metatag.metatag_defaults.node.yml
+++ b/docroot/profiles/custom/cgov_site/config/install/metatag.metatag_defaults.node.yml
@@ -8,5 +8,9 @@ tags:
   content_language: '[node:langcode]'
   description: '[node:field_page_description:value]'
   title: '[cgov_tokens:cgov-title] - [site:name]'
+  dcterms_subject: '[cgov_tokens:cgov-analytics-channel]'
+  dcterms_is_referenced_by: event1
+  dcterms_issued: '[node:field_date_posted:date:short]'
+  dcterms_is_part_of: '[cgov_tokens:cgov-analytics-group]'
   og_description: '[node:field_page_description:value]'
   og_title: '[node:field_browser_title:value]'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_biography/cgov_biography.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_biography/cgov_biography.info.yml
@@ -7,4 +7,6 @@ dependencies:
   - cgov_core
   - cgov_image
   - cgov_list
+  - metatag
+  - metatag_dc
   - taxonomy

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/cgov_blog.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/cgov_blog.info.yml
@@ -8,3 +8,6 @@ dependencies:
   - cgov_image
   - cgov_list
   - cgov_site_section
+  - metatag
+  - metatag_dc
+  - metatag_dc_advanced

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/config/install/metatag.metatag_defaults.node__cgov_blog_post.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/config/install/metatag.metatag_defaults.node__cgov_blog_post.yml
@@ -2,6 +2,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: node__cgov_blog_post
-label: 'Content: Blog Post'
+label: "Content: Blog Post"
 tags:
+  dcterms_is_referenced_by: 'event1,event53'
   dcterms_type: cgvBlogPost

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_center/cgov_cancer_center.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_center/cgov_cancer_center.info.yml
@@ -8,4 +8,6 @@ dependencies:
   - cgov_core
   - cgov_image
   - cgov_list
+  - metatag
+  - metatag_dc
   - taxonomy

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_research/cgov_cancer_research.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_research/cgov_cancer_research.info.yml
@@ -7,3 +7,5 @@ dependencies:
   - cgov_core
   - cgov_image
   - cgov_list
+  - metatag
+  - metatag_dc

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.info.yml
@@ -22,6 +22,7 @@ dependencies:
   - language
   - media
   - metatag
+  - metatag_dc
   - node
   - options
   - page_manager_ui

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/cgov_cthp.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/cgov_cthp.info.yml
@@ -10,5 +10,7 @@ dependencies:
   - cgov_home_landing
   - cgov_list
   - cgov_video
+  - metatag
+  - metatag_dc
   - paragraphs_asymmetric_translation_widgets
   - pdq_cancer_information_summary

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/metatag.metatag_defaults.node__cgov_cthp.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/metatag.metatag_defaults.node__cgov_cthp.yml
@@ -5,3 +5,4 @@ id: node__cgov_cthp
 label: 'Content: Cancer Type Homepage'
 tags:
   dcterms_type: cgvCancerTypeHome
+  dcterms_audience: '[node:field_audience:value]'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_event/cgov_event.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_event/cgov_event.info.yml
@@ -6,4 +6,6 @@ core: 8.x
 dependencies:
   - cgov_core
   - cgov_image
+  - metatag
+  - metatag_dc
   - taxonomy

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/cgov_home_landing.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/cgov_home_landing.info.yml
@@ -8,4 +8,6 @@ dependencies:
   - cgov_image
   - cgov_list
   - cgov_promo
+  - metatag
+  - metatag_dc
   - paragraphs_asymmetric_translation_widgets

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_infographic/cgov_infographic.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_infographic/cgov_infographic.info.yml
@@ -7,3 +7,5 @@ dependencies:
   - cgov_media
   - media
   - image
+  - metatag
+  - metatag_dc

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_metatag/cgov_metatag.tokens.inc
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_metatag/cgov_metatag.tokens.inc
@@ -5,6 +5,9 @@
  * Cgov metatag tokens.
  */
 
+use Drupal\node\Entity\Node;
+use Drupal\taxonomy\Entity\Term;
+
 /**
  * Implements hook_token_info().
  */
@@ -12,11 +15,20 @@ function cgov_metatag_token_info() {
   $info = [];
   $info['types']['cgov_tokens'] = ['name' => t('Cancer.gov Tokens'), 'description' => t('Cancer.gov Tokens')];
 
-  $info['tokens']['cgov_tokens']['cgov-title'] =
-    [
+  $info['tokens']['cgov_tokens'] = [
+    'cgov-title' => [
       'name' => t('Cgov Title Meta Tag'),
       'description' => t('The value to user for the title meta tag.'),
-    ];
+    ],
+    'cgov-analytics-channel' => [
+      'name' => t('Cgov WA Channel'),
+      'description' => t('The channel field value.'),
+    ],
+    'cgov-analytics-group' => [
+      'name' => t('Cgov WA Group'),
+      'description' => t('The content group field value.'),
+    ],
+  ];
 
   return $info;
 }
@@ -31,6 +43,14 @@ function cgov_metatag_tokens($type, $tokens, array $data, array $options, $bubbl
       switch ($name) {
         case 'cgov-title':
           $replacements[$original] = get_meta_title_token($data);
+          break;
+
+        case 'cgov-analytics-channel':
+          $replacements[$original] = get_taxonomy_field_token($data, 'field_channel');
+          break;
+
+        case 'cgov-analytics-group':
+          $replacements[$original] = get_taxonomy_field_token($data, 'field_content_group');
           break;
       }
     }
@@ -59,4 +79,90 @@ function get_meta_title_token(array $data) {
     }
   }
   return $titleToken;
+}
+
+/**
+ * Get a given field value from taxonomy term.
+ *
+ * @param array $data
+ *   An associative array of data objects.
+ * @param string $fieldname
+ *   The name of the field.
+ *
+ * @return string
+ *   String value of the selected field.
+ */
+function get_taxonomy_field_token(array $data, $fieldname) {
+  $rtn = t('NCI');
+  $node = $data['node'] ?? NULL;
+
+  if (isset($node) && !empty($node)) {
+
+    /*
+     * Get the site section and its ancestors, then loop through
+     * until a valid string value is found or we run out of site
+     * section taxons.
+     */
+    if ($node->hasField('field_site_section') && !empty($node->get('field_site_section')->first())) {
+      $tid = $node->get('field_site_section')->first()->getValue()['target_id'];
+      $sections = \Drupal::service('entity_type.manager')->getStorage("taxonomy_term")->loadAllParents($tid);
+      foreach ($sections as $section) {
+        $sid = $section->id();
+        $fieldToken = Term::load($sid)->get($fieldname)->value;
+        if (isset($fieldToken) && trim($fieldToken) !== '') {
+          return $fieldToken;
+        }
+      }
+    }
+
+    /*
+     * If there is no site section, traverse through ancestor
+     * paths until one is found.
+     */
+    else {
+      $nid = $node->id();
+      $alias = \Drupal::service('path.alias_manager')->getAliasByPath('/node/' . $nid);
+      $parent['node'] = get_valid_parent($alias);
+
+      // Recurse through this method until a field value is found.
+      $fieldToken = get_taxonomy_field_token($parent, $fieldname);
+      return $fieldToken;
+    }
+  }
+
+  /*
+   * If we hit this, it means the taxonomy field is not set
+   * anywhere between here and the tree root.
+   */
+  return $rtn;
+}
+
+/**
+ * Search for ancestor nodes by alias.
+ *
+ * @param string $alias
+ *   An associative array of data objects.
+ *
+ * @return \Drupal\node\Entity\Node
+ *   Node object.
+ */
+function get_valid_parent($alias) {
+  if (!isset($alias) || trim($alias) === '') {
+    return NULL;
+  }
+
+  // Trim the last section of the current alias and get the 'node/<nid>' path.
+  $parentAlias = preg_replace('#\/[^/]*$#', '', $alias);
+  $parentPath = \Drupal::service('path.alias_manager')->getPathByAlias($parentAlias);
+
+  // Return node if matches, otherwise run through this method again.
+  if (preg_match('/node\/(\d+)/', $parentPath, $matches)) {
+    $node = Node::load($matches[1]);
+    return $node;
+  }
+  else {
+    $node = get_valid_parent($parentAlias);
+    return $node;
+  }
+
 }

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/cgov_press_release.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/cgov_press_release.info.yml
@@ -7,3 +7,5 @@ dependencies:
   - cgov_core
   - cgov_image
   - cgov_list
+  - metatag
+  - metatag_dc

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_site_section/config/install/core.entity_form_display.taxonomy_term.cgov_site_sections.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_site_section/config/install/core.entity_form_display.taxonomy_term.cgov_site_sections.default.yml
@@ -3,6 +3,8 @@ status: true
 dependencies:
   config:
     - field.field.taxonomy_term.cgov_site_sections.field_breadcrumb_root
+    - field.field.taxonomy_term.cgov_site_sections.field_channel
+    - field.field.taxonomy_term.cgov_site_sections.field_content_group
     - field.field.taxonomy_term.cgov_site_sections.field_landing_page
     - field.field.taxonomy_term.cgov_site_sections.field_levels_to_display
     - field.field.taxonomy_term.cgov_site_sections.field_main_nav_root
@@ -33,6 +35,22 @@ content:
       display_label: true
     third_party_settings: {  }
     type: boolean_checkbox
+    region: content
+  field_channel:
+    weight: 14
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_content_group:
+    weight: 15
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
     region: content
   field_landing_page:
     weight: 10

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_site_section/config/install/core.entity_view_display.taxonomy_term.cgov_site_sections.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_site_section/config/install/core.entity_view_display.taxonomy_term.cgov_site_sections.default.yml
@@ -3,6 +3,8 @@ status: true
 dependencies:
   config:
     - field.field.taxonomy_term.cgov_site_sections.field_breadcrumb_root
+    - field.field.taxonomy_term.cgov_site_sections.field_channel
+    - field.field.taxonomy_term.cgov_site_sections.field_content_group
     - field.field.taxonomy_term.cgov_site_sections.field_landing_page
     - field.field.taxonomy_term.cgov_site_sections.field_levels_to_display
     - field.field.taxonomy_term.cgov_site_sections.field_main_nav_root
@@ -36,6 +38,22 @@ content:
       format_custom_true: ''
     third_party_settings: {  }
     type: boolean
+    region: content
+  field_channel:
+    weight: 13
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_content_group:
+    weight: 14
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
     region: content
   field_landing_page:
     weight: 6

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_site_section/config/install/field.field.taxonomy_term.cgov_site_sections.field_channel.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_site_section/config/install/field.field.taxonomy_term.cgov_site_sections.field_channel.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_channel
+    - taxonomy.vocabulary.cgov_site_sections
+id: taxonomy_term.cgov_site_sections.field_channel
+field_name: field_channel
+entity_type: taxonomy_term
+bundle: cgov_site_sections
+label: 'Channel'
+description: 'This analytics field is used to assign a channel (site section) value to content. Be sure to consult with the AARB team before modifying this field.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_site_section/config/install/field.field.taxonomy_term.cgov_site_sections.field_content_group.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_site_section/config/install/field.field.taxonomy_term.cgov_site_sections.field_content_group.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_content_group
+    - taxonomy.vocabulary.cgov_site_sections
+id: taxonomy_term.cgov_site_sections.field_content_group
+field_name: field_content_group
+entity_type: taxonomy_term
+bundle: cgov_site_sections
+label: 'Content Group'
+description: 'This analytics field is used to assign a content group value to content. Be sure to consult with the AARB team before modifying this field.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_site_section/config/install/field.storage.taxonomy_term.field_channel.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_site_section/config/install/field.storage.taxonomy_term.field_channel.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+id: taxonomy_term.field_channel
+field_name: field_channel
+entity_type: taxonomy_term
+type: string
+settings:
+  max_length: 64
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_site_section/config/install/field.storage.taxonomy_term.field_content_group.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_site_section/config/install/field.storage.taxonomy_term.field_content_group.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+id: taxonomy_term.field_content_group
+field_name: field_content_group
+entity_type: taxonomy_term
+type: string
+settings:
+  max_length: 64
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/cgov_video.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/cgov_video.info.yml
@@ -9,4 +9,6 @@ dependencies:
   - cgov_content_block
   - cgov_media
   - cgov_list
+  - metatag
+  - metatag_dc
 hidden: false

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/900_pet_nav.content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/900_pet_nav.content.yml
@@ -10,6 +10,11 @@
     - value: 'hide_in_main_nav'
     - value: 'hide_in_section_nav'
     - value: 'hide_in_mobile_nav'
+  field_channel:
+    value: 'WA Channel: Pets'
+  field_content_group:
+    value: 'WA Group: Pets'
+  field_navigation_display_options:
   parent:
     - "#process":
         callback: "reference"

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/metatag.metatag_defaults.node__pdq_cancer_information_summary.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/metatag.metatag_defaults.node__pdq_cancer_information_summary.yml
@@ -4,4 +4,5 @@ dependencies: {  }
 id: node__pdq_cancer_information_summary
 label: 'Content: PDQ Cancer Information Summary'
 tags:
-  dcterms_type:
+  dcterms_type: pdqCancerInfoSummary
+  dcterms_audience: '[node:field_pdq_audience:value]'

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/pdq_cancer_information_summary.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/pdq_cancer_information_summary.info.yml
@@ -5,5 +5,7 @@ description: 'The PDQ Cancer Information Summary content type'
 core: 8.x
 dependencies:
   - cgov_core
+  - metatag
+  - metatag_dc
   - paragraphs_asymmetric_translation_widgets
   - pdq_core

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_drug_information_summary/config/install/metatag.metatag_defaults.node__pdq_drug_information_summary.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_drug_information_summary/config/install/metatag.metatag_defaults.node__pdq_drug_information_summary.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+id: node__pdq_drug_information_summary
+label: 'Content: PDQ Drug Information Summary'
+tags:
+  dcterms_type: pdqDrugInfoSummary

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_drug_information_summary/pdq_drug_information_summary.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_drug_information_summary/pdq_drug_information_summary.info.yml
@@ -5,4 +5,6 @@ description: 'The PDQ Drug Information Summary content type'
 core: 8.x
 dependencies:
   - cgov_core
+  - metatag
+  - metatag_dc
   - pdq_core


### PR DESCRIPTION
* Added new global & content level metadata values to config
* Added configs for Event metatag
* New site_section fields for analytics (field_channel, field_content_group)
* Added cgov analytics tokens to cgov_metatag_tokens.inc 
* Added test fields for pets site section & more taxonomy token logic
* Ancestor field check for site_section taxonomy
* Logic for content items withou site section
* Utility method to find valid nodes by alias