### PR TITLE
NCI-000: Updating libraries to remove specific version IDs

### DIFF
--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/cgov_common.libraries.yml
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/cgov_common.libraries.yml
@@ -1,11 +1,9 @@
 global-styling:
-  version: 1.x
   css:
     theme:
       dist/css/Common.css: { preprocess: false }
 
 global-scripts:
-  version: 1.x
   js:
     dist/js/Common.js: { preprocess: false }
   dependencies:
@@ -19,7 +17,6 @@ global-scripts:
     - core/jquery.ui.widget
 
 article:
-  version: 1.x
   css:
     theme:
       dist/css/Article.css: { preprocess: false }
@@ -30,7 +27,6 @@ article:
     - core/jquery.ui
 
 homelanding:
-  version: 1.x
   css:
     theme:
       dist/css/Homelanding.css: { preprocess: false }
@@ -41,7 +37,6 @@ homelanding:
     - core/jquery.ui
 
 pdq:
-  version: 1.x
   css:
     theme:
       dist/css/PDQ.css: { preprocess: false }
@@ -52,7 +47,6 @@ pdq:
     - core/jquery.ui
 
 minilanding:
-  version: 1.x
   css:
     theme:
       dist/css/Minilanding.css: { preprocess: false }
@@ -63,7 +57,6 @@ minilanding:
     - core/jquery.ui
 
 cancer-centers:
-  version: 1.x
   css:
     theme:
       dist/css/CancerCenters.css: { preprocess: false }
@@ -71,7 +64,6 @@ cancer-centers:
     dist/js/CancerCenters.js: { preprocess: false }
 
 biography:
-  version: 1.x
   css:
     theme:
       dist/css/Biography.css: { preprocess: false }
@@ -79,7 +71,6 @@ biography:
     dist/js/Biography.js: { preprocess: false }
 
 event:
-  version: 1.x
   css:
     theme:
       dist/css/Event.css: { preprocess: false }
@@ -87,7 +78,6 @@ event:
     dist/js/Event.js: { preprocess: false }
 
 blogPost:
-  version: 1.x
   css:
     theme:
       dist/css/BlogPost.css: { preprocess: false }
@@ -98,7 +88,6 @@ blogPost:
     - core/jquery.ui
 
 blogSeries:
-  version: 1.x
   css:
     theme:
       dist/css/BlogSeries.css: { preprocess: false }
@@ -110,7 +99,6 @@ blogSeries:
     - core/jquery.ui.accordion
 
 purple-theme:
-  version: 1.x
   css:
     theme:
       dist/css/Purple.css: { preprocess: false }
@@ -118,7 +106,6 @@ purple-theme:
     dist/js/Purple.js: { preprocess: false }
 
 blue-theme:
-  version: 1.x
   css:
     theme:
       dist/css/Blue.css: { preprocess: false }
@@ -126,7 +113,6 @@ blue-theme:
     dist/js/Blue.js: { preprocess: false }
 
 green-theme:
-  version: 1.x
   css:
     theme:
       dist/css/Green.css: { preprocess: false }
@@ -134,7 +120,6 @@ green-theme:
     dist/js/Green.js: { preprocess: false }
 
 cthp:
-  version: 1.x
   css:
     theme:
       dist/css/CTHP.css: { preprocess: false }


### PR DESCRIPTION
### Changes
- Removes versions for libraries defined in cgov_common.
  - When not defining a version in the library definition, Drupal will add a cache-buster to the end of the file. 
  - If a version is added, the cache-buster is not added as it assumes the version of the library will be updated when changes are made. 

### Future Enhancements
- This fixes the issue with updates not being pushed through, but it would be nice to update this to utilize the content hash so that it only needs to be updated when changes are made.  

### Alternate Considerations: 
* If you want to turn on aggregation for these files, it looks like there is a parameter that can be passed into the libraries for a SMACSS group. 
* https://www.drupal.org/docs/8/theming/adding-stylesheets-css-and-javascript-js-to-a-drupal-8-theme#libraries-options-details
    * group | Assets are aggregated per group.Default: The SMACSS group in which the asset is placed. | Is rarely used



