### PR TITLE
(#1804) Update template styling for Syndication

### DIFF
--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/article/node--cgov-article--hhs-syndication.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/article/node--cgov-article--hhs-syndication.html.twig
@@ -9,9 +9,18 @@
  * is selected.
  */
 #}
-<h1>{{ node.label }}</h1>
-<div id="cgvBody">
-  {{ content.field_image_article }}
-  {{ content.field_intro_text }}
-  {{ content.field_article_body }}
+
+{% import '@cgov_common/content_page_macros.twig' as contentPageMacros %}
+<!-- ********************************* BEGIN Page Content ********************************** -->
+
+<h1 id="bodyTitle">{{ node.label }}</h1>
+<div id="bodyContent">
+    {{ content.field_image_article }}
+    {{ content.field_intro_text }}
+    {{ content.field_article_body }}
+</div>
+<div id="footer">
+    {{ content.field_citation }}
+    {{ content.field_related_resources }}
+    {{ contentPageMacros.syndicationFooter(content) }}
 </div>

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/pdq/node--pdq-cancer-information-summary--hhs-syndication.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/pdq/node--pdq-cancer-information-summary--hhs-syndication.html.twig
@@ -9,9 +9,16 @@
  * is selected.
  */
 #}
-<h1>{{- node.label -}}</h1>
-<div id="cgvBody">
-  <div class="summary-sections">
-    {{ content.field_summary_sections }}
-  </div>
+
+{% import '@cgov_common/content_page_macros.twig' as contentPageMacros %}
+<!-- ********************************* BEGIN Page Content ********************************** -->
+
+<h2 id="bodyTitle">{{ node.label }}</h2>
+<div id="bodyContent">
+    <div class="summaryPage">
+        {{ content.field_summary_sections }}
+    </div>
+</div>
+<div id="footer">
+    {{ contentPageMacros.syndicationFooter(content) }}
 </div>

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/pdq/node--pdq-drug-information-summary--full.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/pdq/node--pdq-drug-information-summary--full.html.twig
@@ -6,7 +6,7 @@
   <div class="resize-content">
     <h1>{{- node.label -}}</h1>
     {{ drupal_block('page_options') }}
-    <div id="cgvBody pdqdruginfosummary">
+    <div id="cgvBody" class="pdqdruginfosummary">
       {{ content.body }}
     </div>
   </div>

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/pdq/paragraph--pdq-summary-section.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/pdq/paragraph--pdq-summary-section.html.twig
@@ -1,4 +1,23 @@
-<section id="{{- content.field_pdq_section_id[0] -}}">
-    <h2>{{- content.field_pdq_section_title -}}</h2>
-    {{ content.field_pdq_section_html }}
-</section>
+
+{#
+/**
+ * @file
+ * Theme override for HHS Syndication of cancer.gov Articles.
+ *
+ * 1804: Separated markup for syndication because it is syndication
+ * output needs to be matched to previous templates 
+ * 
+ */
+#}
+
+{% if '/syndication' in path('<current>')|render|render %}
+    <h3>{{- content.field_pdq_section_title -}}</h3>
+    <div id="{{- content.field_pdq_section_id[0] -}}" class="pdq-sections">
+        {{ content.field_pdq_section_html }}
+    </div>
+{% else %}
+    <section id="{{- content.field_pdq_section_id[0] -}}">
+        <h2>{{- content.field_pdq_section_title -}}</h2>
+        {{ content.field_pdq_section_html }}
+    </section>
+{% endif %}

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content_page_macros.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content_page_macros.twig
@@ -6,36 +6,57 @@
 #}
 
 {% macro displayDates(node, content) %}
-  {% if content.field_date_posted[0] or content.field_date_updated[0] or content.field_date_reviewed[0] %}
-    {# The context used with trans is because some of the labels are translated differently
-        in core.
-    #}
+    {% if content.field_date_posted[0] or content.field_date_updated[0] or content.field_date_reviewed[0] %}
+        {# The context used with trans is because some of the labels are translated differently
+                in core.
+            #}
+        {% if node.getType == 'cgov_blog_post' %}
+            {# Do nothing if this is a Blog Post. Blog Post dates are a special case with different fields. #}
+        {% else %}
 
-    {% if node.getType == 'cgov_blog_post' %}
-      {# Do nothing if this is a Blog Post. Blog Post dates are a special case with different fields. #}
-    {% else %}
-      <div class="document-dates horizontal">
-        <ul class="clearfix">
-          {% if content.field_date_posted[0] %}
-            <li>
-              <strong>{% trans with {'context': 'CGov UI' } %}Posted{% endtrans %}:</strong>
-              {{ content.field_date_posted }}
-            </li>
-          {% endif %}
-          {% if content.field_date_updated[0] %}
-            <li>
-              <strong>{% trans with {'context': 'CGov UI' } %}Updated{% endtrans %}:</strong>
-              {{ content.field_date_updated }}
-            </li>
-          {% endif %}
-          {% if content.field_date_reviewed[0] %}
-            <li>
-              <strong>{% trans with {'context': 'CGov UI' } %}Reviewed{% endtrans %}:</strong>
-              {{ content.field_date_reviewed }}
-            </li>
-          {% endif %}
-        </ul>
-      </div>
+            <div class="document-dates horizontal">
+                <ul class="clearfix">
+                    {% if content.field_date_posted[0] %}
+                        <li>
+                            <strong>{% trans with {'context': 'CGov UI' } %}Posted{% endtrans %}:</strong>
+                            {{ content.field_date_posted }}
+                        </li>
+                    {% endif %}
+                    {% if content.field_date_updated[0] %}
+                        <li>
+                            <strong>{% trans with {'context': 'CGov UI' } %}Updated{% endtrans %}:</strong>
+                            {{ content.field_date_updated }}
+                        </li>
+                    {% endif %}
+                    {% if content.field_date_reviewed[0] %}
+                        <li>
+                            <strong>{% trans with {'context': 'CGov UI' } %}Reviewed{% endtrans %}:</strong>
+                            {{ content.field_date_reviewed }}
+                        </li>
+                    {% endif %}
+                </ul>
+            </div>
+        {% endif %}
     {% endif %}
-  {% endif %}
+{% endmacro %}
+
+
+{% macro syndicationFooter(content) %}
+    {% if content.field_date_posted[0] or content.field_date_updated[0] or content.field_date_reviewed[0] %}
+        <div class="document-dates">
+            {% if content.field_date_posted[0] %}
+                <p>{% trans with {'context': 'CGov UI' } %}Posted{% endtrans %}:
+                    {{ content.field_date_posted}}</p>
+            {% endif %}
+            {% if content.field_date_updated[0] %}
+                <p>{% trans with {'context': 'CGov UI' } %}Updated{% endtrans %}:
+                    {{ content.field_date_updated }}</p>
+            {% endif %}
+            {% if content.field_date_reviewed[0] %}
+                <p>{% trans with {'context': 'CGov UI' } %}Reviewed{% endtrans %}:
+                    {{ content.field_date_reviewed }}</p>
+            {% endif %}
+        </div>
+    {% endif %}
+    <span id="nciLink">This content is provided by the National Cancer Institute (<a href="http://www.cancer.gov">www.cancer.gov</a>)</span>
 {% endmacro %}


### PR DESCRIPTION
Closes #1804 .
Closes #1844 .

Updated templates for CIS and articles so that the syndication output matches what's out on www.

Moved the syndication footer into its own macro because the dates had a slightly different structure than the global content footer(Most notably now being a list as opposed to simple paragraphs.)

(#1844 ).pdqdruginfosummary was incorrectly inserted alongside cgovBody in the id field and causing an error to show up when visiting a DIS page

