### PR TITLE
Multiple SSO-related tickets

### DIFF
--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_saml_auth_config/cgov_saml_auth_config.install
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_saml_auth_config/cgov_saml_auth_config.install
@@ -24,13 +24,4 @@ function cgov_saml_auth_config_install() {
   // Custom config object is no longer needed.
   $customConfig->delete();
 
-  // Set up permissions for roles allowed to interact with SAML config.
-  $samlPermissions = [
-    'administer simplesamlphp authentication',
-    'change saml authentication setting',
-  ];
-  // Get our helper.
-  $siteHelper = \Drupal::service('cgov_core.tools');
-  $siteHelper->addRolePermissions(['site_admin' => $samlPermissions]);
-
 }

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_saml_auth_config/config/install/cgov_saml_auth_config.settings.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_saml_auth_config/config/install/cgov_saml_auth_config.settings.yml
@@ -21,7 +21,7 @@ allow:
     image_manager: '0'
     advanced_editor: '0'
     layout_manager: '0'
-    pdq_importer: '0'
+    pdq_importer: pdq_importer
     authenticated: '0'
     administrator: administrator
     admin_ui: '0'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_saml_auth_config/config/install/cgov_saml_auth_config.settings.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_saml_auth_config/config/install/cgov_saml_auth_config.settings.yml
@@ -1,6 +1,6 @@
 langcode: en
 default_langcode: en
-activate: false
+activate: true
 mail_attr: https://federation.nih.gov/person/Mail
 unique_id: https://federation.nih.gov/person/SamAccountName
 user_name: https://federation.nih.gov/person/SamAccountName


### PR DESCRIPTION
* Allow pdq_importer to use the default login. (#1768)
* Remove ability to edit SAML configuration from site_admin role.  (#1769)
* Make SSO mandatory when the system is deployed to a non-ODE environment. (#1466)

Closes #1768 
Closes #1769 
Closes #1466 