### PR TITLE
(#1670, #1663, #1719, #1639) Meta description updates; missing media meta tags; browser title and og:site_name meta tags

### DIFF
--- a/docroot/profiles/custom/cgov_site/config/install/metatag.metatag_defaults.global.yml
+++ b/docroot/profiles/custom/cgov_site/config/install/metatag.metatag_defaults.global.yml
@@ -5,12 +5,12 @@ id: global
 label: Global
 tags:
   canonical_url: '[current-page:url]'
-  title: '[cgov_tokens:cgov-title] - [site:name]'
+  title: '[cgov_tokens:cgov-title] - [cgov_tokens:cgov-trans-org-name]'
   dcterms_coverage: 'nciglobal,ncienterprise'
   dcterms_subject: '[cgov_tokens:cgov-analytics-channel]'
   dcterms_is_part_of: '[cgov_tokens:cgov-analytics-group]'
   og_image: '[cgov_tokens:cgov-og-image]'
-  og_site_name: 'National Cancer Institute'
+  og_site_name: '[cgov_tokens:cgov-og-site-name]'
   og_type: Website
   og_url: '[current-page:url]'
   twitter_cards_type: summary

--- a/docroot/profiles/custom/cgov_site/config/install/metatag.metatag_defaults.media.yml
+++ b/docroot/profiles/custom/cgov_site/config/install/metatag.metatag_defaults.media.yml
@@ -3,4 +3,10 @@ status: true
 dependencies: {  }
 id: media
 label: Media
-tags: {  }
+tags:
+  canonical_url: '[media:url]'
+  content_language: '[media:langcode]'
+  description: '[media:field_page_description:value]'
+  title: '[cgov_tokens:cgov-title] - [site:name]'
+  og_description: '[media:field_page_description:value]'
+  og_title: '[media:field_browser_title:value]'

--- a/docroot/profiles/custom/cgov_site/config/install/metatag.metatag_defaults.media.yml
+++ b/docroot/profiles/custom/cgov_site/config/install/metatag.metatag_defaults.media.yml
@@ -7,6 +7,6 @@ tags:
   canonical_url: '[media:url]'
   content_language: '[media:langcode]'
   description: '[media:field_page_description:value]'
-  title: '[cgov_tokens:cgov-title] - [site:name]'
+  title: '[cgov_tokens:cgov-title] - [cgov_tokens:cgov-trans-org-name]'
   og_description: '[media:field_page_description:value]'
   og_title: '[media:field_browser_title:value]'

--- a/docroot/profiles/custom/cgov_site/config/install/metatag.metatag_defaults.node.yml
+++ b/docroot/profiles/custom/cgov_site/config/install/metatag.metatag_defaults.node.yml
@@ -7,7 +7,7 @@ tags:
   canonical_url: '[node:url]'
   content_language: '[node:langcode]'
   description: '[node:field_page_description:value]'
-  title: '[cgov_tokens:cgov-title] - [site:name]'
+  title: '[cgov_tokens:cgov-title] - [cgov_tokens:cgov-trans-org-name]'
   dcterms_subject: '[cgov_tokens:cgov-analytics-channel]'
   dcterms_is_referenced_by: event1
   dcterms_issued: '[node:field_date_posted:date:short]'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/config/install/field.storage.node.field_page_description.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/config/install/field.storage.node.field_page_description.yml
@@ -11,7 +11,7 @@ field_name: field_page_description
 entity_type: node
 type: string
 settings:
-  max_length: 320
+  max_length: 600
   is_ascii: false
   case_sensitive: false
 module: core

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_infographic/config/install/core.entity_form_display.media.cgov_infographic.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_infographic/config/install/core.entity_form_display.media.cgov_infographic.default.yml
@@ -15,8 +15,8 @@ dependencies:
     - field.field.media.cgov_infographic.field_image_promotional
     - field.field.media.cgov_infographic.field_infographic
     - field.field.media.cgov_infographic.field_list_description
-    - field.field.media.cgov_infographic.field_meta_description
     - field.field.media.cgov_infographic.field_meta_tags
+    - field.field.media.cgov_infographic.field_page_description
     - field.field.media.cgov_infographic.field_pretty_url
     - field.field.media.cgov_infographic.field_public_use
     - field.field.media.cgov_infographic.field_search_engine_restrictions
@@ -124,7 +124,7 @@ content:
     third_party_settings: {  }
     type: string_textarea
     region: content
-  field_meta_description:
+  field_page_description:
     type: string_textfield
     weight: 7
     region: content

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_infographic/config/install/core.entity_view_display.media.cgov_infographic.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_infographic/config/install/core.entity_view_display.media.cgov_infographic.default.yml
@@ -14,8 +14,8 @@ dependencies:
     - field.field.media.cgov_infographic.field_image_promotional
     - field.field.media.cgov_infographic.field_infographic
     - field.field.media.cgov_infographic.field_list_description
-    - field.field.media.cgov_infographic.field_meta_description
     - field.field.media.cgov_infographic.field_meta_tags
+    - field.field.media.cgov_infographic.field_page_description
     - field.field.media.cgov_infographic.field_pretty_url
     - field.field.media.cgov_infographic.field_public_use
     - field.field.media.cgov_infographic.field_search_engine_restrictions
@@ -90,7 +90,7 @@ hidden:
   field_feature_card_description: true
   field_image_promotional: true
   field_list_description: true
-  field_meta_description: true
+  field_page_description: true
   field_pretty_url: true
   field_public_use: true
   field_search_engine_restrictions: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_infographic/config/install/core.entity_view_display.media.cgov_infographic.full.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_infographic/config/install/core.entity_view_display.media.cgov_infographic.full.yml
@@ -15,8 +15,8 @@ dependencies:
     - field.field.media.cgov_infographic.field_image_promotional
     - field.field.media.cgov_infographic.field_infographic
     - field.field.media.cgov_infographic.field_list_description
-    - field.field.media.cgov_infographic.field_meta_description
     - field.field.media.cgov_infographic.field_meta_tags
+    - field.field.media.cgov_infographic.field_page_description
     - field.field.media.cgov_infographic.field_pretty_url
     - field.field.media.cgov_infographic.field_public_use
     - field.field.media.cgov_infographic.field_search_engine_restrictions
@@ -138,8 +138,8 @@ hidden:
   field_feature_card_description: true
   field_image_promotional: true
   field_list_description: true
-  field_meta_description: true
   field_meta_tags: true
+  field_page_description: true
   field_pretty_url: true
   field_search_engine_restrictions: true
   field_site_section: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_infographic/config/install/core.entity_view_display.media.cgov_infographic.infographic_display_article_large.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_infographic/config/install/core.entity_view_display.media.cgov_infographic.infographic_display_article_large.yml
@@ -15,8 +15,8 @@ dependencies:
     - field.field.media.cgov_infographic.field_image_promotional
     - field.field.media.cgov_infographic.field_infographic
     - field.field.media.cgov_infographic.field_list_description
-    - field.field.media.cgov_infographic.field_meta_description
     - field.field.media.cgov_infographic.field_meta_tags
+    - field.field.media.cgov_infographic.field_page_description
     - field.field.media.cgov_infographic.field_pretty_url
     - field.field.media.cgov_infographic.field_public_use
     - field.field.media.cgov_infographic.field_search_engine_restrictions
@@ -50,8 +50,8 @@ hidden:
   field_feature_card_description: true
   field_infographic: true
   field_list_description: true
-  field_meta_description: true
   field_meta_tags: true
+  field_page_description: true
   field_pretty_url: true
   field_public_use: true
   field_search_engine_restrictions: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_infographic/config/install/core.entity_view_display.media.cgov_infographic.infographic_display_article_medium.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_infographic/config/install/core.entity_view_display.media.cgov_infographic.infographic_display_article_medium.yml
@@ -15,8 +15,8 @@ dependencies:
     - field.field.media.cgov_infographic.field_image_promotional
     - field.field.media.cgov_infographic.field_infographic
     - field.field.media.cgov_infographic.field_list_description
-    - field.field.media.cgov_infographic.field_meta_description
     - field.field.media.cgov_infographic.field_meta_tags
+    - field.field.media.cgov_infographic.field_page_description
     - field.field.media.cgov_infographic.field_pretty_url
     - field.field.media.cgov_infographic.field_public_use
     - field.field.media.cgov_infographic.field_search_engine_restrictions
@@ -50,8 +50,8 @@ hidden:
   field_feature_card_description: true
   field_infographic: true
   field_list_description: true
-  field_meta_description: true
   field_meta_tags: true
+  field_page_description: true
   field_pretty_url: true
   field_public_use: true
   field_search_engine_restrictions: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_infographic/config/install/core.entity_view_display.media.cgov_infographic.link.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_infographic/config/install/core.entity_view_display.media.cgov_infographic.link.yml
@@ -15,7 +15,7 @@ dependencies:
     - field.field.media.cgov_infographic.field_image_promotional
     - field.field.media.cgov_infographic.field_infographic
     - field.field.media.cgov_infographic.field_list_description
-    - field.field.media.cgov_infographic.field_meta_description
+    - field.field.media.cgov_infographic.field_page_description
     - field.field.media.cgov_infographic.field_pretty_url
     - field.field.media.cgov_infographic.field_public_use
     - field.field.media.cgov_infographic.field_search_engine_restrictions
@@ -62,7 +62,7 @@ hidden:
   field_feature_card_description: true
   field_image_promotional: true
   field_infographic: true
-  field_meta_description: true
+  field_page_description: true
   field_pretty_url: true
   field_public_use: true
   field_search_engine_restrictions: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_infographic/config/install/core.entity_view_display.media.cgov_infographic.multimedia_card.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_infographic/config/install/core.entity_view_display.media.cgov_infographic.multimedia_card.yml
@@ -15,8 +15,8 @@ dependencies:
     - field.field.media.cgov_infographic.field_image_promotional
     - field.field.media.cgov_infographic.field_infographic
     - field.field.media.cgov_infographic.field_list_description
-    - field.field.media.cgov_infographic.field_meta_description
     - field.field.media.cgov_infographic.field_meta_tags
+    - field.field.media.cgov_infographic.field_page_description
     - field.field.media.cgov_infographic.field_pretty_url
     - field.field.media.cgov_infographic.field_public_use
     - field.field.media.cgov_infographic.field_search_engine_restrictions
@@ -71,8 +71,8 @@ hidden:
   field_date_updated: true
   field_infographic: true
   field_list_description: true
-  field_meta_description: true
   field_meta_tags: true
+  field_page_description: true
   field_pretty_url: true
   field_public_use: true
   field_search_engine_restrictions: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_infographic/config/install/core.entity_view_display.media.cgov_infographic.thumbnail_card_image.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_infographic/config/install/core.entity_view_display.media.cgov_infographic.thumbnail_card_image.yml
@@ -15,7 +15,7 @@ dependencies:
     - field.field.media.cgov_infographic.field_image_promotional
     - field.field.media.cgov_infographic.field_infographic
     - field.field.media.cgov_infographic.field_list_description
-    - field.field.media.cgov_infographic.field_meta_description
+    - field.field.media.cgov_infographic.field_page_description
     - field.field.media.cgov_infographic.field_pretty_url
     - field.field.media.cgov_infographic.field_public_use
     - field.field.media.cgov_infographic.field_search_engine_restrictions
@@ -49,7 +49,7 @@ hidden:
   field_feature_card_description: true
   field_infographic: true
   field_list_description: true
-  field_meta_description: true
+  field_page_description: true
   field_pretty_url: true
   field_public_use: true
   field_search_engine_restrictions: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_infographic/config/install/field.field.media.cgov_infographic.field_page_description.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_infographic/config/install/field.field.media.cgov_infographic.field_page_description.yml
@@ -2,10 +2,10 @@ langcode: en
 status: true
 dependencies:
   config:
-    - field.storage.media.field_meta_description
+    - field.storage.media.field_page_description
     - media.type.cgov_infographic
-id: media.cgov_infographic.field_meta_description
-field_name: field_meta_description
+id: media.cgov_infographic.field_page_description
+field_name: field_page_description
 entity_type: media
 bundle: cgov_infographic
 label: 'Meta Description'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_media/config/install/field.storage.media.field_page_description.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_media/config/install/field.storage.media.field_page_description.yml
@@ -11,7 +11,7 @@ field_name: field_page_description
 entity_type: media
 type: string
 settings:
-  max_length: 320
+  max_length: 600
   is_ascii: false
   case_sensitive: false
 module: core

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_media/config/install/field.storage.media.field_page_description.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_media/config/install/field.storage.media.field_page_description.yml
@@ -6,8 +6,8 @@ dependencies:
   enforced:
     module:
       - cgov_media
-id: media.field_meta_description
-field_name: field_meta_description
+id: media.field_page_description
+field_name: field_page_description
 entity_type: media
 type: string
 settings:

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_metatag/cgov_metatag.tokens.inc
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_metatag/cgov_metatag.tokens.inc
@@ -23,8 +23,21 @@ function cgov_metatag_token_info() {
   $info['tokens']['cgov_tokens']['cgov-og-image'] =
         [
           'name' => t('Cgov og:image Metatag'),
-          'description' => t('The value to user for the title meta tag.'),
+          'description' => t('The value to use for the og:image meta tag.'),
         ];
+
+  $info['tokens']['cgov_tokens']['cgov-trans-org-name'] =
+        [
+          'name' => t('Translated Org Name'),
+          'description' => t('The value to use for the org name (translated if another language.'),
+        ];
+
+  $info['tokens']['cgov_tokens']['cgov-og-site-name'] =
+        [
+          'name' => t('Cgov og:site_name Meta Tag'),
+          'description' => t('The value to use for the og:site_name meta tag.'),
+        ];
+
   return $info;
 }
 
@@ -42,6 +55,14 @@ function cgov_metatag_tokens($type, $tokens, array $data, array $options, $bubbl
 
         case 'cgov-og-image':
           $replacements[$original] = get_meta_og_image_token($data);
+          break;
+
+        case 'cgov-trans-org-name':
+          $replacements[$original] = t('National Cancer Institute');
+          break;
+
+        case 'cgov-og-site-name':
+          $replacements[$original] = get_meta_og_site_name_token(t('National Cancer Institute'));
           break;
       }
     }
