### PR TITLE
(NCIOCPL#1678) Browser title is missing from Drug Info Summaries

### DIFF
--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/pdq_dis.content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/pdq_dis.content.yml
@@ -3,6 +3,7 @@
   status: 1
   langcode: en
   title: 'Bevacizumab'
+  field_browser_title: 'Bevacizumab'
   moderation_state:
     value: published
   field_pdq_url:
@@ -39,6 +40,7 @@
   status: 1
   langcode: en
   title: 'BEP'
+  field_browser_title: 'BEP'
   moderation_state:
     value: published
   field_pdq_url:
@@ -81,6 +83,7 @@
   status: 1
   langcode: en
   title: 'Blinatumomab'
+  field_browser_title: 'Blinatumomab'
   moderation_state:
     value: published
   field_pdq_url:

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_drug_information_summary/config/install/core.entity_form_display.node.pdq_drug_information_summary.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_drug_information_summary/config/install/core.entity_form_display.node.pdq_drug_information_summary.default.yml
@@ -3,8 +3,10 @@ status: true
 dependencies:
   config:
     - field.field.node.pdq_drug_information_summary.body
+    - field.field.node.pdq_drug_information_summary.field_browser_title
     - field.field.node.pdq_drug_information_summary.field_date_posted
     - field.field.node.pdq_drug_information_summary.field_date_updated
+    - field.field.node.pdq_drug_information_summary.field_meta_tags
     - field.field.node.pdq_drug_information_summary.field_page_description
     - field.field.node.pdq_drug_information_summary.field_pdq_audio_id
     - field.field.node.pdq_drug_information_summary.field_pdq_cdr_id
@@ -27,7 +29,7 @@ bundle: pdq_drug_information_summary
 mode: default
 content:
   body:
-    weight: 120
+    weight: 16
     settings:
       rows: 9
       summary_rows: 3
@@ -37,24 +39,32 @@ content:
     region: content
   created:
     type: datetime_timestamp
-    weight: 3
+    weight: 4
     region: content
     settings: {  }
     third_party_settings: {  }
+  field_browser_title:
+    weight: 1
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
   field_date_posted:
-    weight: 102
+    weight: 12
     settings: {  }
     third_party_settings: {  }
     type: datetime_default
     region: content
   field_date_updated:
-    weight: 103
+    weight: 13
     settings: {  }
     third_party_settings: {  }
     type: datetime_default
     region: content
   field_page_description:
-    weight: 110
+    weight: 15
     settings:
       size: 60
       placeholder: ''
@@ -62,21 +72,21 @@ content:
     type: string_textfield
     region: content
   field_pdq_audio_id:
-    weight: 131
+    weight: 18
     settings:
       placeholder: ''
     third_party_settings: {  }
     type: number
     region: content
   field_pdq_cdr_id:
-    weight: 106
+    weight: 14
     settings:
       placeholder: ''
     third_party_settings: {  }
     type: number
     region: content
   field_pdq_pronunciation_key:
-    weight: 132
+    weight: 19
     settings:
       size: 60
       placeholder: ''
@@ -84,7 +94,7 @@ content:
     type: string_textfield
     region: content
   field_pdq_url:
-    weight: 133
+    weight: 20
     settings:
       size: 60
       placeholder: ''
@@ -92,28 +102,27 @@ content:
     type: string_textfield
     region: content
   field_public_use:
-    weight: 130
-    settings:
-      display_label: true
+    weight: 17
+    settings: {  }
     third_party_settings: {  }
-    type: boolean_checkbox
+    type: options_select
     region: content
   langcode:
     type: language_select
-    weight: 1
+    weight: 2
     region: content
     settings:
       include_locked: true
     third_party_settings: {  }
   moderation_state:
     type: moderation_state_default
-    weight: 8
+    weight: 9
     settings: {  }
     region: content
     third_party_settings: {  }
   path:
     type: path
-    weight: 7
+    weight: 8
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -121,21 +130,21 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 5
+    weight: 6
     region: content
     third_party_settings: {  }
   status:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 9
+    weight: 10
     region: content
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 6
+    weight: 7
     region: content
     third_party_settings: {  }
   title:
@@ -147,13 +156,13 @@ content:
       placeholder: ''
     third_party_settings: {  }
   translation:
-    weight: 4
+    weight: 5
     region: content
     settings: {  }
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 2
+    weight: 3
     settings:
       match_operator: CONTAINS
       size: 60

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_drug_information_summary/config/install/core.entity_view_display.node.pdq_drug_information_summary.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_drug_information_summary/config/install/core.entity_view_display.node.pdq_drug_information_summary.default.yml
@@ -3,8 +3,10 @@ status: true
 dependencies:
   config:
     - field.field.node.pdq_drug_information_summary.body
+    - field.field.node.pdq_drug_information_summary.field_browser_title
     - field.field.node.pdq_drug_information_summary.field_date_posted
     - field.field.node.pdq_drug_information_summary.field_date_updated
+    - field.field.node.pdq_drug_information_summary.field_meta_tags
     - field.field.node.pdq_drug_information_summary.field_page_description
     - field.field.node.pdq_drug_information_summary.field_pdq_audio_id
     - field.field.node.pdq_drug_information_summary.field_pdq_cdr_id
@@ -35,6 +37,14 @@ content:
     weight: -20
     settings: {  }
     third_party_settings: {  }
+    region: content
+  field_browser_title:
+    weight: 3
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
     region: content
   field_date_updated:
     weight: 103

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_drug_information_summary/config/install/core.entity_view_display.node.pdq_drug_information_summary.teaser.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_drug_information_summary/config/install/core.entity_view_display.node.pdq_drug_information_summary.teaser.yml
@@ -4,12 +4,15 @@ dependencies:
   config:
     - core.entity_view_mode.node.teaser
     - field.field.node.pdq_drug_information_summary.body
+    - field.field.node.pdq_drug_information_summary.field_browser_title
     - field.field.node.pdq_drug_information_summary.field_date_posted
     - field.field.node.pdq_drug_information_summary.field_date_updated
+    - field.field.node.pdq_drug_information_summary.field_meta_tags
     - field.field.node.pdq_drug_information_summary.field_page_description
     - field.field.node.pdq_drug_information_summary.field_pdq_audio_id
     - field.field.node.pdq_drug_information_summary.field_pdq_cdr_id
     - field.field.node.pdq_drug_information_summary.field_pdq_pronunciation_key
+    - field.field.node.pdq_drug_information_summary.field_pdq_url
     - field.field.node.pdq_drug_information_summary.field_public_use
     - node.type.pdq_drug_information_summary
   module:
@@ -26,11 +29,14 @@ content:
     region: content
 hidden:
   body: true
+  field_browser_title: true
   field_date_posted: true
   field_date_updated: true
+  field_meta_tags: true
   field_page_description: true
   field_pdq_audio_id: true
   field_pdq_cdr_id: true
   field_pdq_pronunciation_key: true
+  field_pdq_url: true
   field_public_use: true
   langcode: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_drug_information_summary/config/install/field.field.node.pdq_drug_information_summary.field_browser_title.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_drug_information_summary/config/install/field.field.node.pdq_drug_information_summary.field_browser_title.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_browser_title
+    - node.type.pdq_drug_information_summary
+id: node.pdq_drug_information_summary.field_browser_title
+field_name: field_browser_title
+entity_type: node
+bundle: pdq_drug_information_summary
+label: 'Browser Title'
+description: 'Browser title for the page. Site name is automatically appended (Browser Title - National Cancer Institute) [Displays in: internal and external search results, browser tabs, social media sharing, and when card title is blank. SEO best practice - 42 characters including spaces]'
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_drug_information_summary/pdq_drug_information_summary.module
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_drug_information_summary/pdq_drug_information_summary.module
@@ -4,3 +4,17 @@
  * @file
  * Contains pdq_drug_information_summary.module.
  */
+
+/**
+ * Implements hook_field_widget_form_alter().
+ *
+ * Limits allowed text formats using the cgov_util form_tools service.
+ */
+function pdq_drug_information_summary_field_widget_form_alter(&$element, $form_state, $context) {
+  // Maps field names to an array containing a single format.
+  $map = [
+    'body' => ['raw_html'],
+  ];
+  $formHelper = \Drupal::service('cgov_util.form_tools');
+  $formHelper->allowTextFormats($map, $element, $context);
+}

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_drug_information_summary/src/Plugin/rest/resource/PDQResource.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_drug_information_summary/src/Plugin/rest/resource/PDQResource.php
@@ -111,6 +111,7 @@ class PDQResource extends ResourceBase {
       'created' => date('c', $node->getCreatedTime()),
       'cdr_id' => $node->field_pdq_cdr_id->value,
       'title' => $node->getTitle(),
+      'browser_title' => $node->field_browser_title->value,
       'body' => $node->body->value,
       'description' => $node->field_page_description->value,
       'posted_date' => $node->field_date_posted->value,
@@ -182,6 +183,7 @@ class PDQResource extends ResourceBase {
     $node->set('field_pdq_audio_id', $drug['audio_id']);
     $node->set('field_pdq_pronunciation_key', $drug['pron']);
     $node->set('field_public_use', 0);
+    $node->set('field_browser_title', $drug['title']);
 
     // Store the node, leaving it unpublished. We'll make all of the
     // nodes published in a separate pass after they've all been


### PR DESCRIPTION
- Add field_browser_title to Drug Info Summaries.
- Load field_browser_title via the API.
- Add hook_field_widget_form_alter to control body field's input format.
- Connect field_meta_tags and field_pdq_url to forms/views.

Closes: #1678