### PR TITLE
(#1777) Media links in research card need styling

### DIFF
--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/listing/list_item_macros.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/listing/list_item_macros.twig
@@ -130,6 +130,20 @@
   </li>
 {% endmacro %}
 
+
+{#
+  Title 
+  
+  Used in:
+    * CTHP Research Block
+#}
+{% macro list_item_cthp_research_media(title, date, url, has_title_heading, media_link_type, file_type, file_size, file_ext)%}
+  <p>
+    {{ _self._output_list_title(title, url, has_title_heading, media_link_type, file_type, file_size, file_ext) }}
+  </p>
+{% endmacro %}
+
+
 {#
   Title, description, and image.
 

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/listing/paragraph--cgov-media-link--cthp-research-card-list-item.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/listing/paragraph--cgov-media-link--cthp-research-card-list-item.html.twig
@@ -1,0 +1,27 @@
+{% import '@cgov_common/listing/list_item_macros.twig' as listItemMacros %}
+{% import '@cgov_common/content_page_macros.twig' as contentPageMacros %}
+
+{% if content.field_media_link[0] %}
+
+  {# ###### Setup Title ####### #}
+  {% if content.field_override_title|field_value %}
+    {% set title = content.field_override_title|field_value %}
+  {% else %}
+    {% set title = content.field_media_link[0]["#media"].name.value %}
+  {% endif %}
+  
+  {# ###### Setup the URL ###### #}
+  {% set url = path('entity.media.canonical', {'media':  content.field_media_link[0]["#media"].mid[0].value}) %}
+
+  {% set media_type = content.media_link_type['#plain_text'] %}
+
+  {% if media_type == 'File' %}
+    {% set file_type = content.media_link_file_type['#plain_text']%}
+    {% set file_size = content.media_link_file_size['#plain_text'] %}
+    {% set file_ext = content.media_link_file_extension['#plain_text'] %}
+    {{ listItemMacros.list_item_cthp_research_media(title, date, url, false, media_type, file_type, file_size, file_ext) }}
+  {% else %}
+    {{ listItemMacros.list_item_cthp_research_media(title, date, url, false, media_type, null, null, null) }}
+  {% endif %}
+
+{% endif %}

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/src/styles/_lists.scss
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/src/styles/_lists.scss
@@ -161,39 +161,37 @@ dl {
 	.infographic {
 		background: transparent;
 	}
+}
 
-	.file {
+// attaches a filetype icon to spans following media links like those used on CTHP Research cards or cthp-dropdown items
+.filetype {
+	position: relative;
+	top: 0.25em;
+	display: inline-block;
+	margin-left: 5px;
 
-		.filetype {
-			position: relative;
-			top: 0.25em;
-			display: inline-block;
-			margin-left: 5px;
-
-			&.pdf {
-				@include svg-sprite(file-pdf-gray-o-thick);
-			}
-			&.exe, &.txt {
-				@include svg-sprite(file-download-gray-o);
-			}
-			&.ebook {
-				@include svg-sprite(file-ebook-gray);
-			}
-			&.ppt {
-				@include svg-sprite(file-ppt-gray);
-			}
-			&.word {
-				@include svg-sprite(file-word-gray);
-			}
-			&.excel {
-				@include svg-sprite(file-excel-gray);
-			}
-			&.unknown {
-				top: 0;
-				height: auto;
-				background: none;
-			}
-		}
+	&.pdf {
+		@include svg-sprite(file-pdf-gray-o-thick);
+	}
+	&.exe, &.txt {
+		@include svg-sprite(file-download-gray-o);
+	}
+	&.ebook {
+		@include svg-sprite(file-ebook-gray);
+	}
+	&.ppt {
+		@include svg-sprite(file-ppt-gray);
+	}
+	&.word {
+		@include svg-sprite(file-word-gray);
+	}
+	&.excel {
+		@include svg-sprite(file-excel-gray);
+	}
+	&.unknown {
+		top: 0;
+		height: auto;
+		background: none;
 	}
 }
 


### PR DESCRIPTION
Closes #1777 

Per #1777 , If a Media link is added to a CTHP research list page, and the CTHP research list page is then added to the CTHP Research Card, it shows up poorly on the research card.  

New template and list item macros created

<img width="495" alt="Screen Shot 2019-05-21 at 2 30 16 PM" src="https://user-images.githubusercontent.com/45469809/58199249-13c70d80-7c9e-11e9-8a97-02cdef295011.png">
