### PR TITLE
(#1705) Blog topic intro text/description field display fix

### DIFF
--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/blog/block--cgov-blog-topic-intro.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/blog/block--cgov-blog-topic-intro.html.twig
@@ -2,7 +2,7 @@
   {% for title, desc in content['#topic_intros'] %}
     {% if title == label and desc|length > 0 %}
       <div class="blog-intro-text">
-        <p>{{desc}}</p>
+        {{desc|raw}}
       </div>
     {% endif %}
   {% endfor %}

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/src/styles/_blogs.scss
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/src/styles/_blogs.scss
@@ -149,15 +149,16 @@ p.blog-post-publishing-info {
 	padding: 1em 1.25em;
 	border-left: 3px solid $purple;
 	background-color: $white03;
+	font-size: 0.8em;
+	font-family: $montserrat-font-stack;
 
 	p {
 		margin: 0;
 		padding-bottom: 1em;
-		font-size: 0.8em;
-		font-family: $montserrat-font-stack;
-	}
-	p:last-child {
-		padding: 0;
+
+		&:last-child {
+			padding: 0;
+		}
 	}
 }
 


### PR DESCRIPTION
Closes #1705 

When FullHTML or RawHTML were selected for the description field, the tags were showing up as part of the rendered string.  Adding raw filter so that the description is unescaped.