### PR TITLE
CTHP video cards w/ external links should always render a card body

### DIFF
--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/entrypoints/cthp/CTHP.scss
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/entrypoints/cthp/CTHP.scss
@@ -160,6 +160,10 @@
     &:last-child {
       margin-bottom: 1.25em;
     }
+
+    &.arrow-link {
+      min-height: 24px;
+    }
   }
 }
 
@@ -263,8 +267,13 @@
   br {
     display: none;
   }
-  a.arrow-link {
-    margin-top: 19px;
+
+  a{
+    &:not(.cthp-mm-text-area){
+    &.arrow-link {
+        margin-top: 19px;
+      }
+    }
   }
 }
 

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/cthp/paragraph--cgov-cthp-video-card.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/cthp/paragraph--cgov-cthp-video-card.html.twig
@@ -28,7 +28,7 @@
   <h2>{{ content.field_cthp_card_title}}</h2>
   <div>
     {{ content.field_cthp_video }}
-    {% if description and (content.field_cthp_target_link|field_value or content.field_cthp_video[0])%}
+    {% if content.field_cthp_target_link|field_value or content.field_cthp_video[0] %}
       <div class="cardBody">
         <a href="{{ url }}" class="arrow-link cthp-mm-text-area">{{ description }}</a>
       </div>


### PR DESCRIPTION
Closes #1809 .

CTHP Video cards with external links should ALWAYS render a card body, even if the description and/or description override is empty.  Per @lburack , the empty render, showing only an exit notification icon and link arrow icon, should signal to the content editor that they messed up.

<img width="472" alt="Screen Shot 2019-05-30 at 4 46 58 PM" src="https://user-images.githubusercontent.com/45469809/58664863-93d41f80-82fd-11e9-8db5-b9059f3b36cf.png">
