### PR TITLE
(#1675) Use page title in Cancer Research Lists

### DIFF
--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/listing/paragraph--cgov-internal-link--cthp-research-card-list-item.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/listing/paragraph--cgov-internal-link--cthp-research-card-list-item.html.twig
@@ -5,7 +5,7 @@
   {% if content.field_override_title|field_value %}
     {% set title = content.field_override_title|field_value %}
   {% else %}
-    {% set title = content.field_internal_link[0]["#node"].field_browser_title[0].value %}
+    {% set title = content.field_internal_link[0]["#node"].title.value %}
   {% endif %}
 
   {# ###### Setup the URL ###### #}


### PR DESCRIPTION
* Page title instead of short title (RIP) on CTHP Cancer Research Card
* Closes #1675