@@ -216,4 +237,21 @@ function find_styled_image_url($image_fid, $social_img_style_name) {
     $image_url = NULL;
   }
   return $image_url;
+}
+
+/**
+ * Sets up og_site_name metatag value.
+ */
+function get_meta_og_site_name_token(string $transOrgName) {
+  // phpcs:disable
+  $name = t(\Drupal::config('system.site')->get('name'));
+  // phpcs:enable
+
+  if ($transOrgName != $name) {
+    $ogSiteName = $name . " - " . $transOrgName;
+    return $ogSiteName;
+  }
+  else {
+    return $name;
+  }
 }

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/core.entity_form_display.media.cgov_video.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/core.entity_form_display.media.cgov_video.default.yml
@@ -14,8 +14,8 @@ dependencies:
     - field.field.media.cgov_video.field_feature_card_description
     - field.field.media.cgov_video.field_list_description
     - field.field.media.cgov_video.field_media_oembed_video
-    - field.field.media.cgov_video.field_meta_description
     - field.field.media.cgov_video.field_meta_tags
+    - field.field.media.cgov_video.field_page_description
     - field.field.media.cgov_video.field_pretty_url
     - field.field.media.cgov_video.field_related_resources
     - field.field.media.cgov_video.field_search_engine_restrictions
