### PR TITLE
(#1936) Create an Embeddable Image Mode for Inline Images

### DIFF
--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.module
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.module
@@ -318,3 +318,23 @@ function cgov_core_page_attachments_alter(array &$attachments) {
   $cache_tags = isset($attachments['#cache']['tags']) ? $attachments['#cache']['tags'] : [];
   $attachments['#cache']['tags'] = Cache::mergeTags($cache_tags, $config->getCacheTags());
 }
+
+/**
+ * Implements hook_theme_suggestions_HOOK().
+ *
+ * The entity embed module does not allow suggestions for the various display
+ * modes. This has been ok, except for the fact that with inline images we
+ * really do not want the container wrapper rendered.
+ */
+function cgov_core_theme_suggestions_entity_embed_container(array $variables) {
+  $suggestions = [];
+
+  $original_hook = $variables['theme_hook_original'];
+  $display = $variables['element']['#attributes']['data-entity-embed-display'];
+  if ($display) {
+    $sugg = str_replace("view_mode:", "", $display);
+    $suggestions[] = $original_hook . '__' . $sugg;
+  }
+
+  return $suggestions;
+}

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_image/config/install/core.entity_view_display.media.cgov_contextual_image.image_display_inline.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_image/config/install/core.entity_view_display.media.cgov_contextual_image.image_display_inline.yml
@@ -1,0 +1,41 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.image_display_inline
+    - field.field.media.cgov_contextual_image.field_accessible_version
+    - field.field.media.cgov_contextual_image.field_caption
+    - field.field.media.cgov_contextual_image.field_credit
+    - field.field.media.cgov_contextual_image.field_display_enlarge
+    - field.field.media.cgov_contextual_image.field_media_image
+    - field.field.media.cgov_contextual_image.field_original_source
+    - image.style.cgov_article
+    - media.type.cgov_contextual_image
+  module:
+    - image
+id: media.cgov_contextual_image.image_display_inline
+targetEntityType: media
+bundle: cgov_contextual_image
+mode: image_display_inline
+content:
+  field_media_image:
+    weight: 0
+    label: hidden
+    settings:
+      image_style: cgov_article
+      image_link: ''
+    third_party_settings: {  }
+    type: image
+    region: content
+hidden:
+  content_moderation_control: true
+  created: true
+  field_accessible_version: true
+  field_caption: true
+  field_credit: true
+  field_display_enlarge: true
+  field_original_source: true
+  langcode: true
+  name: true
+  thumbnail: true
+  uid: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_image/config/install/core.entity_view_display.media.cgov_image.image_display_inline.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_image/config/install/core.entity_view_display.media.cgov_image.image_display_inline.yml
@@ -1,0 +1,49 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.image_display_inline
+    - field.field.media.cgov_image.field_accessible_version
+    - field.field.media.cgov_image.field_caption
+    - field.field.media.cgov_image.field_credit
+    - field.field.media.cgov_image.field_display_enlarge
+    - field.field.media.cgov_image.field_media_image
+    - field.field.media.cgov_image.field_original_source
+    - field.field.media.cgov_image.field_override_img_featured
+    - field.field.media.cgov_image.field_override_img_panoramic
+    - field.field.media.cgov_image.field_override_img_social_media
+    - field.field.media.cgov_image.field_override_img_thumbnail
+    - image.style.cgov_article
+    - media.type.cgov_image
+  module:
+    - image
+id: media.cgov_image.image_display_inline
+targetEntityType: media
+bundle: cgov_image
+mode: image_display_inline
+content:
+  field_media_image:
+    weight: 0
+    label: hidden
+    settings:
+      image_style: cgov_article
+      image_link: ''
+    third_party_settings: {  }
+    type: image
+    region: content
+hidden:
+  content_moderation_control: true
+  created: true
+  field_accessible_version: true
+  field_caption: true
+  field_credit: true
+  field_display_enlarge: true
+  field_original_source: true
+  field_override_img_featured: true
+  field_override_img_panoramic: true
+  field_override_img_social_media: true
+  field_override_img_thumbnail: true
+  langcode: true
+  name: true
+  thumbnail: true
+  uid: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_image/config/install/core.entity_view_mode.media.image_display_inline.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_image/config/install/core.entity_view_mode.media.image_display_inline.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+id: media.image_display_inline
+label: 'Image Display: Inline'
+targetEntityType: media
+cache: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_image/config/install/embed.button.cgov_image_button.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_image/config/install/embed.button.cgov_image_button.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.entity_view_mode.media.image_display_article_large
     - core.entity_view_mode.media.image_display_article_medium
     - core.entity_view_mode.media.image_display_article_small
+    - core.entity_view_mode.media.image_display_inline
     - entity_browser.browser.cgov_embedded_image_browser
     - media.type.cgov_contextual_image
     - media.type.cgov_image
@@ -25,6 +26,7 @@ type_settings:
     - 'view_mode:media.image_display_article_large'
     - 'view_mode:media.image_display_article_medium'
     - 'view_mode:media.image_display_article_small'
+    - 'view_mode:media.image_display_inline'
   entity_browser: cgov_embedded_image_browser
   entity_browser_settings:
     display_review: false

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_migration/src/Plugin/migrate/process/CgovPluginBase.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_migration/src/Plugin/migrate/process/CgovPluginBase.php
@@ -237,7 +237,7 @@ abstract class CgovPluginBase extends ProcessPluginBase {
       // INLINE IMAGES.
       // gloBnUtilityImage    B - Utility Image.
       case '2254':
-        $values['view_mode'] = 'view_mode:media.image_display_article_medium';
+        $values['view_mode'] = 'view_mode:media.image_display_inline';
         $values['data_align'] = '';
         $values['data_embed_button'] = 'cgov_image_button';
         $values['data_entity_type'] = 'media';
@@ -246,7 +246,7 @@ abstract class CgovPluginBase extends ProcessPluginBase {
       // gloBnImage    B - Image1.
       case '1482':
 
-        $values['view_mode'] = 'view_mode:media.image_display_article_medium';
+        $values['view_mode'] = 'view_mode:media.image_display_inline';
         $values['data_align'] = '';
         $values['data_embed_button'] = 'cgov_image_button';
         $values['data_entity_type'] = 'media';
@@ -255,7 +255,7 @@ abstract class CgovPluginBase extends ProcessPluginBase {
       // nciBnImage    B - NCI Image .
       case '917':
 
-        $values['view_mode'] = 'view_mode:media.image_display_article_medium';
+        $values['view_mode'] = 'view_mode:media.image_display_inline';
         $values['data_align'] = '';
         $values['data_embed_button'] = 'cgov_image_button';
         $values['data_entity_type'] = 'media';

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/image/entity-embed-container--media.image-display-inline.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/image/entity-embed-container--media.image-display-inline.html.twig
@@ -1,0 +1,11 @@
+{#
+/**
+ * @file
+ * Overridden template for inline images. We don't want a
+ * wrapper for these to keep it as close to existing
+ * behavior. Do not add this to the cgov_admin theme as
+ * it will most likely mess with the ability to edit the
+ * items.
+ */
+#}
+{{ children }}


### PR DESCRIPTION
- Updated Entity Embed to RC1
- Add Entity Embed suggestions to allow for wrapper-less inline images.
- Changed migration rule for inline images.

Closes #1936 
ODE:  ncigovcdode161.prod.acquia-sites.com