### PR TITLE
Fixed file changes after ACSF module update

### DIFF
--- a/acsf-convert/files/docroot/sites/default/acsf.settings.php
+++ b/acsf-convert/files/docroot/sites/default/acsf.settings.php
@@ -4,8 +4,9 @@
  * @file
  * ACSF business logic to catch mistyped domains arriving to the infrastructure.
  *
- * This file is not intended to be modified. Any modification may result in the
- * release process failing.
+ * This file must not be modified. For a customized response / "site not found"
+ * page, change sites/default/settings.php instead (above the line that says
+ * "===== Added by acsf-init") and copy the below logic in there if necessary.
  */
 
 // Only execute the ACSF specific code when it is run on an ACSF infrastructure.
@@ -19,7 +20,7 @@ if (!empty($_ENV['AH_SITE_GROUP']) && !empty($_ENV['AH_SITE_ENVIRONMENT']) && fu
     if (!function_exists('drush_main')) {
       header($_SERVER['SERVER_PROTOCOL'] . ' 404 Not Found');
     }
-    return;
+    return 'acsf-infrastructure';
   }
 
   // Print a 404 response and a small HTML page.

--- a/acsf-convert/files/docroot/sites/g/apc_rebuild.php
+++ b/acsf-convert/files/docroot/sites/g/apc_rebuild.php
@@ -27,10 +27,15 @@ require_once dirname(__FILE__) . '/sites.inc';
 
 if (!empty($_GET['domains'])) {
   $domains = explode(',', $_GET['domains']);
+  // Refresh data for specified domains. If the domains are not found (which
+  // could be caused by the domain not being present or by a read failure of the
+  // sites.json file), that fact will be cached in APC for each domain passed.
   gardens_site_data_refresh_domains($domains);
   syslog(LOG_INFO, sprintf('Updated APC cache for [%s].', $_GET['domains']));
 }
 else {
+  // Refresh data for all domains present in sites.json. If there is a read
+  // failure, the cache will not be refreshed.
   gardens_site_data_refresh_all();
   syslog(LOG_INFO, 'Updated APC cache for all domains.');
 }

--- a/acsf-convert/files/docroot/sites/g/sites.inc
+++ b/acsf-convert/files/docroot/sites/g/sites.inc
@@ -2,10 +2,16 @@
 
 /**
  * @file
- * Configuration file for Drupal's multi-site directory aliasing feature.
+ * ACSF helper functions for Drupal's multi-site directory aliasing feature.
+ *
+ * Make sure to use require_once() so this file is never loaded more than
+ * once per page.
  */
 
 // Load SimpleRest classes, needed for sending requests to the Site Factory.
+// @todo if we ever change/test gardens_site_data_alert_send(), we should move
+//   this include_once() into there. It is perfectly fine to execute in a
+//   shutdown function (as long as we don't make assumptions about the cwd).
 include_once dirname(__FILE__) . '/SimpleRest.php';
 
 // Bail out if we're not on an Acquia server.
@@ -13,8 +19,6 @@ if (function_exists('is_acquia_host') && !is_acquia_host()) {
   return;
 }
 
-// Make sure to use require_once() so this file is never loaded more than
-// once per page.
 define('GARDENS_SITE_DATA_USE_APC', (get_cfg_var('gardens.disable_apc_for_sites_php') != 1));
 // TTL set to 30 minutes to allow a cron to run full refreshes.
 define('GARDENS_SITE_DATA_TTL', 1800);
@@ -41,18 +45,25 @@ define('GARDENS_SITE_DATA_READ_FAILURE_TTL', 60);
 // is unreadable. Sitegroup + env need to be filled.
 define('GARDENS_SITE_JSON_ALERT_LOCK_TEMPLATE', '/mnt/tmp/%s.%s/.sites-json-alert');
 