@@ -114,7 +114,7 @@ content:
       placeholder: ''
     third_party_settings: {  }
     region: content
-  field_meta_description:
+  field_page_description:
     weight: 7
     settings:
       size: 60

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/core.entity_view_display.media.cgov_video.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/core.entity_view_display.media.cgov_video.default.yml
@@ -13,8 +13,8 @@ dependencies:
     - field.field.media.cgov_video.field_feature_card_description
     - field.field.media.cgov_video.field_list_description
     - field.field.media.cgov_video.field_media_oembed_video
-    - field.field.media.cgov_video.field_meta_description
     - field.field.media.cgov_video.field_meta_tags
+    - field.field.media.cgov_video.field_page_description
     - field.field.media.cgov_video.field_pretty_url
     - field.field.media.cgov_video.field_related_resources
     - field.field.media.cgov_video.field_search_engine_restrictions
@@ -132,20 +132,20 @@ content:
       max_height: 0
     third_party_settings: {  }
     region: content
-  field_meta_description:
-    weight: 23
-    label: above
-    settings:
-      link_to_entity: false
-    third_party_settings: {  }
-    type: string
-    region: content
   field_meta_tags:
     weight: 25
     label: above
     settings: {  }
     third_party_settings: {  }
     type: metatag_empty_formatter
