### PR TITLE
(#1589, #1692, #1675) CTHP External Feature Card; CTHP Internal Feature Card updates; CTHP Cancer Research Card title updates

### DIFF
--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/core.entity_form_display.paragraph.cgov_cthp_feature_card_external.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/core.entity_form_display.paragraph.cgov_cthp_feature_card_external.default.yml
@@ -30,7 +30,6 @@ content:
     region: content
   field_cthp_featured_url:
     weight: 2
-    weight: 0
     settings:
       placeholder_url: ''
       placeholder_title: ''

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/core.entity_form_display.paragraph.cgov_cthp_feature_card_external.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/core.entity_form_display.paragraph.cgov_cthp_feature_card_external.default.yml
@@ -1,0 +1,66 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - entity_browser.browser.cgov_image_browser
+    - field.field.paragraph.cgov_cthp_feature_card_external.field_cthp_card_theme
+    - field.field.paragraph.cgov_cthp_feature_card_external.field_cthp_card_title
+    - field.field.paragraph.cgov_cthp_feature_card_external.field_cthp_featured_url
+    - field.field.paragraph.cgov_cthp_feature_card_external.field_cthp_override_description
+    - field.field.paragraph.cgov_cthp_feature_card_external.field_override_image_promotional
+    - paragraphs.paragraphs_type.cgov_cthp_feature_card_external
+id: paragraph.cgov_cthp_feature_card_external.default
+targetEntityType: paragraph
+bundle: cgov_cthp_feature_card_external
+mode: default
+content:
+  field_cthp_card_theme:
+    weight: 1
+    settings: {  }
+    third_party_settings: {  }
+    type: options_select
+    region: content
+  field_cthp_card_title:
+    weight: 0
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_cthp_featured_url:
+    weight: 2
+    weight: 0
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+    type: link_default
+    region: content
+  field_cthp_override_description:
+    weight: 3
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_override_image_promotional:
+    weight: 4
+    settings:
+      entity_browser: cgov_image_browser
+      field_widget_display: rendered_entity
+      field_widget_remove: true
+      field_widget_replace: false
+      selection_mode: selection_append
+      field_widget_display_settings:
+        view_mode: image_reference_field_form
+      field_widget_edit: false
+      open: false
+    third_party_settings: {  }
+    type: entity_browser_entity_reference
+    region: content
+hidden:
+  created: true
+  status: true
+  uid: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/core.entity_form_display.paragraph.cgov_cthp_feature_card_internal.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/core.entity_form_display.paragraph.cgov_cthp_feature_card_internal.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.paragraph.cgov_cthp_feature_card_internal.field_cthp_card_title
     - field.field.paragraph.cgov_cthp_feature_card_internal.field_cthp_featured_content
     - field.field.paragraph.cgov_cthp_feature_card_internal.field_cthp_override_description
+    - field.field.paragraph.cgov_cthp_feature_card_internal.field_override_image_promotional
     - paragraphs.paragraphs_type.cgov_cthp_feature_card_internal
 id: paragraph.cgov_cthp_feature_card_internal.default
 targetEntityType: paragraph
@@ -27,7 +28,7 @@ content:
     type: string_textfield
     region: content
   field_cthp_featured_content:
-    weight: 3
+    weight: 2
     settings:
       entity_browser: cgov_content_browser
       field_widget_display: label
@@ -41,12 +42,27 @@ content:
     type: entity_browser_entity_reference
     region: content
   field_cthp_override_description:
-    weight: 2
+    weight: 3
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
     type: string_textfield
+    region: content
+  field_override_image_promotional:
+    weight: 4
+    settings:
+      entity_browser: cgov_image_browser
+      field_widget_display: rendered_entity
+      field_widget_remove: true
+      field_widget_replace: false
+      selection_mode: selection_append
+      field_widget_display_settings:
+        view_mode: image_reference_field_form
+      field_widget_edit: false
+      open: false
+    third_party_settings: {  }
+    type: entity_browser_entity_reference
     region: content
 hidden:
   created: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/core.entity_form_display.paragraph.cgov_cthp_feature_card_internal.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/core.entity_form_display.paragraph.cgov_cthp_feature_card_internal.default.yml
@@ -2,14 +2,14 @@ langcode: en
 status: true
 dependencies:
   config:
-    - field.field.paragraph.cgov_cthp_feature_card.field_cthp_card_theme
-    - field.field.paragraph.cgov_cthp_feature_card.field_cthp_card_title
-    - field.field.paragraph.cgov_cthp_feature_card.field_cthp_featured_content
-    - field.field.paragraph.cgov_cthp_video_card.field_cthp_override_description
-    - paragraphs.paragraphs_type.cgov_cthp_feature_card
-id: paragraph.cgov_cthp_feature_card.default
+    - field.field.paragraph.cgov_cthp_feature_card_internal.field_cthp_card_theme
+    - field.field.paragraph.cgov_cthp_feature_card_internal.field_cthp_card_title
+    - field.field.paragraph.cgov_cthp_feature_card_internal.field_cthp_featured_content
+    - field.field.paragraph.cgov_cthp_feature_card_internal.field_cthp_override_description
+    - paragraphs.paragraphs_type.cgov_cthp_feature_card_internal
+id: paragraph.cgov_cthp_feature_card_internal.default
 targetEntityType: paragraph
-bundle: cgov_cthp_feature_card
+bundle: cgov_cthp_feature_card_internal
 mode: default
 content:
   field_cthp_card_theme:

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/core.entity_view_display.paragraph.cgov_cthp_feature_card_external.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/core.entity_view_display.paragraph.cgov_cthp_feature_card_external.default.yml
@@ -1,0 +1,62 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.cgov_cthp_feature_card_external.field_cthp_card_theme
+    - field.field.paragraph.cgov_cthp_feature_card_external.field_cthp_card_title
+    - field.field.paragraph.cgov_cthp_feature_card_external.field_cthp_featured_url
+    - field.field.paragraph.cgov_cthp_feature_card_external.field_cthp_override_description
+    - field.field.paragraph.cgov_cthp_feature_card_external.field_override_image_promotional
+    - paragraphs.paragraphs_type.cgov_cthp_feature_card_external
+  module:
+    - options
+id: paragraph.cgov_cthp_feature_card_external.default
+targetEntityType: paragraph
+bundle: cgov_cthp_feature_card_external
+mode: default
+content:
+  field_cthp_card_theme:
+    weight: 1
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: list_key
+    region: content
+  field_cthp_card_title:
+    weight: 0
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_cthp_featured_url:
+    weight: 2
+    label: hidden
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: '0'
+      target: '0'
+    third_party_settings: {  }
+    type: link_separate
+    region: content
+  field_cthp_override_description:
+    weight: 3
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_override_image_promotional:
+    type: entity_reference_entity_view
+    weight: 4
+    region: content
+    label: above
+    settings:
+      view_mode: image_crop_panoramic
+      link: false
+    third_party_settings: {  }
+hidden: {  }

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/core.entity_view_display.paragraph.cgov_cthp_feature_card_internal.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/core.entity_view_display.paragraph.cgov_cthp_feature_card_internal.default.yml
@@ -2,15 +2,16 @@ langcode: en
 status: true
 dependencies:
   config:
-    - field.field.paragraph.cgov_cthp_feature_card.field_cthp_card_theme
-    - field.field.paragraph.cgov_cthp_feature_card.field_cthp_card_title
-    - field.field.paragraph.cgov_cthp_feature_card.field_cthp_featured_content
-    - paragraphs.paragraphs_type.cgov_cthp_feature_card
+    - field.field.paragraph.cgov_cthp_feature_card_internal.field_cthp_card_theme
+    - field.field.paragraph.cgov_cthp_feature_card_internal.field_cthp_card_title
+    - field.field.paragraph.cgov_cthp_feature_card_internal.field_cthp_featured_content
+    - field.field.paragraph.cgov_cthp_feature_card_internal.field_cthp_override_description
+    - paragraphs.paragraphs_type.cgov_cthp_feature_card_internal
   module:
     - options
-id: paragraph.cgov_cthp_feature_card.default
+id: paragraph.cgov_cthp_feature_card_internal.default
 targetEntityType: paragraph
-bundle: cgov_cthp_feature_card
+bundle: cgov_cthp_feature_card_internal
 mode: default
 content:
   field_cthp_card_theme:

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/core.entity_view_display.paragraph.cgov_cthp_feature_card_internal.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/core.entity_view_display.paragraph.cgov_cthp_feature_card_internal.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.paragraph.cgov_cthp_feature_card_internal.field_cthp_card_title
     - field.field.paragraph.cgov_cthp_feature_card_internal.field_cthp_featured_content
     - field.field.paragraph.cgov_cthp_feature_card_internal.field_cthp_override_description
+    - field.field.paragraph.cgov_cthp_feature_card_internal.field_override_image_promotional
     - paragraphs.paragraphs_type.cgov_cthp_feature_card_internal
   module:
     - options
@@ -46,4 +47,13 @@ content:
     third_party_settings: {  }
     type: string
     region: content
+  field_override_image_promotional:
+    type: entity_reference_entity_view
+    weight: 4
+    region: content
+    label: above
+    settings:
+      view_mode: image_crop_panoramic
+      link: false
+    third_party_settings: {  }
 hidden: {  }

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/field.field.node.cgov_cthp.field_cthp_cards.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/field.field.node.cgov_cthp.field_cthp_cards.yml
@@ -5,7 +5,7 @@ dependencies:
     - field.storage.node.field_cthp_cards
     - node.type.cgov_cthp
     - paragraphs.paragraphs_type.cgov_cthp_block_card
-    - paragraphs.paragraphs_type.cgov_cthp_feature_card
+    - paragraphs.paragraphs_type.cgov_cthp_feature_card_internal
     - paragraphs.paragraphs_type.cgov_cthp_guide_card
     - paragraphs.paragraphs_type.cgov_cthp_overview_card
     - paragraphs.paragraphs_type.cgov_cthp_raw_html_card
@@ -29,7 +29,8 @@ settings:
     negate: 0
     target_bundles:
       cgov_cthp_block_card: cgov_cthp_block_card
-      cgov_cthp_feature_card: cgov_cthp_feature_card
+      cgov_cthp_feature_card_external: cgov_cthp_feature_card_external
+      cgov_cthp_feature_card_internal: cgov_cthp_feature_card_internal
       cgov_cthp_guide_card: cgov_cthp_guide_card
       cgov_cthp_overview_card: cgov_cthp_overview_card
       cgov_cthp_raw_html_card: cgov_cthp_raw_html_card
@@ -59,8 +60,11 @@ settings:
         enabled: false
       cgov_cthp_block_card:
         enabled: true
-        weight: 35
-      cgov_cthp_feature_card:
+        weight: 36
+      cgov_cthp_feature_card_external:
+        enabled: true
+        weight: 33
+      cgov_cthp_feature_card_internal:
         enabled: true
         weight: 32
       cgov_cthp_guide_card:
@@ -71,35 +75,35 @@ settings:
         weight: 30
       cgov_cthp_raw_html_card:
         enabled: true
-        weight: 36
+        weight: 37
       cgov_cthp_research_card:
         enabled: true
-        weight: 34
+        weight: 35
       cgov_cthp_video_card:
         enabled: true
-        weight: 33
+        weight: 34
       cgov_external_link:
-        weight: 37
-        enabled: false
-      cgov_guide_row:
         weight: 38
         enabled: false
-      cgov_internal_link:
+      cgov_guide_row:
         weight: 39
         enabled: false
-      cgov_primary_feature_row:
+      cgov_internal_link:
         weight: 40
         enabled: false
-      cgov_secondary_feature_row:
+      cgov_primary_feature_row:
         weight: 41
         enabled: false
-      cgov_thumbnail_row:
+      cgov_secondary_feature_row:
         weight: 42
         enabled: false
-      cgov_two_item_feature_row:
+      cgov_thumbnail_row:
         weight: 43
         enabled: false
-      pdq_summary_section:
+      cgov_two_item_feature_row:
         weight: 44
+        enabled: false
+      pdq_summary_section:
+        weight: 45
         enabled: false
 field_type: entity_reference_revisions

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/field.field.paragraph.cgov_cthp_feature_card_external.field_cthp_card_theme.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/field.field.paragraph.cgov_cthp_feature_card_external.field_cthp_card_theme.yml
@@ -3,13 +3,13 @@ status: true
 dependencies:
   config:
     - field.storage.paragraph.field_cthp_card_theme
-    - paragraphs.paragraphs_type.cgov_cthp_feature_card
+    - paragraphs.paragraphs_type.cgov_cthp_feature_card_external
   module:
     - options
-id: paragraph.cgov_cthp_feature_card.field_cthp_card_theme
+id: paragraph.cgov_cthp_feature_card_external.field_cthp_card_theme
 field_name: field_cthp_card_theme
 entity_type: paragraph
-bundle: cgov_cthp_feature_card
+bundle: cgov_cthp_feature_card_external
 label: 'CTHP Card Theme'
 description: ''
 required: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/field.field.paragraph.cgov_cthp_feature_card_external.field_cthp_card_title.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/field.field.paragraph.cgov_cthp_feature_card_external.field_cthp_card_title.yml
@@ -3,11 +3,11 @@ status: true
 dependencies:
   config:
     - field.storage.paragraph.field_cthp_card_title
-    - paragraphs.paragraphs_type.cgov_cthp_feature_card
-id: paragraph.cgov_cthp_feature_card.field_cthp_card_title
+    - paragraphs.paragraphs_type.cgov_cthp_feature_card_external
+id: paragraph.cgov_cthp_feature_card_external.field_cthp_card_title
 field_name: field_cthp_card_title
 entity_type: paragraph
-bundle: cgov_cthp_feature_card
+bundle: cgov_cthp_feature_card_external
 label: 'CTHP Card Title'
 description: ''
 required: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/field.field.paragraph.cgov_cthp_feature_card_external.field_cthp_featured_url.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/field.field.paragraph.cgov_cthp_feature_card_external.field_cthp_featured_url.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_cthp_featured_url
+    - paragraphs.paragraphs_type.cgov_cthp_feature_card_external
+  module:
+    - link
+id: paragraph.cgov_cthp_feature_card_external.field_cthp_featured_url
+field_name: field_cthp_featured_url
+entity_type: paragraph
+bundle: cgov_cthp_feature_card_external
+label: External Link
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  link_type: 16
+  title: 0
+field_type: link

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/field.field.paragraph.cgov_cthp_feature_card_external.field_cthp_override_description.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/field.field.paragraph.cgov_cthp_feature_card_external.field_cthp_override_description.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_cthp_override_description
+    - paragraphs.paragraphs_type.cgov_cthp_feature_card_external
+id: paragraph.cgov_cthp_feature_card_external.field_cthp_override_description
+field_name: field_cthp_override_description
+entity_type: paragraph
+bundle: cgov_cthp_feature_card_external
+label: 'Override Card Description'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/field.field.paragraph.cgov_cthp_feature_card_external.field_override_image_promotional.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/field.field.paragraph.cgov_cthp_feature_card_external.field_override_image_promotional.yml
@@ -1,0 +1,27 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_override_image_promotional
+    - media.type.cgov_image
+    - paragraphs.paragraphs_type.cgov_cthp_feature_card_external
+id: paragraph.cgov_cthp_feature_card_external.field_override_image_promotional
+field_name: field_override_image_promotional
+entity_type: paragraph
+bundle: cgov_cthp_feature_card_external
+label: 'Promotional Image'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      cgov_image: cgov_image
+    sort:
+      field: _none
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/field.field.paragraph.cgov_cthp_feature_card_internal.field_cthp_card_theme.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/field.field.paragraph.cgov_cthp_feature_card_internal.field_cthp_card_theme.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_cthp_card_theme
+    - paragraphs.paragraphs_type.cgov_cthp_feature_card_internal
+  module:
+    - options
+id: paragraph.cgov_cthp_feature_card_internal.field_cthp_card_theme
+field_name: field_cthp_card_theme
+entity_type: paragraph
+bundle: cgov_cthp_feature_card_internal
+label: 'CTHP Card Theme'
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/field.field.paragraph.cgov_cthp_feature_card_internal.field_cthp_card_title.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/field.field.paragraph.cgov_cthp_feature_card_internal.field_cthp_card_title.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_cthp_card_title
+    - paragraphs.paragraphs_type.cgov_cthp_feature_card_internal
+id: paragraph.cgov_cthp_feature_card_internal.field_cthp_card_title
+field_name: field_cthp_card_title
+entity_type: paragraph
+bundle: cgov_cthp_feature_card_internal
+label: 'CTHP Card Title'
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/field.field.paragraph.cgov_cthp_feature_card_internal.field_cthp_featured_content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/field.field.paragraph.cgov_cthp_feature_card_internal.field_cthp_featured_content.yml
@@ -3,11 +3,11 @@ status: true
 dependencies:
   config:
     - field.storage.paragraph.field_cthp_featured_content
-    - paragraphs.paragraphs_type.cgov_cthp_feature_card
-id: paragraph.cgov_cthp_feature_card.field_cthp_featured_content
+    - paragraphs.paragraphs_type.cgov_cthp_feature_card_internal
+id: paragraph.cgov_cthp_feature_card_internal.field_cthp_featured_content
 field_name: field_cthp_featured_content
 entity_type: paragraph
-bundle: cgov_cthp_feature_card
+bundle: cgov_cthp_feature_card_internal
 label: 'Featured Content'
 description: ''
 required: false

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/field.field.paragraph.cgov_cthp_feature_card_internal.field_cthp_override_description.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/field.field.paragraph.cgov_cthp_feature_card_internal.field_cthp_override_description.yml
@@ -3,11 +3,11 @@ status: true
 dependencies:
   config:
     - field.storage.paragraph.field_cthp_override_description
-    - paragraphs.paragraphs_type.cgov_cthp_feature_card
-id: paragraph.cgov_cthp_video_card.field_cthp_override_description
+    - paragraphs.paragraphs_type.cgov_cthp_feature_card_internal
+id: paragraph.cgov_cthp_feature_card_internal.field_cthp_override_description
 field_name: field_cthp_override_description
 entity_type: paragraph
-bundle: cgov_cthp_feature_card
+bundle: cgov_cthp_feature_card_internal
 label: 'Override Card Description'
 description: ''
 required: false

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/field.field.paragraph.cgov_cthp_feature_card_internal.field_override_image_promotional.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/field.field.paragraph.cgov_cthp_feature_card_internal.field_override_image_promotional.yml
@@ -1,0 +1,27 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_override_image_promotional
+    - media.type.cgov_image
+    - paragraphs.paragraphs_type.cgov_cthp_feature_card_internal
+id: paragraph.cgov_cthp_feature_card_internal.field_override_image_promotional
+field_name: field_override_image_promotional
+entity_type: paragraph
+bundle: cgov_cthp_feature_card_internal
+label: 'Promotional Image'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      cgov_image: cgov_image
+    sort:
+      field: _none
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/field.storage.paragraph.field_cthp_featured_url.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/field.storage.paragraph.field_cthp_featured_url.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - link
+    - paragraphs
+id: paragraph.field_cthp_featured_url
+field_name: field_cthp_featured_url
+entity_type: paragraph
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/paragraphs.paragraphs_type.cgov_cthp_feature_card.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/paragraphs.paragraphs_type.cgov_cthp_feature_card.yml
@@ -1,8 +1,0 @@
-langcode: en
-status: true
-dependencies: {  }
-id: cgov_cthp_feature_card
-label: 'CTHP Feature Card'
-icon_uuid: null
-description: 'Feature Card to display on CTHP'
-behavior_plugins: {  }

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/paragraphs.paragraphs_type.cgov_cthp_feature_card_external.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/paragraphs.paragraphs_type.cgov_cthp_feature_card_external.yml
@@ -1,0 +1,8 @@
+langcode: en
+status: true
+dependencies: {  }
+id: cgov_cthp_feature_card_external
+label: 'CTHP External Feature Card'
+icon_uuid: null
+description: 'External Feature Card to display on CTHP'
+behavior_plugins: {  }

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/paragraphs.paragraphs_type.cgov_cthp_feature_card_internal.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/paragraphs.paragraphs_type.cgov_cthp_feature_card_internal.yml
@@ -1,0 +1,8 @@
+langcode: en
+status: true
+dependencies: {  }
+id: cgov_cthp_feature_card_internal
+label: 'CTHP Internal Feature Card'
+icon_uuid: null
+description: 'Internal Feature Card to display on CTHP'
+behavior_plugins: {  }

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/z041_breast-hp.content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/z041_breast-hp.content.yml
@@ -165,33 +165,6 @@
                   - type: 'pdq_cancer_information_summary'
                     title: 'Genetics of Breast and Gynecologic Cancers (PDQ®)–Health Professional Version'
     - entity: 'paragraph'
-      type: "cgov_cthp_video_card"
-      field_cthp_card_title:
-        - value: 'Statistics'
-      field_cthp_card_theme:
-        - value: 'cthp-survival'
-      field_cthp_override_description:
-        - value: "Breast cancer statistics based on data from large groups of patients to be used as a general guide."
-      field_cthp_video:
-        - target_type: 'media'
-          '#process':
-            callback: 'reference'
-            args:
-              - 'media'
-              - bundle: 'cgov_video'
-                name: 'Hedge Maze'
-      field_cthp_target_link:
-        - entity: 'paragraph'
-          type: "cgov_internal_link"
-          field_internal_link:
-            - target_type: 'node'
-              '#process':
-                callback: 'reference'
-                args:
-                  - 'node'
-                  - type: 'cgov_home_landing'
-                    title: 'Cancer Types'
-    - entity: 'paragraph'
       type: "cgov_cthp_block_card"
       field_cthp_card_title:
         - value: 'Supportive & Palliative Care'
@@ -219,7 +192,25 @@
               - type: 'cgov_cancer_research'
                 title: 'Breast Cancer Research'
     - entity: 'paragraph'
-      type: "cgov_cthp_feature_card"
+      type: "cgov_cthp_feature_card_external"
+      field_cthp_card_title:
+        - value: 'Statistics'
+      field_cthp_card_theme:
+        - value: 'cthp-survival'
+      field_cthp_override_description:
+        - value: "Breast cancer statistics based on data from large groups of patients to be used as a general guide."
+      field_cthp_featured_url:
+        - uri: 'https://seer.cancer.gov/statfacts/html/breast.html'
+      field_override_image_promotional:
+            - target_type: 'media'
+              '#process':
+                callback: 'reference'
+                args:
+                  - 'media'
+                  - bundle: 'cgov_image'
+                    name: 'Lead Placeholder'
+    - entity: 'paragraph'
+      type: "cgov_cthp_feature_card_internal"
       field_cthp_card_title:
         - value: 'Breast Reconstruction Options'
       field_cthp_card_theme:

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/entrypoints/cthp/CTHP.scss
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/entrypoints/cthp/CTHP.scss
@@ -142,15 +142,24 @@
   }
 }
 
