### PR TITLE
(#1198) Drop duplicates from press release rss feed

### DIFF
--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/config/install/views.view.blog_rss.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/config/install/views.view.blog_rss.yml
@@ -985,7 +985,7 @@ display:
           plugin_id: bundle
         langcode:
           id: langcode
-          table: node_field_revision
+          table: node_field_data
           field: langcode
           relationship: none
           group_type: group

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/views.view.press_release_rss.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/views.view.press_release_rss.yml
@@ -677,72 +677,6 @@ display:
           entity_type: node
           entity_field: nid
           plugin_id: field
-        langcode:
-          id: langcode
-          table: node_field_revision
-          field: langcode
-          relationship: none
-          group_type: group
-          admin_label: ''
-          label: 'Translation language'
-          exclude: false
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: true
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          click_sort_column: value
-          type: language
-          settings:
-            link_to_entity: false
-            native_language: false
-          group_column: value
-          group_columns: {  }
-          group_rows: true
-          delta_limit: 0
-          delta_offset: 0
-          delta_reversed: false
-          delta_first_last: false
-          multi_type: separator
-          separator: ', '
-          field_api_classes: false
-          entity_type: node
-          entity_field: langcode
-          plugin_id: field
         langcode_1:
           id: langcode_1
           table: node_field_data
@@ -916,7 +850,7 @@ display:
           plugin_id: bundle
         langcode:
           id: langcode
-          table: node_field_revision
+          table: node_field_data
           field: langcode
           relationship: none
           group_type: group

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/views.view.press_releases.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/views.view.press_releases.yml
@@ -148,7 +148,7 @@ display:
           plugin_id: bundle
         langcode:
           id: langcode
-          table: node_field_revision
+          table: node_field_data
           field: langcode
           relationship: none
           group_type: group


### PR DESCRIPTION
Closes #1198 
Closes #1712 
Closes #1713 

Uses the content posted date instead of the content revision posted date.