+    region: content
+  field_page_description:
+    weight: 23
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
     region: content
   field_pretty_url:
     weight: 12

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/core.entity_view_display.media.cgov_video.entity_browser_selected_entity.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/core.entity_view_display.media.cgov_video.entity_browser_selected_entity.yml
@@ -14,8 +14,8 @@ dependencies:
     - field.field.media.cgov_video.field_feature_card_description
     - field.field.media.cgov_video.field_list_description
     - field.field.media.cgov_video.field_media_oembed_video
-    - field.field.media.cgov_video.field_meta_description
     - field.field.media.cgov_video.field_meta_tags
+    - field.field.media.cgov_video.field_page_description
     - field.field.media.cgov_video.field_pretty_url
     - field.field.media.cgov_video.field_related_resources
     - field.field.media.cgov_video.field_search_engine_restrictions
@@ -67,8 +67,8 @@ hidden:
   field_date_updated: true
   field_feature_card_description: true
   field_list_description: true
-  field_meta_description: true
   field_meta_tags: true
+  field_page_description: true
   field_pretty_url: true
   field_related_resources: true
   field_search_engine_restrictions: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/core.entity_view_display.media.cgov_video.full.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/core.entity_view_display.media.cgov_video.full.yml
@@ -14,8 +14,8 @@ dependencies:
     - field.field.media.cgov_video.field_feature_card_description
     - field.field.media.cgov_video.field_list_description
     - field.field.media.cgov_video.field_media_oembed_video
-    - field.field.media.cgov_video.field_meta_description
     - field.field.media.cgov_video.field_meta_tags
+    - field.field.media.cgov_video.field_page_description
     - field.field.media.cgov_video.field_pretty_url
     - field.field.media.cgov_video.field_related_resources
     - field.field.media.cgov_video.field_search_engine_restrictions
@@ -121,8 +121,8 @@ hidden:
   field_card_title: true
   field_feature_card_description: true
   field_list_description: true
-  field_meta_description: true
   field_meta_tags: true
+  field_page_description: true
   field_pretty_url: true
   field_search_engine_restrictions: true
   field_site_section: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/core.entity_view_display.media.cgov_video.image_reference_field_form.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/core.entity_view_display.media.cgov_video.image_reference_field_form.yml
@@ -14,8 +14,8 @@ dependencies:
     - field.field.media.cgov_video.field_feature_card_description
     - field.field.media.cgov_video.field_list_description
     - field.field.media.cgov_video.field_media_oembed_video
-    - field.field.media.cgov_video.field_meta_description
     - field.field.media.cgov_video.field_meta_tags
+    - field.field.media.cgov_video.field_page_description
     - field.field.media.cgov_video.field_pretty_url
     - field.field.media.cgov_video.field_related_resources
     - field.field.media.cgov_video.field_search_engine_restrictions
@@ -171,8 +171,8 @@ content:
     settings: {  }
     third_party_settings: {  }
 hidden:
-  field_meta_description: true
   field_meta_tags: true
+  field_page_description: true
   field_related_resources: true
   field_search_engine_restrictions: true
   langcode: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/core.entity_view_display.media.cgov_video.link.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/core.entity_view_display.media.cgov_video.link.yml
@@ -14,7 +14,7 @@ dependencies:
     - field.field.media.cgov_video.field_feature_card_description
     - field.field.media.cgov_video.field_list_description
     - field.field.media.cgov_video.field_media_oembed_video
-    - field.field.media.cgov_video.field_meta_description
+    - field.field.media.cgov_video.field_page_description
     - field.field.media.cgov_video.field_pretty_url
     - field.field.media.cgov_video.field_related_resources
     - field.field.media.cgov_video.field_search_engine_restrictions
@@ -32,7 +32,7 @@ content:
     third_party_settings: {  }
     type: basic_string
     region: content
-  field_meta_description:
+  field_page_description:
     type: string
     weight: 1
     region: content

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/core.entity_view_display.media.cgov_video.multimedia_card.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/core.entity_view_display.media.cgov_video.multimedia_card.yml
@@ -14,8 +14,8 @@ dependencies:
     - field.field.media.cgov_video.field_feature_card_description
     - field.field.media.cgov_video.field_list_description
     - field.field.media.cgov_video.field_media_oembed_video
-    - field.field.media.cgov_video.field_meta_description
     - field.field.media.cgov_video.field_meta_tags
+    - field.field.media.cgov_video.field_page_description
     - field.field.media.cgov_video.field_pretty_url
     - field.field.media.cgov_video.field_related_resources
     - field.field.media.cgov_video.field_search_engine_restrictions
@@ -171,8 +171,8 @@ content:
     settings: {  }
     third_party_settings: {  }
 hidden:
-  field_meta_description: true
   field_meta_tags: true
+  field_page_description: true
   field_related_resources: true
   field_search_engine_restrictions: true
   langcode: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/core.entity_view_display.media.cgov_video.thumbnail_card_image.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/core.entity_view_display.media.cgov_video.thumbnail_card_image.yml
@@ -14,7 +14,7 @@ dependencies:
     - field.field.media.cgov_video.field_feature_card_description
     - field.field.media.cgov_video.field_list_description
     - field.field.media.cgov_video.field_media_oembed_video
-    - field.field.media.cgov_video.field_meta_description
+    - field.field.media.cgov_video.field_page_description
     - field.field.media.cgov_video.field_pretty_url
     - field.field.media.cgov_video.field_related_resources
     - field.field.media.cgov_video.field_search_engine_restrictions
@@ -39,7 +39,7 @@ hidden:
   field_feature_card_description: true
   field_list_description: true
   field_media_oembed_video: true
-  field_meta_description: true
+  field_page_description: true
   field_pretty_url: true
   field_related_resources: true
   field_search_engine_restrictions: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/core.entity_view_display.media.cgov_video.video_display_cthp_multimedia.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/core.entity_view_display.media.cgov_video.video_display_cthp_multimedia.yml
