### PR TITLE
(NCIOCPL#1466) Make SAML active on installation

### DIFF
--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_saml_auth_config/config/install/cgov_saml_auth_config.settings.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_saml_auth_config/config/install/cgov_saml_auth_config.settings.yml
@@ -1,6 +1,6 @@
 langcode: en
 default_langcode: en
-activate: false
+activate: true
 mail_attr: https://federation.nih.gov/person/Mail
 unique_id: https://federation.nih.gov/person/SamAccountName
 user_name: https://federation.nih.gov/person/SamAccountName


### PR DESCRIPTION
When deploying to a (non-ODE) environoment, make SSO mandatory without
a manual activation step.

Closes #1466 