+
 .cthp-pdq-label {
   margin-top: 0;
 }
 
-.cardBody p {
-  font-size: 1em;
+.cardBody {
+  p {
+    font-size: 1em;
 
-  &:first-child {
-    margin-top: 0;
+    &:first-child {
+      margin-top: 0;
+    }
+  }
+
+  > a {
+    &:last-child {
+      margin-bottom: 1.25em;
+    }
   }
 }
 

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/libraries/exitDisclaimer/exitDisclaimer.js
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/libraries/exitDisclaimer/exitDisclaimer.js
@@ -40,12 +40,6 @@ function _initialize() {
 
 	// move the feature card exit notification within the dom to come right after the image in the feature card to meet design request, WCMSFEQ-282
 	$('.feature-card a.icon-exit-notification').insertAfter('.feature-card a:not([href^="/"]):not([href*=".gov"]) div img');
-
-	// Create a div around the CTHP card image so that we can position the exit disclaimer to it, then move the exit disclaimer inside the newly created div, WCMSFEQ-423
-	$('.cgvcancertypehome .cthpCard div h3 + div > a:not([class="icon-exit-notification"])')
-		.wrapInner("<div class='cthp-card-image'></div>");
-	$('.cgvcancertypehome .cthpCard div div a.icon-exit-notification').first()
-		.insertAfter('.cgvcancertypehome .cthpCard div div > a:not([href^="/"]):not([href*=".gov"]) div img');
 };
 
 let initialized = false;

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/cthp/paragraph--cgov-cthp-feature-card-external.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/cthp/paragraph--cgov-cthp-feature-card-external.html.twig
@@ -1,0 +1,30 @@
+{% if content.field_cthp_featured_url[0] %}
+  {# ###### Setup Description ####### #}
+  {% if content.field_cthp_override_description|field_value %}
+    {% set description = content.field_cthp_override_description|field_value %}
+  {% endif %}
+
+  {# ###### Setup Img ######## #}
+  {% if content.field_override_image_promotional[0] %}
+    {% set image = content.field_override_image_promotional %}
+  {% endif %}
+
+  {# ###### Setup the URL ###### #}
+  {% set url = content.field_cthp_featured_url[0]['#url'] %}
+{% endif %}
+
+<div class="equalheight bgWhite {{ content.field_cthp_card_theme|field_value }}">
+  <h2>{{ content.field_cthp_card_title}}</h2>
+  <div>
+    {% if image %}
+      <div class="cthp-card-image">
+        <a href="{{ url }}">{{ image }}</a>
+      </div>
+    {% endif %}
+    {% if description %}
+      <div class="cardBody">
+        <a href="{{ url }}" class="arrow-link">{{ description }}</a>
+      </div>
+    {% endif %}
+  </div>
+</div>

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/cthp/paragraph--cgov-cthp-feature-card-internal.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/cthp/paragraph--cgov-cthp-feature-card-internal.html.twig
@@ -1,4 +1,11 @@
 {% set url = path('entity.node.canonical', {'node':  content.field_cthp_featured_content[0]["#node"].nid[0].value}) %}
+
+{% if content.field_override_image_promotional[0] %}
+  {% set image = content.field_override_image_promotional %}
+{% else %}
+  {% set image = content.field_cthp_featured_content %}
+{% endif %}
+
 {% if content.field_cthp_override_description|field_value %}
   {% set description = content.field_cthp_override_description %}
 {% elseif content.field_cthp_featured_content[0]["#node"].field_feature_card_description[0] %}
@@ -10,7 +17,7 @@
 <div class="equalheight bgWhite {{ content.field_cthp_card_theme|field_value }}">
   <h2>{{ content.field_cthp_card_title}}</h2>
   <div>
-    <a href="{{ url }}">{{ content.field_cthp_featured_content }}</a>
+    <a href="{{ url }}">{{ image }}</a>
     {% if description %}
       <div class="cardBody">
         <a href="{{ url }}" class="arrow-link">{{ description }}</a>

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/cthp/paragraph--cgov-cthp-feature-card-internal.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/cthp/paragraph--cgov-cthp-feature-card-internal.html.twig
@@ -13,11 +13,7 @@
     <a href="{{ url }}">{{ content.field_cthp_featured_content }}</a>
     {% if description %}
       <div class="cardBody">
-        <ul>
-          <li>
-            <a href="{{ url }}" class="arrow-link">{{ description }}</a>
-          </li>
-        </ul>
+        <a href="{{ url }}" class="arrow-link">{{ description }}</a>
       </div>
     {% endif %}
   </div>

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/listing/paragraph--cgov-internal-link--cthp-research-card-list-item.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/listing/paragraph--cgov-internal-link--cthp-research-card-list-item.html.twig
@@ -5,7 +5,7 @@
   {% if content.field_override_title|field_value %}
     {% set title = content.field_override_title|field_value %}
   {% else %}
-    {% set title = content.field_internal_link[0]["#node"].field_browser_title[0].value %}
+    {% set title = content.field_internal_link[0]["#node"].title.value %}
   {% endif %}
 
   {# ###### Setup the URL ###### #}


### PR DESCRIPTION
Closes #1589
- [ ] Rename CTHP Feature Card to CTHP Internal Feature Card
- [ ] Rename field/form display/view display for CTHP Internal Feature Card
- [ ] Rename paragraph template for CTHP Internal Feature Card
- [ ] Create CTHP External Feature Card paragraph type
- [ ] Add required field storage/definitions for CTHP External Feature Card
- [ ] Add form/view display for CTHP External Feature Card
- [ ] Add paragraph template for CTHP External Feature Card
- [ ] Allow CTHP External Feature Card paragraph types in CTHP Cards
- [ ] Update CTHP YAML content to include CTHP External Feature Card

Closes #1692
- [ ] Add override image promotional field to CTHP Internal Feature Card
- [ ] Reorder fields on CTHP Internal Feature Card form
- [ ] Display override img promotional if set on CTHP Internal Feature Card

Closes #1675
- [ ] Page title instead of short title (RIP) on CTHP Cancer Research Card

Per discussion with @lburack and @VictoriaSunNIH ,
image DOES NOT receive purple exit disclaimer icon