@@ -14,8 +14,8 @@ dependencies:
     - field.field.media.cgov_video.field_feature_card_description
     - field.field.media.cgov_video.field_list_description
     - field.field.media.cgov_video.field_media_oembed_video
-    - field.field.media.cgov_video.field_meta_description
     - field.field.media.cgov_video.field_meta_tags
+    - field.field.media.cgov_video.field_page_description
     - field.field.media.cgov_video.field_pretty_url
     - field.field.media.cgov_video.field_related_resources
     - field.field.media.cgov_video.field_search_engine_restrictions
@@ -71,8 +71,8 @@ hidden:
   field_date_updated: true
   field_feature_card_description: true
   field_list_description: true
-  field_meta_description: true
   field_meta_tags: true
+  field_page_description: true
   field_pretty_url: true
   field_related_resources: true
   field_search_engine_restrictions: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/core.entity_view_display.media.cgov_video.video_display_large_no_title.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/core.entity_view_display.media.cgov_video.video_display_large_no_title.yml
@@ -14,8 +14,8 @@ dependencies:
     - field.field.media.cgov_video.field_feature_card_description
     - field.field.media.cgov_video.field_list_description
     - field.field.media.cgov_video.field_media_oembed_video
-    - field.field.media.cgov_video.field_meta_description
     - field.field.media.cgov_video.field_meta_tags
+    - field.field.media.cgov_video.field_page_description
     - field.field.media.cgov_video.field_pretty_url
     - field.field.media.cgov_video.field_related_resources
     - field.field.media.cgov_video.field_search_engine_restrictions
@@ -71,8 +71,8 @@ hidden:
   field_date_updated: true
   field_feature_card_description: true
   field_list_description: true
-  field_meta_description: true
   field_meta_tags: true
+  field_page_description: true
   field_pretty_url: true
   field_related_resources: true
   field_search_engine_restrictions: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/core.entity_view_display.media.cgov_video.video_display_large_title.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/core.entity_view_display.media.cgov_video.video_display_large_title.yml
@@ -14,8 +14,8 @@ dependencies:
     - field.field.media.cgov_video.field_feature_card_description
     - field.field.media.cgov_video.field_list_description
     - field.field.media.cgov_video.field_media_oembed_video
-    - field.field.media.cgov_video.field_meta_description
     - field.field.media.cgov_video.field_meta_tags
+    - field.field.media.cgov_video.field_page_description
     - field.field.media.cgov_video.field_pretty_url
     - field.field.media.cgov_video.field_related_resources
     - field.field.media.cgov_video.field_search_engine_restrictions
@@ -79,8 +79,8 @@ hidden:
   field_date_updated: true
   field_feature_card_description: true
   field_list_description: true
-  field_meta_description: true
   field_meta_tags: true
+  field_page_description: true
   field_pretty_url: true
   field_related_resources: true
   field_search_engine_restrictions: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/core.entity_view_display.media.cgov_video.video_display_medium_no_title.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/core.entity_view_display.media.cgov_video.video_display_medium_no_title.yml
@@ -14,8 +14,8 @@ dependencies:
     - field.field.media.cgov_video.field_feature_card_description
     - field.field.media.cgov_video.field_list_description
     - field.field.media.cgov_video.field_media_oembed_video
-    - field.field.media.cgov_video.field_meta_description
     - field.field.media.cgov_video.field_meta_tags
+    - field.field.media.cgov_video.field_page_description
     - field.field.media.cgov_video.field_pretty_url
     - field.field.media.cgov_video.field_related_resources
     - field.field.media.cgov_video.field_search_engine_restrictions
@@ -71,8 +71,8 @@ hidden:
   field_date_updated: true
   field_feature_card_description: true
   field_list_description: true
-  field_meta_description: true
   field_meta_tags: true
+  field_page_description: true
   field_pretty_url: true
   field_related_resources: true
   field_search_engine_restrictions: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/core.entity_view_display.media.cgov_video.video_display_medium_title.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/core.entity_view_display.media.cgov_video.video_display_medium_title.yml
@@ -14,8 +14,8 @@ dependencies:
     - field.field.media.cgov_video.field_feature_card_description
     - field.field.media.cgov_video.field_list_description
     - field.field.media.cgov_video.field_media_oembed_video
-    - field.field.media.cgov_video.field_meta_description
     - field.field.media.cgov_video.field_meta_tags
+    - field.field.media.cgov_video.field_page_description
     - field.field.media.cgov_video.field_pretty_url
     - field.field.media.cgov_video.field_related_resources
     - field.field.media.cgov_video.field_search_engine_restrictions
@@ -79,8 +79,8 @@ hidden:
   field_date_updated: true
   field_feature_card_description: true
   field_list_description: true
-  field_meta_description: true
   field_meta_tags: true
+  field_page_description: true
   field_pretty_url: true
   field_related_resources: true
   field_search_engine_restrictions: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/core.entity_view_display.media.cgov_video.video_display_small_no_title.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/core.entity_view_display.media.cgov_video.video_display_small_no_title.yml
@@ -14,8 +14,8 @@ dependencies:
     - field.field.media.cgov_video.field_feature_card_description
     - field.field.media.cgov_video.field_list_description
     - field.field.media.cgov_video.field_media_oembed_video
-    - field.field.media.cgov_video.field_meta_description
     - field.field.media.cgov_video.field_meta_tags
+    - field.field.media.cgov_video.field_page_description
     - field.field.media.cgov_video.field_pretty_url
     - field.field.media.cgov_video.field_related_resources
     - field.field.media.cgov_video.field_search_engine_restrictions
@@ -71,8 +71,8 @@ hidden:
   field_date_updated: true
   field_feature_card_description: true
   field_list_description: true
-  field_meta_description: true
   field_meta_tags: true
