### PR TITLE
Remove placeholder processing from the first pass migrations.

### DIFF
--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_migration/config/install/migrate_plus.migration.article_es_migration.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_migration/config/install/migrate_plus.migration.article_es_migration.yml
@@ -203,8 +203,6 @@ process:
     -
       plugin: remove_rx_wrapper
       source: field_intro_text
-    -
-      plugin: generate_placeholders
   field_intro_text/format:
    plugin: default_value
    default_value: streamlined

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_migration/config/install/migrate_plus.migration.biography_migration.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_migration/config/install/migrate_plus.migration.biography_migration.yml
@@ -141,8 +141,7 @@ process:
     -
       plugin: remove_rx_wrapper
       source: body
-    -
-      plugin: generate_placeholders
+
 
   uid:
    plugin: default_value

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_migration/config/install/migrate_plus.migration.blogpost_es_migration.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_migration/config/install/migrate_plus.migration.blogpost_es_migration.yml
@@ -206,8 +206,7 @@ process:
     -
       plugin: remove_rx_wrapper
       source: body
-    -
-      plugin: generate_placeholders
+
   body/format:
    plugin: default_value
    default_value: full_html

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_migration/config/install/migrate_plus.migration.blogseries_en_migration.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_migration/config/install/migrate_plus.migration.blogseries_en_migration.yml
@@ -189,8 +189,7 @@ process:
     -
       plugin: remove_rx_wrapper
       source: field_about_blog
-    -
-      plugin: generate_placeholders
+
   field_archive_back_years: field_archive_back_years
   field_archive_group_by: field_archive_group_by
 

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_migration/config/install/migrate_plus.migration.blogseries_es_migration.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_migration/config/install/migrate_plus.migration.blogseries_es_migration.yml
@@ -193,8 +193,7 @@ process:
     -
       plugin: remove_rx_wrapper
       source: field_about_blog
-    -
-      plugin: generate_placeholders
+
   field_about_blog/format:
    plugin: default_value
    default_value: streamlined

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_migration/config/install/migrate_plus.migration.cancercenter_migration.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_migration/config/install/migrate_plus.migration.cancercenter_migration.yml
@@ -250,8 +250,7 @@ process:
     -
       plugin: remove_rx_wrapper
       source: body
-    -
-      plugin: generate_placeholders
+
   body/format:
    plugin: default_value
    default_value: full_html

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_migration/config/install/migrate_plus.migration.cgovimage_es_migration.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_migration/config/install/migrate_plus.migration.cgovimage_es_migration.yml
@@ -97,8 +97,7 @@ process:
     -
       plugin: remove_rx_wrapper
       source: field_caption
-    -
-      plugin: generate_placeholders
+
   field_caption/format:
      plugin: default_value
      default_value: simple

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_migration/config/install/migrate_plus.migration.cgovimage_migration.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_migration/config/install/migrate_plus.migration.cgovimage_migration.yml
@@ -93,8 +93,7 @@ process:
     -
       plugin: remove_rx_wrapper
       source: field_caption
-    -
-      plugin: generate_placeholders
+
   field_caption/format:
      plugin: default_value
      default_value: simple

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_migration/config/install/migrate_plus.migration.citation_migration.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_migration/config/install/migrate_plus.migration.citation_migration.yml
@@ -39,8 +39,6 @@ process:
    -
      plugin: remove_rx_wrapper
      source: field_citation_content
-   -
-     plugin: generate_placeholders
  field_citation_content/format:
     plugin: default_value
     default_value: streamlined

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_migration/config/install/migrate_plus.migration.contentblock_migration.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_migration/config/install/migrate_plus.migration.contentblock_migration.yml
@@ -41,8 +41,7 @@ process:
     -
       plugin: remove_rx_wrapper
       source: field_html_content
-    -
-      plugin: generate_placeholders
+
   field_html_content/format:
    plugin: default_value
    default_value: full_html

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_migration/config/install/migrate_plus.migration.contextualimage_es_migration.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_migration/config/install/migrate_plus.migration.contextualimage_es_migration.yml
@@ -64,8 +64,7 @@ process:
     -
       plugin: remove_rx_wrapper
       source: field_caption
-    -
-      plugin: generate_placeholders
+
   field_caption/format:
      plugin: default_value
      default_value: simple

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_migration/config/install/migrate_plus.migration.contextualimage_migration.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_migration/config/install/migrate_plus.migration.contextualimage_migration.yml
@@ -61,8 +61,7 @@ process:
     -
       plugin: remove_rx_wrapper
       source: field_caption
-    -
-      plugin: generate_placeholders
+
   field_caption/format:
      plugin: default_value
      default_value: simple

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_migration/config/install/migrate_plus.migration.cthpcontentblock_migration.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_migration/config/install/migrate_plus.migration.cthpcontentblock_migration.yml
@@ -51,8 +51,7 @@ process:
     -
       plugin: remove_rx_wrapper
       source: body
