### PR TITLE
(#792) Generate site maps

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,6 +55,7 @@
         "drupal/seckit": "^1.1",
         "drupal/shield": "^1.2",
         "drupal/simplesamlphp_auth": "3.0",
+        "drupal/simple_sitemap": "^3.1",
         "drupal/token": "^1.5",
         "drupal/token_filter": "^1.1",
         "drupal/twig_field_value": "^1.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "658bec4ba3541f75ca17b5e7d4c931ec",
+    "content-hash": "dc71883d93ba56b3f5f51dba8245487a",
     "packages": [
         {
             "name": "acquia/acsf-tools",
@@ -2785,7 +2785,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.4",
-                    "datestamp": "1554332581",
+                    "datestamp": "1527081784",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -2813,10 +2813,6 @@
                     "homepage": "https://www.drupal.org/user/386230"
                 },
                 {
-                    "name": "mglaman",
-                    "homepage": "https://www.drupal.org/user/2416470"
-                },
-                {
                     "name": "rszrama",
                     "homepage": "https://www.drupal.org/user/49344"
                 }
@@ -2824,7 +2820,7 @@
             "description": "Provides functionality for storing, validating and displaying international postal addresses.",
             "homepage": "http://drupal.org/project/address",
             "support": {
-                "source": "https://git.drupalcode.org/project/address"
+                "source": "http://cgit.drupalcode.org/address"
             }
         },
         {
@@ -4503,7 +4499,7 @@
                 },
                 "drupal": {
                     "version": "8.x-4.1",
-                    "datestamp": "1555683487",
+                    "datestamp": "1546879080",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -4696,7 +4692,7 @@
                 },
                 "drupal": {
                     "version": "8.x-4.3",
-                    "datestamp": "1553565784",
+                    "datestamp": "1523670784",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -4725,10 +4721,6 @@
                     "homepage": "https://www.drupal.org/user/45640"
                 },
                 {
-                    "name": "joelpittet",
-                    "homepage": "https://www.drupal.org/user/160302"
-                },
-                {
                     "name": "merlinofchaos",
                     "homepage": "https://www.drupal.org/user/26979"
                 },
@@ -4739,6 +4731,10 @@
                 {
                     "name": "samuel.mortenson",
                     "homepage": "https://www.drupal.org/user/2582268"
+                },
+                {
+                    "name": "sdboyer",
+                    "homepage": "https://www.drupal.org/user/146719"
                 },
                 {
                     "name": "tim.plunkett",
@@ -4830,7 +4826,7 @@
             "description": "Enables the creation of Paragraphs entities.",
             "homepage": "https://www.drupal.org/project/paragraphs",
             "support": {
-                "source": "https://git.drupalcode.org/project/paragraphs"
+                "source": "http://cgit.drupalcode.org/paragraphs"
             }
         },
         {
@@ -4915,7 +4911,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.3",
-                    "datestamp": "1554239887",
+                    "datestamp": "1536407884",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -4950,7 +4946,7 @@
             "description": "Provides a mechanism for modules to automatically generate aliases for the content they manage.",
             "homepage": "https://www.drupal.org/project/pathauto",
             "support": {
-                "source": "https://git.drupalcode.org/project/pathauto"
+                "source": "http://cgit.drupalcode.org/pathauto"
             }
         },
         {
@@ -5520,6 +5516,67 @@
             "homepage": "https://www.drupal.org/project/shield",
             "support": {
                 "source": "http://cgit.drupalcode.org/shield"
+            }
+        },
+        {
+            "name": "drupal/simple_sitemap",
+            "version": "3.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/simple_sitemap.git",
+                "reference": "8.x-3.1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/simple_sitemap-8.x-3.1.zip",
+                "reference": "8.x-3.1",
+                "shasum": "7194caf8482c4a80a5b7eddf28d94e798bb4786d"
+            },
+            "require": {
+                "drupal/core": "~8.0",
+                "ext-xmlwriter": "*"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "branch-alias": {
+                    "dev-3.x": "3.x-dev"
+                },
+                "drupal": {
+                    "version": "8.x-3.1",
+                    "datestamp": "1555534615",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                },
+                "drush": {
+                    "services": {
+                        "drush.services.yml": "^9"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "Pawel Ginalski (gbyte.co)",
+                    "homepage": "https://www.drupal.org/u/gbyte.co",
+                    "email": "contact@gbyte.co",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "gbyte.co",
+                    "homepage": "https://www.drupal.org/user/2381352"
+                }
+            ],
+            "description": "Creates a standard conform hreflang XML sitemap of the site content and provides a framework for developing other sitemap types.",
+            "homepage": "https://drupal.org/project/simple_sitemap",
+            "support": {
+                "source": "https://cgit.drupalcode.org/simple_sitemap",
+                "issues": "https://drupal.org/project/issues/simple_sitemap",
+                "irc": "irc://irc.freenode.org/drupal-contribute"
             }
         },
         {

--- a/docroot/profiles/custom/cgov_site/cgov_site.info.yml
+++ b/docroot/profiles/custom/cgov_site/cgov_site.info.yml
@@ -94,6 +94,7 @@ install:
   - cgov_event
   - cgov_infographic
   - cgov_cancer_research
+  - cgov_sitemap
 themes:
   - cgov_common
   - cgov_admin

--- a/docroot/profiles/custom/cgov_site/config/install/simple_sitemap.settings.yml
+++ b/docroot/profiles/custom/cgov_site/config/install/simple_sitemap.settings.yml
@@ -1,0 +1,16 @@
+max_links: 2000
+cron_generate: true
+cron_generate_interval: 0
+generate_duration: 10000
+remove_duplicates: true
+skip_untranslated: true
+xsl: true
+base_url: ''
+default_variant: 'content'
+custom_links_include_images: false
+excluded_languages: {  }
+enabled_entity_types:
+  - node
+  - media
+  - taxonomy_term
+  - menu_link_content

--- a/docroot/profiles/custom/cgov_site/config/install/simple_sitemap.variants.default_hreflang.yml
+++ b/docroot/profiles/custom/cgov_site/config/install/simple_sitemap.variants.default_hreflang.yml
@@ -1,0 +1,4 @@
+variants:
+  content:
+    label: Default
+    weight: 0

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/simple_sitemap.bundle_settings.content.node.cgov_article.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/simple_sitemap.bundle_settings.content.node.cgov_article.yml
@@ -1,0 +1,4 @@
+index: true
+priority: '1.0'
+changefreq: weekly
+include_images: false

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_biography/config/install/simple_sitemap.bundle_settings.content.node.cgov_biography.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_biography/config/install/simple_sitemap.bundle_settings.content.node.cgov_biography.yml
@@ -1,0 +1,4 @@
+index: true
+priority: '0.5'
+changefreq: weekly
+include_images: false

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/config/install/simple_sitemap.bundle_settings.content.node.cgov_blog_post.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/config/install/simple_sitemap.bundle_settings.content.node.cgov_blog_post.yml
@@ -1,0 +1,4 @@
+index: true
+priority: '0.5'
+changefreq: weekly
+include_images: false

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/config/install/simple_sitemap.bundle_settings.content.node.cgov_blog_series.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/config/install/simple_sitemap.bundle_settings.content.node.cgov_blog_series.yml
@@ -1,0 +1,4 @@
+index: true
+priority: '0.5'
+changefreq: weekly
+include_images: false

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_center/config/install/simple_sitemap.bundle_settings.content.node.cgov_cancer_center.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_center/config/install/simple_sitemap.bundle_settings.content.node.cgov_cancer_center.yml
@@ -1,0 +1,4 @@
+index: true
+priority: '0.5'
+changefreq: weekly
+include_images: false

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_research/config/install/simple_sitemap.bundle_settings.content.node.cgov_cancer_research.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_research/config/install/simple_sitemap.bundle_settings.content.node.cgov_cancer_research.yml
@@ -1,0 +1,4 @@
+index: true
+priority: '1.0'
+changefreq: weekly
+include_images: false

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.info.yml
@@ -29,6 +29,7 @@ dependencies:
   - panels
   - paragraphs
   - paragraphs_asymmetric_translation_widgets
+  - simple_sitemap
   - system
   - taxonomy
   - text

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.links.menu.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.links.menu.yml
@@ -1,0 +1,5 @@
+cgov_core.site_config:
+  title: 'Cancer.gov site configuration'
+  description: 'Set the site ID and production URL for this site.'
+  route_name: cgov_core.site_config_route
+  parent: system.admin_config_system

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.routing.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.routing.yml
@@ -1,0 +1,7 @@
+cgov_core.site_config_route:
+  path: '/admin/config/cgov-site-config'
+  defaults:
+    _form: '\Drupal\cgov_core\Form\SiteConfigForm'
+    _title: 'Cancer.gov site configuration'
+  requirements:
+    _permission: 'administer site configuration'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/config/schema/cgov_core.schema.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/config/schema/cgov_core.schema.yml
@@ -10,3 +10,15 @@ field.formatter.settings.cgov_date_formatter:
 ## core does, so we will inherit from that.
 entity_reference_selection.cgov_all_selection:
   type: entity_reference_selection.default
+
+## Capture information specific to each site.
+cgov_core.site_config:
+  type: config_object
+  label: 'Cancer.gov site-specific settings'
+  mapping:
+    site:
+      type: string
+      label: 'The site ID'
+    prod_base:
+      type: string
+      label: 'Production base URL'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Form/SiteConfigForm.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Form/SiteConfigForm.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Drupal\cgov_core\Form;
+
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Class SiteConfigForm.
+ *
+ * @package Drupal\cgov_core\Form
+ */
+class SiteConfigForm extends ConfigFormBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return ['cgov_core.site_config'];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'site_configuration_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $config = $this->config('cgov_core.site_config');
+    $form['site'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Site ID'),
+      '#description' => $this->t('Unique string identifying specific micro-site (e.g., cgov).'),
+      '#default_value' => $config->get('site'),
+    ];
+    $form['prod_base'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Prod URL'),
+      '#description' => $this->t('The base URL for this site on the production tier (e.g., https://www.cancer.gov).'),
+      '#default_value' => $config->get('prod_base'),
+    ];
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $this->config('cgov_core.site_config')
+      ->set('site', $form_state->getValue('site'))
+      ->set('prod_base', $form_state->getValue('prod_base'))
+      ->save();
+    parent::submitForm($form, $form_state);
+  }
+
+}

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/simple_sitemap.bundle_settings.content.node.cgov_cthp.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/simple_sitemap.bundle_settings.content.node.cgov_cthp.yml
@@ -1,0 +1,4 @@
+index: true
+priority: '1.0'
+changefreq: weekly
+include_images: false

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_event/config/install/simple_sitemap.bundle_settings.content.node.cgov_event.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_event/config/install/simple_sitemap.bundle_settings.content.node.cgov_event.yml
@@ -1,0 +1,4 @@
+index: true
+priority: '0.5'
+changefreq: weekly
+include_images: false

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_file/config/install/simple_sitemap.bundle_settings.content.media.cgov_file.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_file/config/install/simple_sitemap.bundle_settings.content.media.cgov_file.yml
@@ -1,0 +1,4 @@
+index: true
+priority: '0.5'
+changefreq: weekly
+include_images: false

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/config/install/simple_sitemap.bundle_settings.content.node.cgov_home_landing.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/config/install/simple_sitemap.bundle_settings.content.node.cgov_home_landing.yml
@@ -1,0 +1,4 @@
+index: true
+priority: '1.0'
+changefreq: weekly
+include_images: false

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/config/install/simple_sitemap.bundle_settings.content.node.cgov_mini_landing.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/config/install/simple_sitemap.bundle_settings.content.node.cgov_mini_landing.yml
@@ -1,0 +1,4 @@
+index: true
+priority: '0.5'
+changefreq: weekly
+include_images: false

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_infographic/config/install/simple_sitemap.bundle_settings.content.media.cgov_infographic.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_infographic/config/install/simple_sitemap.bundle_settings.content.media.cgov_infographic.yml
@@ -1,0 +1,4 @@
+index: true
+priority: '0.5'
+changefreq: weekly
+include_images: false

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_media/cgov_media.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_media/cgov_media.info.yml
@@ -9,4 +9,5 @@ dependencies:
   - language
   - content_translation
   - entity_browser