+  field_page_description: true
   field_pretty_url: true
   field_related_resources: true
   field_search_engine_restrictions: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/core.entity_view_display.media.cgov_video.video_display_small_title.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/core.entity_view_display.media.cgov_video.video_display_small_title.yml
@@ -14,8 +14,8 @@ dependencies:
     - field.field.media.cgov_video.field_feature_card_description
     - field.field.media.cgov_video.field_list_description
     - field.field.media.cgov_video.field_media_oembed_video
-    - field.field.media.cgov_video.field_meta_description
     - field.field.media.cgov_video.field_meta_tags
+    - field.field.media.cgov_video.field_page_description
     - field.field.media.cgov_video.field_pretty_url
     - field.field.media.cgov_video.field_related_resources
     - field.field.media.cgov_video.field_search_engine_restrictions
@@ -79,8 +79,8 @@ hidden:
   field_date_updated: true
   field_feature_card_description: true
   field_list_description: true
-  field_meta_description: true
   field_meta_tags: true
+  field_page_description: true
   field_pretty_url: true
   field_related_resources: true
   field_search_engine_restrictions: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/field.field.media.cgov_video.field_page_description.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/field.field.media.cgov_video.field_page_description.yml
@@ -2,10 +2,10 @@ langcode: en
 status: true
 dependencies:
   config:
-    - field.storage.media.field_meta_description
+    - field.storage.media.field_page_description
     - media.type.cgov_video
-id: media.cgov_video.field_meta_description
-field_name: field_meta_description
+id: media.cgov_video.field_page_description
+field_name: field_page_description
 entity_type: media
 bundle: cgov_video
 label: 'Meta Description'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/007_video.content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/007_video.content.yml
@@ -22,6 +22,6 @@
       value: |
         Everyone over the age of 50 should be screened for colorectal cancer. Learn about the three screening methods that work to reduce the chance of death from colorectal cancer: colonoscopy, sigmoidoscopy, and home stool test. Also hear personal stories from people who have gone through colorectal cancer screening.
   field_list_description: "LIST: Everyone over the age of 50 should be screened for colorectal cancer. Learn about the three screening methods that work to reduce the chance of death from colorectal cancer: colonoscopy, sigmoidoscopy, and home stool test. Also hear personal stories from people who have gone through colorectal cancer screening."
-  field_meta_description: "META: Everyone over the age of 50 should be screened for colorectal cancer. Learn about the three screening methods that work to reduce the chance of death from colorectal cancer: colonoscopy, sigmoidoscopy, and home stool test. Also hear personal stories from people who have gone through colorectal cancer screening."
+  field_page_description: "META: Everyone over the age of 50 should be screened for colorectal cancer. Learn about the three screening methods that work to reduce the chance of death from colorectal cancer: colonoscopy, sigmoidoscopy, and home stool test. Also hear personal stories from people who have gone through colorectal cancer screening."
   field_browser_title: "Colorectal Cancer Screening: What to Expect"
   field_media_oembed_video: "https://www.youtube.com/watch?v=zXE7rexUCeI"

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/010_key_initiatives_ras_central.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/010_key_initiatives_ras_central.yml
@@ -9,9 +9,9 @@
   moderation_state:
     value: 'published'
   title: "RAS Central"
-  field_page_description:
+  field_list_description:
     value: "To help solve the 30-year challenge of how to treat RAS-driven cancers, we need an open model of collaboration. Whether you are a dedicated RAS expert or curious researcher, we encourage you to help advance the research by joining our RAS community."
-  field_meta_description:
+  field_page_description:
     value: "RAS Central is NCI's online forum for RAS researchers, featuring blog posts, an online discussion forum, events and videos, and other useful tools and resources"
   field_browser_title:
     value: "RAS Central"

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/020_infographic_NCI_at_a_glance.content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/020_infographic_NCI_at_a_glance.content.yml
@@ -10,21 +10,21 @@
   moderation_state: published
   name: 'NCI at a Glance Infographic'
   name__ES:
-      value: 'Instituto Nacional del Cáncer Panorama'
-  field_meta_description: 'NCI at a Glance Infographic'
-  field_meta_description__ES:
-      value: ''
+    value: 'Instituto Nacional del Cáncer Panorama'
+  field_page_description: 'NCI at a Glance Infographic'
+  field_page_description__ES:
+    value: ''
   field_card_title: 'NCI at a Glance'
   field_browser_title:
-      value: 'NCI At A Glance Infographic'
+    value: 'NCI At A Glance Infographic'
   field_browser_title__ES:
-      value: 'Instituto Nacional del Cáncer Panorama'
+    value: 'Instituto Nacional del Cáncer Panorama'
   field_list_description: 'This infographic provides a high-level overview of NCI''s historical milestones, funding process, the NCI-designated cancer centers, and training numbers for fiscal year (FY) 2017. The work we do includes genomics, public health, clinical trials, surveillance, scientific review, basic research, funding, drug development, cancer research, survivorship research, and more. Funds available to the NCI in FY 2018 totaled $5.67 billion which reflects an increase of $254 million from the previous fiscal year. In FY 2017, NCI supported 3,795 emerging cancer researchers through training and career development grants and intramural research experiences (not including students and postdoctoral fellows supported by NCI research project grants, cancer center grants, and other non-training mechanisms).'
   field_list_description__ES:
-      value: 'La infografía "Instituto Nacional del Cáncer Panorama" permite conocer más acerca del Instituto Nacional del Cáncer y las actividades que realiza en la investigación del cáncer.'
+    value: 'La infografía "Instituto Nacional del Cáncer Panorama" permite conocer más acerca del Instituto Nacional del Cáncer y las actividades que realiza en la investigación del cáncer.'
   field_feature_card_description: 'Discover more about what NCI does, what we fund, and some highlights from our long history in leading cancer research in this infographic.'
   field_feature_card_description__ES:
