### PR TITLE
(#1593, #1732) Rename/move image to simple workflow; attach block_content types to simple workflow

### DIFF
--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_content_block/cgov_content_block.install
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_content_block/cgov_content_block.install
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * @file
+ * Contains cgov_content_block.install.
+ */
+
+/**
+ * Implements hook_install().
+ *
+ * Perform actions to set up the site for this profile.
+ *
+ * @see system_install()
+ */
+function cgov_content_block_install() {
+  $tools = \Drupal::service('cgov_core.tools');
+  foreach ([
+    'content_block',
+    'raw_html_block',
+  ] as $block_type) {
+    // Add workflow.
+    $tools->attachBlockContentTypeToWorkflow($block_type, 'simple_workflow');
+  }
+}

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/config/install/workflows.workflow.editorial_workflow.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/config/install/workflows.workflow.editorial_workflow.yml
@@ -124,6 +124,5 @@ type_settings:
         - published
       to: editing
       weight: 2
-  entity_types:
-    node: {}
+  entity_types: { }
   default_moderation_state: draft

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/config/install/workflows.workflow.simple_workflow.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/config/install/workflows.workflow.simple_workflow.yml
@@ -3,8 +3,8 @@ status: true
 dependencies:
   module:
     - content_moderation
-id: image_workflow
-label: 'Image Workflow'
+id: simple_workflow
+label: 'Simple Workflow'
 type: content_moderation
 type_settings:
   states:
@@ -33,6 +33,5 @@ type_settings:
       from:
         - draft
         - published
-  entity_types:
-    media: {}
+  entity_types: { }
   default_moderation_state: published

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/CgovCoreTools.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/CgovCoreTools.php
@@ -184,6 +184,18 @@ class CgovCoreTools {
   }
 
   /**
+   * Links a block content type to a workflow.
+   *
+   * See https://github.com/NCIOCPL/cgov-digital-platform/issues/1732.
+   */
+  public function attachBlockContentTypeToWorkflow($type_name, $workflow_name) {
+    $workflows = $this->entityTypeManager->getStorage('workflow')->loadMultiple();
+    $workflow = $workflows[$workflow_name];
+    $workflow->getTypePlugin()->addEntityTypeAndBundle('block_content', $type_name);
+    $workflow->save(TRUE);
+  }
+
+  /**
    * Add Permissions to a role.
    *
    * @param array $rolePermissions

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_image/cgov_image.install
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_image/cgov_image.install
@@ -20,6 +20,9 @@ function cgov_image_install() {
     $tools->attachMediaTypeToWorkflow($image_type, 'simple_workflow');
   }
 
+  // Attach image carousel to right workflow.
+  $tools->attachBlockContentTypeToWorkflow('cgov_image_carousel', 'simple_workflow');
+
   // Install permissions for this module.
   _cgov_image_install_permissions($tools);
 }

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_image/cgov_image.install
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_image/cgov_image.install
@@ -17,7 +17,7 @@ function cgov_image_install() {
   foreach (['cgov_image', 'cgov_contextual_image'] as $image_type) {
     // Add content type permissions.
     $tools->addMediaTypePermissions($image_type, 'image_manager');
-    $tools->attachMediaTypeToWorkflow($image_type, 'image_workflow');
+    $tools->attachMediaTypeToWorkflow($image_type, 'simple_workflow');
   }
 
   // Install permissions for this module.
@@ -37,8 +37,8 @@ function _cgov_image_install_permissions(CgovCoreTools $siteHelper) {
       'access cgov_image_browser entity browser pages',
     ],
     'image_manager' => [
-      'use image_workflow transition create_new_draft',
-      'use image_workflow transition publish',
+      'use simple_workflow transition create_new_draft',
+      'use simple_workflow transition publish',
     ],
   ];
 

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_image/config/install/core.entity_form_display.media.cgov_contextual_image.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_image/config/install/core.entity_form_display.media.cgov_contextual_image.default.yml
@@ -10,7 +10,7 @@ dependencies:
     - field.field.media.cgov_contextual_image.field_original_source
     - image.style.thumbnail
     - media.type.cgov_contextual_image
-    - workflows.workflow.image_workflow
+    - workflows.workflow.simple_workflow
   module:
     - content_moderation
     - image

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_image/config/install/core.entity_form_display.media.cgov_image.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_image/config/install/core.entity_form_display.media.cgov_image.default.yml
@@ -14,7 +14,7 @@ dependencies:
     - field.field.media.cgov_image.field_override_img_thumbnail
     - image.style.thumbnail
     - media.type.cgov_image
-    - workflows.workflow.image_workflow
+    - workflows.workflow.simple_workflow
   module:
     - content_moderation
     - image

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_media/config/install/views.view.moderated_media.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_media/config/install/views.view.moderated_media.yml
@@ -4,7 +4,7 @@ dependencies:
   config:
     - image.style.thumbnail
     - workflows.workflow.editorial_workflow
-    - workflows.workflow.image_workflow
+    - workflows.workflow.simple_workflow
   module:
     - content_moderation
     - image
@@ -779,7 +779,7 @@ display:
             editorial_workflow-post_publication_review: editorial_workflow-post_publication_review
             editorial_workflow-archive_requested: editorial_workflow-archive_requested
             editorial_workflow-archived: editorial_workflow-archived
-            image_workflow-draft: image_workflow-draft
+            simple_workflow-draft: simple_workflow-draft
           group: 1
           exposed: true
           expose:
@@ -829,7 +829,7 @@ display:
           operator: 'not in'
           value:
             editorial_workflow-published: editorial_workflow-published
-            image_workflow-published: image_workflow-published
+            simple_workflow-published: simple_workflow-published
           group: 1
           exposed: false
           expose:

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/cgov_video.install
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/cgov_video.install
@@ -22,9 +22,11 @@ function cgov_video_install() {
   $siteHelper->addMediaTypePermissions('cgov_video', ['content_author']);
   $siteHelper->attachMediaTypeToWorkflow('cgov_video', 'editorial_workflow');
 
+  // Attach video carousel to right workflow.
+  $siteHelper->attachBlockContentTypeToWorkflow('cgov_video_carousel', 'simple_workflow');
+
   // Install permissions for this module.
   _cgov_video_install_permissions($siteHelper);
-
 }
 
 /**

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/core.entity_form_display.media.cgov_video.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/core.entity_form_display.media.cgov_video.default.yml
@@ -21,7 +21,7 @@ dependencies:
     - field.field.media.cgov_video.field_search_engine_restrictions
     - field.field.media.cgov_video.field_site_section
     - media.type.cgov_video
-    - workflows.workflow.image_workflow
+    - workflows.workflow.simple_workflow
   module:
     - content_moderation
     - datetime


### PR DESCRIPTION
Closes NCIOCPL#1593
- [x] Rename to simple_workflow (including all references to it)
- [x] Move to cgov_core

Closes NCIOCPL#1732
- [x] Add method to attach block content type to workflow
- [x] Create install file to add raw html/content block to simple workflow
- [x] Add simple workflow to image carousel in install
- [x] Add simple workflow to video carousel in install