+  - simple_sitemap
   - views

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/simple_sitemap.bundle_settings.content.node.cgov_press_release.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/simple_sitemap.bundle_settings.content.node.cgov_press_release.yml
@@ -1,0 +1,4 @@
+index: true
+priority: '0.5'
+changefreq: weekly
+include_images: false

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_sitemap/cgov_sitemap.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_sitemap/cgov_sitemap.info.yml
@@ -1,0 +1,8 @@
+name: 'CGov Site Map'
+type: module
+package: 'CGov Digital Platform'
+description: 'CGov Site Map Generation'
+core: 8.x
+dependencies:
+  - cgov_core
+  - simple_sitemap

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_sitemap/cgov_sitemap.services.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_sitemap/cgov_sitemap.services.yml
@@ -1,0 +1,6 @@
+services:
+  cgov_sitemap.route_subscriber:
+    class: Drupal\cgov_sitemap\Routing\RouteSubscriber
+    arguments: ['@config.factory']
+    tags:
+      - { name: event_subscriber }

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_sitemap/src/Controller/SitemapIndex.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_sitemap/src/Controller/SitemapIndex.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Drupal\cgov_sitemap\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Class SitemapIndex.
+ *
+ * @package Drupal\cgov_sitemap\Controller
+ */
+class SitemapIndex extends ControllerBase {
+
+  /**
+   * Replace the generated site map with a site index.
+   *
+   * We only route to this controller for the www.cancer.gov microsite.
+   *
+   * @param \Symfony\Component\HttpFoundation\Request $request
+   *   The request.
+   *
+   * @return \Symfony\Component\HttpFoundation\Response
+   *   Prepared response object.
+   */
+  public function index(Request $request) {
+    $base = $request->getSchemeAndHttpHost();
+    $now = \date('c');
+    $content = <<<EOT
+<?xml version="1.0" encoding="utf-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap>
+    <loc>$base/content/sitemap.xml</loc>
+    <lastmod>$now</lastmod>
+  </sitemap>
+  <sitemap>
+    <loc>https://www.cancer.gov/sitemaps/dictionaries.xml</loc>
+    <lastmod>$now</lastmod>
+  </sitemap>
+  <sitemap>
+    <loc>https://www.cancer.gov/sitemaps/dynamiclistingpages.xml</loc>
+    <lastmod>$now</lastmod>
+  </sitemap>
+  <sitemap>
+    <loc>https://www.cancer.gov/sitemaps/clinicaltrials.xml</loc>
+    <lastmod>$now</lastmod>
+  </sitemap>
+</sitemapindex>
+EOT;
+    $response = new Response();
+    $response->headers->set('Content-type', 'text/xml');
+    $response->setContent($content);
+    return $response;
+  }
+
+}

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_sitemap/src/Routing/RouteSubscriber.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_sitemap/src/Routing/RouteSubscriber.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Drupal\cgov_sitemap\Routing;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Routing\RouteSubscriberBase;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * Class RouteSubscriber.
+ *
+ * @package Drupal\cgov_sitemap\Routing
+ */
+class RouteSubscriber extends RouteSubscriberBase {
+
+  /**
+   * Provides access to information about which site we're on.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
+
+  /**
+   * RouteSubscriber constructor.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   Access to information about which site we're running under.
+   */
+  public function __construct(ConfigFactoryInterface $config_factory) {
+    $this->configFactory = $config_factory;
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * If this is the c.gov site, replace the simple_sitemap
+   * file with an index for all the site maps.
+   */
+  public function alterRoutes(RouteCollection $collection) {
+    $config = $this->configFactory->get('cgov_core.site_config');
+    if ($config->get('site') === 'cgov') {
+      $route = $collection->get('simple_sitemap.sitemap_default');
+      if (!empty($route)) {
+        $controller = '\Drupal\cgov_sitemap\Controller\SitemapIndex::index';
+        $route->setDefaults(['_controller' => $controller]);
+      }
+    }
+  }
+
+}

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/simple_sitemap.bundle_settings.content.media.cgov_video.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/simple_sitemap.bundle_settings.content.media.cgov_video.yml
@@ -1,0 +1,4 @@
+index: true
+priority: '0.5'
+changefreq: weekly
+include_images: false

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/simple_sitemap.bundle_settings.content.node.pdq_cancer_information_summary.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/simple_sitemap.bundle_settings.content.node.pdq_cancer_information_summary.yml
@@ -1,0 +1,4 @@
+index: true
+priority: '1.0'
+changefreq: weekly
+include_images: false

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_drug_information_summary/config/install/simple_sitemap.bundle_settings.content.node.pdq_drug_information_summary.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_drug_information_summary/config/install/simple_sitemap.bundle_settings.content.node.pdq_drug_information_summary.yml
@@ -1,0 +1,4 @@
+index: true
+priority: '1.0'
+changefreq: weekly
+include_images: false


### PR DESCRIPTION
Closes #792 

- adds the `simple_sitemap` module
- overrides the default configuration for that module
- configures which content types should be mapped with what settings
- implements a controller which provides a site index XML file for www.cancer.gov
- adds a route subscriber which serves up the index at `/sitemap.xml` if the site is `cgov`
- implements a configuration interface to manage the site ID and production URL

We don't need the production URL for this task, but we will need it for HHS syndication, and it fits well here. I won't be shocked or surprised if you decide you want a different approach to capturing the information about which site we're on, but this works, and I figured it would be easier (for me, at least) to have the conversation about what we really want to do if we actually have something to look at as a starting point. Or, you might decide we'll use this as is for the initial launch, and swap in something you like better after the dust settles. The only thing in the whole system that depends on this config information is the new `cgov_sitemap` module (and all it needs to know is the answer to the question "are we on the cgov web site?").

Let's first see if the tests pass in the cloud. They do on my local machine.