-      value: 'La infografía "Instituto Nacional del Cáncer Panorama" permite conocer más acerca del Instituto Nacional del Cáncer.'
+    value: 'La infografía "Instituto Nacional del Cáncer Panorama" permite conocer más acerca del Instituto Nacional del Cáncer.'
   body:
     - format: full_html
       value: |
@@ -79,12 +79,12 @@
   field_pretty_url: 'nci-at-a-glance'
   field_pretty_url__ES: 'infografia-nci'
   field_site_section:
-  - '#process':
-      callback: 'reference'
-      args:
-        - taxonomy_term
-        - vid: 'cgov_site_sections'
-          computed_path: '/about-nci/organization'
+    - '#process':
+        callback: 'reference'
+        args:
+          - taxonomy_term
+          - vid: 'cgov_site_sections'
+            computed_path: '/about-nci/organization'
   field_site_section__ES:
     - '#process':
         callback: 'reference'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/020_infographic_cancer_and_the_human_tumor_atlas_network.content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/020_infographic_cancer_and_the_human_tumor_atlas_network.content.yml
@@ -10,8 +10,8 @@
   moderation_state: published
   name: 'Cancer and the Human Tumor Atlas Network Infographic'
   name__ES:
-  field_meta_description: 'Cancer and the Human Tumor Atlas Network Infographic'
-  field_meta_description__ES:
+  field_page_description: 'Cancer and the Human Tumor Atlas Network Infographic'
+  field_page_description__ES:
   field_card_title: 'Cancer and the Human Tumor Atlas Network'
   field_card_title__ES:
   field_browser_title: 'Cancer and the Human Tumor Atlas Network Infographic'
@@ -47,10 +47,10 @@
   field_pretty_url: 'screen-to-save-infographic'
   field_pretty_url__ES:
   field_site_section:
-  - '#process':
-      callback: 'reference'
-      args:
-        - taxonomy_term
-        - vid: 'cgov_site_sections'
-          computed_path: '/about-nci/organization'
+    - '#process':
+        callback: 'reference'
+        args:
+          - taxonomy_term
+          - vid: 'cgov_site_sections'
+            computed_path: '/about-nci/organization'
   field_site_section__ES:

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/020_infographic_pediatric_match.content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/020_infographic_pediatric_match.content.yml
@@ -10,20 +10,20 @@
   moderation_state: published
   name: 'Pediatric MATCH Infographic'
   name__ES:
-      value: 'Estudio MATCH Infantil'
-  field_meta_description: 'Infographic explaining NCI-COG Pediatric MATCH, a cancer treatment clinical trial for children and adolescents, from 1 to 21 years of age, that is testing the use of precision medicine for pediatric cancers.'
-  field_meta_description__ES:
-      value: 'Infografía sobre MATCH Infantil de NCI y COG, un estudio clínico de tratamiento del cáncer para niños y adolescentes, de 1 a 21 años de edad, que está evaluando el uso de la medicina de precisión para cánceres infantiles.'
+    value: 'Estudio MATCH Infantil'
+  field_page_description: 'Infographic explaining NCI-COG Pediatric MATCH, a cancer treatment clinical trial for children and adolescents, from 1 to 21 years of age, that is testing the use of precision medicine for pediatric cancers.'
+  field_page_description__ES:
+    value: 'Infografía sobre MATCH Infantil de NCI y COG, un estudio clínico de tratamiento del cáncer para niños y adolescentes, de 1 a 21 años de edad, que está evaluando el uso de la medicina de precisión para cánceres infantiles.'
   field_browser_title:
     value: 'Pediatric MATCH Infographic'
   field_browser_title__ES:
-      value: 'Estudio MATCH Infantil'
+    value: 'Estudio MATCH Infantil'
   field_list_description: 'Infographic explaining NCI-COG Pediatric MATCH, a cancer treatment clinical trial for children and adolescents, from 1 to 21 years of age, that is testing the use of precision medicine for pediatric cancers.'
   field_list_description__ES:
-      value: 'Infografía sobre MATCH Infantil de NCI y COG, un estudio clínico de tratamiento del cáncer para niños y adolescentes, de 1 a 21 años de edad, que está evaluando el uso de la medicina de precisión para cánceres infantiles.'
+    value: 'Infografía sobre MATCH Infantil de NCI y COG, un estudio clínico de tratamiento del cáncer para niños y adolescentes, de 1 a 21 años de edad, que está evaluando el uso de la medicina de precisión para cánceres infantiles.'
   field_feature_card_description: 'Infographic explaining Pediatric MATCH, which is a clinical treatment trial using precision medicine for pediatric cancers.'
   field_feature_card_description__ES:
-      value: 'Infografía sobre MATCH Infantil, un estudio clínico de tratamiento del cáncer para niños y adolescentes que está evaluando el uso de la medicina de precisión para cánceres infantiles.'
+    value: 'Infografía sobre MATCH Infantil, un estudio clínico de tratamiento del cáncer para niños y adolescentes que está evaluando el uso de la medicina de precisión para cánceres infantiles.'
   body:
   body__ES:
   field_accessible_version:
@@ -48,7 +48,7 @@
             filename: 'pediatric-match-espanol-enlarge.png'
   field_image_promotional:
   field_image_promotional__ES:
-      value:
+    value:
   field_date_posted: '2017-07-24'
   field_date_updated: '2017-07-24'
   field_date_reviewed: '2017-07-24'
@@ -57,7 +57,7 @@
   field_pretty_url: 'pediatric-match-infographic'
   field_pretty_url__ES: 'match-infantil-infografia'
   field_site_section:
