### PR TITLE
(#1362) Fix url alias for new infographics.

### DIFF
--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_infographic/cgov_infographic.module
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_infographic/cgov_infographic.module
@@ -32,7 +32,7 @@ function cgov_infographic_media_view(array &$build, EntityInterface $entity, Ent
   // reference field (promotional image) and hoist those to the
   // top level of the infographic render array so that we have access to
   // the rendered values in the infographic templates (while we can access
-  // the infographic.field_image_promotional fields, they are in a prerender
+  // the infographic.field_image_promotional fields, they are in a pre-render
   // state which makes certain properties inaccessible.)
   $aliasedFieldsToExtractFromPromotionalImage = [
     'caption' => 'field_caption',

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_infographic/config/install/core.entity_form_display.media.cgov_infographic.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_infographic/config/install/core.entity_form_display.media.cgov_infographic.default.yml
@@ -29,6 +29,7 @@ dependencies:
     - datetime
     - entity_browser
     - image
+    - path
     - text
 id: media.cgov_infographic.default
 targetEntityType: media
@@ -194,6 +195,12 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+  path:
+    type: path
+    weight: 23
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   status:
     type: boolean_checkbox
     settings:
@@ -209,5 +216,4 @@ content:
 hidden:
   created: true
   field_meta_tags: true
-  path: true
   uid: true


### PR DESCRIPTION
Closes #1362 

Enables the url_alias field for the infographic form display mode. 

ODE: http://ncigovcdode139.prod.acquia-sites.com