-// Populate $_ENV if we are running cli.
-if ((!isset($_ENV['AH_SITE_NAME']) || !isset($_ENV['AH_SITE_GROUP']) || !isset($_ENV['AH_SITE_ENVIRONMENT'])) && file_exists('/var/www/site-scripts/site-info.php')) {
-  require_once '/var/www/site-scripts/site-info.php';
-  list($name, $group, $stage, $secret) = ah_site_info();
-  if (!isset($_ENV['AH_SITE_NAME'])) {
-    $_ENV['AH_SITE_NAME'] = $name;
+// This fallback to populate $_ENV should not be necessary on Acquia Hosting
+// anymore. Also, ah_site_info() is not a public API and not guaranteed to
+// keep existing. Still, we keep it for exotic environments which may be using
+// it to insert the environment values, e.g. local development environments.
+if (!isset($_ENV['AH_SITE_NAME']) || !isset($_ENV['AH_SITE_GROUP']) || !isset($_ENV['AH_SITE_ENVIRONMENT'])) {
+  if (!function_exists('ah_site_info') && file_exists('/var/www/site-scripts/site-info.php')) {
+    require_once '/var/www/site-scripts/site-info.php';
   }
-  if (!isset($_ENV['AH_SITE_GROUP'])) {
-    $_ENV['AH_SITE_GROUP'] = $group;
-  }
-  if (!isset($_ENV['AH_SITE_ENVIRONMENT'])) {
-    $_ENV['AH_SITE_ENVIRONMENT'] = $stage;
+  if (function_exists('ah_site_info')) {
+    list($name, $group, $stage, $secret) = ah_site_info();
+    if (!isset($_ENV['AH_SITE_NAME'])) {
+      $_ENV['AH_SITE_NAME'] = $name;
+    }
+    if (!isset($_ENV['AH_SITE_GROUP'])) {
+      $_ENV['AH_SITE_GROUP'] = $group;
+    }
+    if (!isset($_ENV['AH_SITE_ENVIRONMENT'])) {
+      $_ENV['AH_SITE_ENVIRONMENT'] = $stage;
+    }
   }
 }
 
@@ -70,6 +81,128 @@ function gardens_site_data_load_file() {
     return json_decode($json, TRUE);
   }
   return FALSE;
+}
+
+/**
+ * Checks for a registered ACSF site based on Apache server variables.
+ *
+ * Prerequisite: $_SERVER and $_ENV are both populated as per Acquia practices.
+ *
+ * @return array|int|null
+ *   0 if no site was found for the given domain; NULL if a sites.json read
+ *   failure was encountered; otherwise, an array of site data as constructed
+ *   by gardens_site_data_build_data() - with an added key 'dir_key' containing
+ *   the key where sites.php would expect to set this site's directory in its
+ *   '$sites' variable.
+ *
+ * @see gardens_site_data_build_data()
+ */
+function gardens_site_data_get_site_from_server_info() {
+  // First derive the 'site uri' (the base domain with possibly a sub path).
+  if (PHP_SAPI === 'cli' && class_exists('\Drush\Drush') && \Drush\Drush::hasContainer()) {
+    $acsf_drush_boot_manager = \Drush\Drush::bootstrapManager();
+    if ($acsf_drush_boot_manager->getUri()) {
+      $acsf_uri = $acsf_drush_boot_manager->getUri();
+    }
+    // Drush site-install gets confused about the uri when we specify the
+    // --sites-subdir option. By specifying the --acsf-install-uri option with
+    // the value of the standard domain, we can catch that here and correct the
+    // uri argument for drush site installs.
+    $acsf_drush_input = \Drush\Drush::input();
+    try {
+      $acsf_install_uri = $acsf_drush_input->getOption('acsf-install-uri');
+      if ($acsf_install_uri) {
+        $acsf_uri = $acsf_install_uri;
+      }
+    }
+    catch (InvalidArgumentException $e) {
+    }
+    if (!preg_match('|https?://|', $acsf_uri)) {
+      $acsf_uri = 'http://' . $acsf_uri;
+    }
+    $host = $_SERVER['HTTP_HOST'] = parse_url($acsf_uri, PHP_URL_HOST);
+    $path = parse_url($acsf_uri, PHP_URL_PATH);
+  }
+  else {
+    $host = rtrim($_SERVER['HTTP_HOST'], '.');
+    $path = $_SERVER['SCRIPT_NAME'] ? $_SERVER['SCRIPT_NAME'] : $_SERVER['SCRIPT_FILENAME'];
+    // Path based domains are implemented by symlinking a subdirectory back to
+    // the docroot. To support these, we need to know which part of the script
+    // path is the domain sub path, and which is a URL path inside the website.
+    // (Note our only concern in 'supporting path based domains' is locating
+    // the right site. How the request would derive the right URL inside that
+    // site is not up to us, and the only thing that is actually known to work
+    // with path based domains -through HTTP requests or Drush- is the standard
+    // index.php.)
+    if (substr($path, -10) === '/index.php') {
+      // Assume the requested index.php is in the root, meaning that the full
+      // script path leading up to it is the domain sub path. In other words:
+      // we do not support index.php being anywhere else except the docroot.
+      // This goes for every customer, not just those using path based domains.
+      $path = substr($path, 0, strlen($path) - 10);
+    }
+    else {
+      // For any non-index.php path, assume the sub path is empty. In other
+      // words: simply do not support path based domains for these.
+      $path = '';
+    }
+  }
+
+  // Convert host/path to lower case because our registry stores data this way;
+  // upper cased paths may still not be recognized (by Drush commands, unless
+  // there is a symlink matching the specific case) though.
+  $host = strtolower($host);
+  // The path may have a trailing slash (because PHP_URL_PATH can contain one,
+  // and because a script may have set SCRIPT_NAME to '//index.php'). Unify, so
+  // the result is either empty or a path with a leading slash.
+  $path = strtolower(rtrim($path, '/'));
+
+  // Get data for the 'site uri' from APC or sites.json.
+  if (!GARDENS_SITE_DATA_USE_APC) {
+    $data = gardens_site_data_refresh_one($host . $path);
+  }
+  else {
+    // Check for data in APC: FALSE means no; 0 means "not found" cached in
+    // APC; NULL means "sites.json read failure" cached in APC.
+    $data = gardens_site_data_cache_get($host . $path);
+    if ($data === FALSE) {
+      // There's no guarantee about how many times this will be called, because
+      // Core doesn't do any caching around the 'conf path'. For instance Drush
+      // 7 would will call this file and logic around 19 times during each
+      // command; Drush 8 only once and Drush 9.6 increases this to around 4. To
+      // minimise gluster access, cache data to a local static cache. We assume
+      // that *if* we have data for a given domain at any point during a request
+      // on the command line then that data remains the same for the duration of
+      // the command execution.
+      $static_cache = &drupal_static('acsf_sites_php_site_data');
+      if (isset($static_cache[$host . $path])) {
+        $data = $static_cache[$host . $path];
+      }
+      else {
+        $data = gardens_site_data_refresh_one($host . $path);
+        if ($data) {
+          // We only cache truthy data ourselves, because we don't want to
+          // assume that if a domain is not found (or there's a gluster error),
+          // that will stay the same during command execution. Note we also set
+          // the static cache if APC is active (which isn't necessary) because
+          // it doesn't really matter and because otherwise, we would have to
+          // - either replicate the check for APC which is now abstracted away
+          //   into gardens_site_data_cache_get()
+          // - or move $static_cache into gardens_site_data_cache_get() &
+          //   gardens_site_data_cache_set(), which isn't wrong but we prefer
+          //   not caching every domain in memory when the full file gets read.
+          $static_cache[$host . $path] = $data;
+        }
+      }
+    }
+  }
+
+  if (is_array($data)) {
+    // Generate the expected drupal sites.php key for this domain.
+    $data['dir_key'] = str_replace('/', '.', $host . $path);
+  }
+
+  return $data;
 }
 
 /**
@@ -157,6 +290,8 @@ function gardens_site_data_build_data(array $site, array $map) {
  *
  * @return array
  *   A gardens site data structure, or zero if the domain was not found.
+ *
+ * @deprecated Use gardens_site_data_refresh_one() for a faster near-equivalent.
  */
 function gardens_site_data_get_site_from_file($domain) {
   $result = 0;

--- a/acsf-convert/files/docroot/sites/sites.php
+++ b/acsf-convert/files/docroot/sites/sites.php
@@ -2,8 +2,51 @@
 
 /**
  * @file
- * Configuration file for Drupal's multi-site directory aliasing feature.
+ * Drupal multi-site configuration file for sites on Acquia Cloud Site Factory.
+ *
+ * See Drupal's example.sites.php for general information on this file.
+ *
+ * In short: this file is supposed to populate the $sites variable for use by
+ * the caller, with a mapping from domain names to site specific directories.
+ * If the requested domain has a site specific directory defined, the caller
+ * (likely) includes the settings.php in that specific directory rather than
+ * sites/default/settings.php.
+ *
+ * Acquia Cloud Site Factory has its own storage of per-domain data, which is
+ * read by this file to get the needed info. In addition, the global variable
+ * $gardens_site_settings is populated with various per-site information, for
+ * use by the site specific settings.php file. (See: sites/g/settings.php).
+ *
+ * If an error occurs or the domain is not found, then we quit processing
+ * without setting $sites. The caller then (likely) includes
+ * sites/default/acsf.settings.php from sites/default/settings.php, which will
+ * emit a "Site not found" response. That response can be customized by
+ * modifying sites/default/settings.php.
+ *
+ * (At least Acquia's standard) Drush aliases are *not supported* for usage
+ * with Acquia Cloud Site Factory. Drush9 commands simply don't work with them.
  */
+
+// Protect against sites.php being included from the wrong docroot, on Acquia
+// servers containing multiple (staging) environments for a customer. This is
+// a known issue only in previous versions of the module which worked with
+// Drush7/8 + Acquia's aliases, but it seems prudent to do this check anyway.
+// Notes:
+// - The environment values are always defined on Acquia hardware. If they are
+//   not defined, we cannot assume anything about the file system structure so
+//   we skip this check.
+// - realpath() includes AH_SITE_NAME; we instead want to match
+//   AH_SITE_GROUP.AH_SITE_ENVIRONMENT (which is always a symlink)
+//   - to accommodate for possible future changes or botched provisioning;
+//   - because Site Factory doesn't use AH_SITE_NAME anywhere else;
+//   - because AH_SITE_NAME may not be correct in some cases, e.g. when our
+//     post-db-copy/000-acquia_required_scrub.php hook executes acsf-site-scrub.
+if (isset($_ENV['AH_SITE_NAME']) && isset($_ENV['AH_SITE_ENVIRONMENT'])
+  && strpos(__FILE__, realpath("/var/www/html/{$_ENV['AH_SITE_GROUP']}.{$_ENV['AH_SITE_ENVIRONMENT']}/docroot")) !== 0
+  && strpos(__FILE__, realpath("/mnt/files/{$_ENV['AH_SITE_GROUP']}.{$_ENV['AH_SITE_ENVIRONMENT']}/livedev/docroot")) !== 0
+) {
+  return;
+}
 
 if (!function_exists('acsf_hooks_includes')) {
 
@@ -18,15 +61,18 @@ if (!function_exists('acsf_hooks_includes')) {
    *   ascending.
    */
   function acsf_hooks_includes($hook_name) {
-    $hook_pattern = sprintf('%s/../factory-hooks/%s/*.php', getcwd(), $hook_name);
+    $hook_pattern = sprintf('%s/../factory-hooks/%s/*.php', DRUPAL_ROOT, $hook_name);
     return glob($hook_pattern);
   }
 
 }
 
 // Include custom sites.php code from factory-hooks/pre-sites-php.
-foreach (acsf_hooks_includes('pre-sites-php') as $pre_hook) {
-  include $pre_hook;
+foreach (acsf_hooks_includes('pre-sites-php') as $_acsf_include_file) {
+  // This should not use include_once / require_once. Some Drush versions do
+  // Drupal bootstrap multiple times, and include_once / require_once would
+  // make the hook modifications not be included on the second bootstrap.
+  include $_acsf_include_file;
 }
 
 if (!function_exists('is_acquia_host')) {
@@ -49,24 +95,9 @@ if (!is_acquia_host()) {
   return;
 }
 
-// There are some drush commands which run other commands as a post execution
-// task, for example the drush updb which automatically executes a cache clear
-// or rebuild after the update has finished, however this is handled by invoking
-// the relevant drush command in a different process on the same site. Since we
-// are calling these drush commands without an alias, drush8 is trying to
-// discover if there is an alias that covers the current site, and in the
-// process it walks over the drush aliases file and includes the sites.php for
-// each entry. In our case drush will include the sites.php for the live and the
-// update environment causing a fatal php error because sites.php includes
-// sites.inc and the functions would be redefined on the fly.
-// When calling the commands with an alias a different issue surfaces: starting
-// from drush7, drush is static caching the alias entries as is, meaning that
-// the extra root and uri parameters we pass to the drush command do not get
-// applied to the static alias entry and when drush is trying to run the cache
-// clear or rebuild using this static cache then it is going to try to run it on
-// the wrong site.
-// Therefore, for the time being, safeguard the sites.inc inclusion and avoid
-// using aliases.
+// This safeguard should not be necessary since we stopped executing sites.php
+// on unrelated environments (above). We keep it only in case removing it would
+// have an effect in exotic unknown cases.
 if (!function_exists('gardens_site_data_load_file')) {
   require_once dirname(__FILE__) . '/g/sites.inc';
 }
@@ -77,81 +108,13 @@ if (empty($_ENV['AH_SITE_GROUP']) || empty($_ENV['AH_SITE_ENVIRONMENT']) || !fun
   return;
 }
 
-if (PHP_SAPI === 'cli') {
-  // Leaving notes here on a lesson I learned the hard way: it is absolutely
-  // imperative that no variable name defined in this file collides with any
-  // variable defined in DrupalKernel::findSitePath before the inclusion of this
-  // file (eg $http_host) as values here may overwrite values from there.
-  $acsf_http_host = '';
-  if (class_exists('\Drush\Drush') && \Drush\Drush::hasContainer()) {
-    $acsf_drush_boot_manager = \Drush\Drush::bootstrapManager();
-    if ($acsf_drush_boot_manager->getUri()) {
-      $acsf_http_host = $acsf_drush_boot_manager->getUri();
-    }
-    // Drush site-install gets confused about the uri when we specify the
-    // --sites-subdir option. By specifying the --acsf-install-uri option with
-    // the value of the standard domain, we can catch that here and correct the
-    // uri argument for drush site installs.
-    $acsf_drush_input = \Drush\Drush::input();
-    try {
-      $acsf_install_uri = $acsf_drush_input->getOption('acsf-install-uri');
-      if ($acsf_install_uri) {
-        $acsf_http_host = $acsf_install_uri;
-      }
-    }
-    catch (InvalidArgumentException $e) {
-    }
-  }
-  if (!preg_match('|https?://|', $acsf_http_host)) {
-    $acsf_http_host = 'http://' . $acsf_http_host;
-  }
-  $host = $_SERVER['HTTP_HOST'] = parse_url($acsf_http_host, PHP_URL_HOST);
-  $acsf_uri_path = parse_url($acsf_http_host, PHP_URL_PATH);
-  $acsf_uri_path .= '/index.php';
-}
-else {
-  $host = rtrim($_SERVER['HTTP_HOST'], '.');
-  $acsf_uri_path = $_SERVER['SCRIPT_NAME'] ? $_SERVER['SCRIPT_NAME'] : $_SERVER['SCRIPT_FILENAME'];
-}
-
-$acsf_host = implode('.', array_reverse(explode(':', $host)));
-// Build an array with maximum one path fragment. Since the paths always start
-// with a '/' and we are splitting them by the '/', the array will always start
-// with an empty string.
-$acsf_uri_path_fragments = explode('/', $acsf_uri_path);
-$acsf_uri_path_fragments = array_diff($acsf_uri_path_fragments, ['index.php']);
-$acsf_uri_path_fragments = array_slice($acsf_uri_path_fragments, 0, 2);
-// Check whether we can find site data for the hostname suffixed by one
-// fragment, or for only the hostname.
-$data = NULL;
-for ($i = count($acsf_uri_path_fragments); $i > 0; $i--) {
-  $dir = $acsf_host . implode('.', array_slice($acsf_uri_path_fragments, 0, $i));
-  $acsf_uri = $acsf_host . implode('/', array_slice($acsf_uri_path_fragments, 0, $i));
-  if (!GARDENS_SITE_DATA_USE_APC) {
-    // gardens_site_data_refresh_one() will do a full parse if the domain is in
-    // the file at all and a single line parse fails.
-    $data = gardens_site_data_refresh_one($acsf_uri);
-  }
-  else {
-    // Check for data in APC: FALSE means no; 0 means "not found" cached in APC;
-    // NULL means "sites.json read failure" cached in APC.
-    $data = gardens_site_data_cache_get($acsf_uri);
-    if ($data === FALSE) {
-      $data = gardens_site_data_refresh_one($acsf_uri);
-    }
-  }
-  // Check again for a hostname with less fragments if we got a "not found";
-  // stop if we got a read failure or found data.
-  if ($data || $data === NULL) {
-    break;
-  }
-}
+$_tmp = gardens_site_data_get_site_from_server_info();
 
 // If either "not found" or "read failure" (from either the cache or the
 // sites.json file): don't set $sites and fall through (to, probably, reading
 // sites/default/settings.php for settings).
-if (empty($data)) {
-  if ($data === NULL) {
+if (empty($_tmp)) {
+  if ($_tmp === NULL) {
     // If we encountered a read error, indicate that we want the same (short)
     // cache time for the page, as we have for the data in APC.
     $GLOBALS['gardens_site_settings']['page_ttl'] = GARDENS_SITE_DATA_READ_FAILURE_TTL;
@@ -159,11 +122,17 @@ if (empty($data)) {
   return;
 }
 
-$GLOBALS['gardens_site_settings'] = $data['gardens_site_settings'];
-$sites[$dir] = $data['dir'];
+// We found a site, so add the corresponding 'configuration directory' to
+// $sites, as per the regular sites.php spec. (For most Drupal sites this is
+// a single-layer directory equal to a domain name; for us, it is typically
+// g/files/SITE-ID.)
+$sites[$_tmp['dir_key']] = $_tmp['dir'];
+// Also set 'gardens_site_settings' for other code further on. (Mainly
+// settings.php.)
+$GLOBALS['gardens_site_settings'] = $_tmp['gardens_site_settings'];
 
 // Include custom sites.php code from factory-hooks/post-sites-php, only when
 // a domain was found.
-foreach (acsf_hooks_includes('post-sites-php') as $post_hook) {
-  include $post_hook;
+foreach (acsf_hooks_includes('post-sites-php') as $_acsf_include_file) {
+  include $_acsf_include_file;
 }

--- a/docroot/sites/default/settings.php
+++ b/docroot/sites/default/settings.php
@@ -8,7 +8,10 @@
 if (!empty($_ENV['AH_SITE_ENVIRONMENT']) &&
   function_exists('gardens_site_data_get_filepath')) {
   // ===== Added by acsf-init, please do not delete. Section start. =====
-  include dirname(__FILE__) . '/acsf.settings.php';
+  $_acsf_infrastructure = include dirname(__FILE__) . '/acsf.settings.php';
+  if ($_acsf_infrastructure === 'acsf-infrastructure') {
+    return;
+  }
   // ===== Added by acsf-init, please do not delete. Section end. =====
 }
 


### PR DESCRIPTION
`drush --include=docroot/modules/contrib/acsf/acsf_init acsf-init-verify` failed because updates of the module can bring along file changes we need to apply to our acsf-convert folder.