### PR TITLE
(#1840) Override Promotional Image Should Display 4x3 Image Crop

### DIFF
--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_promo/config/install/core.entity_view_display.paragraph.cgov_card_external.recommended_content_card.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_promo/config/install/core.entity_view_display.paragraph.cgov_card_external.recommended_content_card.yml
@@ -16,7 +16,7 @@ bundle: cgov_card_external
 mode: recommended_content_card
 content:
   field_featured_url:
-    weight: 3
+    weight: 2
     label: hidden
     settings:
       trim_length: 80
@@ -45,10 +45,10 @@ content:
     region: content
   field_override_image_promotional:
     type: entity_reference_entity_view
-    weight: 2
+    weight: 3
     label: hidden
     settings:
-      view_mode: image_crop_article
+      view_mode: image_crop_featured
       link: false
     third_party_settings: {  }
     region: content


### PR DESCRIPTION
* Fixed override crop (4x3 / featured) - recommended paragraph crop mode changed from image_crop_article to image_crop_featured