-    -
-      plugin: generate_placeholders
+
   body/format:
    plugin: default_value
    default_value: full_html

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_migration/config/install/migrate_plus.migration.cthpguidecard_migration.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_migration/config/install/migrate_plus.migration.cthpguidecard_migration.yml
@@ -57,8 +57,7 @@ process:
    -
      plugin: remove_rx_wrapper
      source: field_cthp_guide_card_desc
-   -
-     plugin: generate_placeholders
+
 
  field_cthp_guide_card_desc/format:
      plugin: default_value

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_migration/config/install/migrate_plus.migration.cthpoverviewcard_migration.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_migration/config/install/migrate_plus.migration.cthpoverviewcard_migration.yml
@@ -46,8 +46,7 @@ process:
    -
      plugin: remove_rx_wrapper
      source: field_cthp_overview_card_text
-   -
-     plugin: generate_placeholders
+
  field_cthp_overview_card_text/format:
     plugin: default_value
     default_value: streamlined

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_migration/config/install/migrate_plus.migration.event_migration.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_migration/config/install/migrate_plus.migration.event_migration.yml
@@ -133,8 +133,7 @@ process:
     -
       plugin: remove_rx_wrapper
       source: body
-    -
-      plugin: generate_placeholders
+
   uid:
    plugin: default_value
    default_value: 1

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_migration/config/install/migrate_plus.migration.infographic_en_migration.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_migration/config/install/migrate_plus.migration.infographic_en_migration.yml
@@ -195,8 +195,7 @@ process:
     -
       plugin: remove_rx_wrapper
       source: body
-    -
-      plugin: generate_placeholders
+
   body/format:
    plugin: default_value
    default_value: full_html

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_migration/config/install/migrate_plus.migration.infographic_es_migration.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_migration/config/install/migrate_plus.migration.infographic_es_migration.yml
@@ -203,8 +203,7 @@ process:
     -
       plugin: remove_rx_wrapper
       source: body
-    -
-      plugin: generate_placeholders
+
 
   body/format:
    plugin: default_value

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_migration/config/install/migrate_plus.migration.minilanding_es_migration.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_migration/config/install/migrate_plus.migration.minilanding_es_migration.yml
@@ -192,8 +192,7 @@ process:
     -
       plugin: remove_rx_wrapper
       source: field_intro_text
-    -
-      plugin: generate_placeholders
+
 
   field_intro_text/format:
    plugin: default_value

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_migration/config/install/migrate_plus.migration.pressrelease_en_migration.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_migration/config/install/migrate_plus.migration.pressrelease_en_migration.yml
@@ -146,8 +146,7 @@ process:
     -
       plugin: remove_rx_wrapper
       source: body
-    -
-      plugin: generate_placeholders
+
 
   uid:
    plugin: default_value

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_migration/config/install/migrate_plus.migration.pressrelease_es_migration.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_migration/config/install/migrate_plus.migration.pressrelease_es_migration.yml
@@ -163,8 +163,7 @@ process:
     -
       plugin: remove_rx_wrapper
       source: body
-    -
-      plugin: generate_placeholders
+
   body/format:
    plugin: default_value
    default_value: full_html

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_migration/config/install/migrate_plus.migration.rawhtml_migration.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_migration/config/install/migrate_plus.migration.rawhtml_migration.yml
@@ -30,12 +30,7 @@ source:
 
 process:
   id: id
-  field_raw_html/value:
-    -
-      plugin: remove_rx_wrapper
-      source: field_html_content
-    -
-      plugin: generate_placeholders
+  field_raw_html/value: field_html_content
   field_raw_html/format:
    plugin: default_value
    default_value: raw_html

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_migration/config/install/migrate_plus.migration.rawhtmlblock_migration.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_migration/config/install/migrate_plus.migration.rawhtmlblock_migration.yml
@@ -47,12 +47,7 @@ process:
   langcode: langcode
   info: info
 
-  field_raw_html/value:
-    -
-      plugin: remove_rx_wrapper
-      source: field_html_content
-    -
-      plugin: generate_placeholders
+  field_raw_html/value: field_html_content
   field_raw_html/format:
    plugin: default_value
    default_value: raw_html

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_migration/config/install/migrate_plus.migration.video_en_migration.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_migration/config/install/migrate_plus.migration.video_en_migration.yml
@@ -129,8 +129,6 @@ process:
    -
     plugin: remove_rx_wrapper
     source: field_caption
-   -
-     plugin: generate_placeholders
 
   field_caption/format:
    plugin: default_value

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_migration/config/install/migrate_plus.migration.video_es_migration.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_migration/config/install/migrate_plus.migration.video_es_migration.yml
@@ -134,8 +134,7 @@ process:
     -
       plugin: remove_rx_wrapper
       source: field_caption
-    -
-      plugin: generate_placeholders
+
 
   field_caption/format:
    plugin: default_value


### PR DESCRIPTION
Removes placeholder generation from the first pas migrations.  (INCLUDING RAW_HTML)