### PR TITLE
(#1720) PDQ listing page styling 

### DIFF
--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/entrypoints/article/Article.scss
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/entrypoints/article/Article.scss
@@ -1,1 +1,41 @@
-@import '~Core/styles/feature_cards';
+@import "~Core/styles/feature_cards";
+
+// PDQ summary list styling ported from InnerPage.scss
+.contentzone {
+  .PDQ-list {
+    padding-left: 0;
+
+    li {
+      background-image: none;
+      margin-left: 0;
+      padding-left: 0;
+
+      &::before {
+        content: none;
+      }
+    }
+
+    ul {
+      margin-left: 0;
+      margin-top: 3px;
+      padding-left: 20px;
+
+      > li {
+        display: inline;
+
+        &::before {
+          content: "|";
+          float: none;
+          padding-left: 20px;
+          padding-right: 5px;
+          top: 0;
+        }
+
+        &:first-child::before {
+          content: none;
+          display: none;
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Closes #1720 

Bringing over unported styles for PDQ lists from InnerPage.scss and adding them to Article.scss