-  - '#process':
+    - '#process':
       callback: 'reference'
       args:
         - taxonomy_term

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/020_infographic_screen_to_save.content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/020_infographic_screen_to_save.content.yml
@@ -10,8 +10,8 @@
   moderation_state: published
   name: 'Screen to Save Infographic'
   name__ES:
-  field_meta_description: 'Screen to Save Infographic'
-  field_meta_description__ES:
+  field_page_description: 'Screen to Save Infographic'
+  field_page_description__ES:
   field_browser_title:
     value: 'Screen to Save Infographic'
   field_browser_title__ES:
@@ -42,10 +42,10 @@
   field_pretty_url: 'screen-to-save-infographic'
   field_pretty_url__ES:
   field_site_section:
-  - '#process':
-      callback: 'reference'
-      args:
-        - taxonomy_term
-        - vid: 'cgov_site_sections'
-          computed_path: '/about-nci/organization'
+    - '#process':
+        callback: 'reference'
+        args:
+          - taxonomy_term
+          - vid: 'cgov_site_sections'
+            computed_path: '/about-nci/organization'
   field_site_section__ES:

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/021_infographic_pediatric_nci.content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/021_infographic_pediatric_nci.content.yml
@@ -9,24 +9,24 @@
   moderation_state: published
   name: 'Pediatric Infographic NCI'
   name__ES:
-      value: 'Infantil Infographic NCI'
-  field_meta_description: 'Infographic Meta Description'
-  field_meta_description__ES:
-      value: 'Infografía sobre  Infantil de NCI.'
+    value: 'Infantil Infographic NCI'
+  field_page_description: 'Infographic Meta Description'
+  field_page_description__ES:
+    value: 'Infografía sobre  Infantil de NCI.'
   field_browser_title:
-      value: "Pediatric Infographic NCI - Browser Title"
+    value: "Pediatric Infographic NCI - Browser Title"
   field_browser_title__ES:
-      value: "Infantil Infografía NCI - Browser Title ES"
+    value: "Infantil Infografía NCI - Browser Title ES"
   field_card_title:
-      value: "Pediatric Infographic NCI - Card Title"
+    value: "Pediatric Infographic NCI - Card Title"
   field_card_title__ES:
     value: "Infantil Infografía NCI - Card Title ES"
   field_list_description: 'Infographic explaining NCI-COG Pediatric MATCH, a cancer treatment clinical trial for children and adolescents, from 1 to 21 years of age, that is testing the use of precision medicine for pediatric cancers.'
   field_list_description__ES:
-      value: 'Infografía sobre MATCH Infantil de NCI y COG, un estudio clínico de tratamiento del cáncer para niños y adolescentes, de 1 a 21 años de edad, que está evaluando el uso de la medicina de precisión para cánceres infantiles.'
+    value: 'Infografía sobre MATCH Infantil de NCI y COG, un estudio clínico de tratamiento del cáncer para niños y adolescentes, de 1 a 21 años de edad, que está evaluando el uso de la medicina de precisión para cánceres infantiles.'
   field_feature_card_description: 'Infographic explaining Pediatric MATCH, which is a clinical treatment trial using precision medicine for pediatric cancers.'
   field_feature_card_description__ES:
-      value: 'Infografía sobre MATCH Infantil, un estudio clínico de tratamiento del cáncer para niños y adolescentes que está evaluando el uso de la medicina de precisión para cánceres infantiles.'
+    value: 'Infografía sobre MATCH Infantil, un estudio clínico de tratamiento del cáncer para niños y adolescentes que está evaluando el uso de la medicina de precisión para cánceres infantiles.'
   body:
   body__ES:
   field_accessible_version:
@@ -51,23 +51,23 @@
             filename: 'pediatric-nci-esp.jpg'
   field_image_promotional:
   field_image_promotional__ES:
-      value:
+    value:
   field_date_posted: '2018-02-25'
   field_date_updated: '2018-02-25'
   field_date_reviewed: '2018-02-25'
   field_date_display_mode:
-      value: 'reviewed'
+    value: 'reviewed'
   field_public_use: 1
   field_search_engine_restrictions: 0
   field_pretty_url: 'infographic-nci'
   field_pretty_url__ES: 'esp-infografia-nci'
   field_site_section:
-  - '#process':
-      callback: 'reference'
-      args:
-        - taxonomy_term
-        - vid: 'cgov_site_sections'
-          computed_path: '/about-nci/organization'
+    - '#process':
+        callback: 'reference'
+        args:
+          - taxonomy_term
+          - vid: 'cgov_site_sections'
+            computed_path: '/about-nci/organization'
   field_site_section__ES:
     - '#process':
         callback: 'reference'

--- a/docroot/profiles/custom/cgov_site/translations/cgov_site.es.po
+++ b/docroot/profiles/custom/cgov_site/translations/cgov_site.es.po
@@ -167,3 +167,6 @@ msgstr "Vaya a la versión para profesionales de salud"
 
 msgid "View more research"
 msgstr "Ver más investigaciones"
+
+msgid "National Cancer Institute"
+msgstr "Instituto Nacional Del Cáncer"


### PR DESCRIPTION
Closes NCIOCPL#1670:
- [x] Rename field_meta_description to field_list_description
- [x] Update field and form/view displays for video and infographic
- [x] Update video and infographic YAML content

Closes NCIOCPL#1663:
- [x] Allow 600 chars in content and media meta descriptions

Closes NCIOCPL#1719:
- [x] Add same metatags as nodes to media types

Closes NCIOCPL#1639:
- [x] Add trans-org-name token to replace [site:name] in meta tags
- [x] Update title meta tag to include trans-org-name for browser title
- [x] Add og-site-name token to replace hardcoded og_site_name meta tag
- [x] Add translation for National Cancer Institute (org name) for meta tags