### PR TITLE
Minimized Features Out of Sync Errors

### DIFF
--- a/blt/01dev.blt.yml
+++ b/blt/01dev.blt.yml
@@ -4,6 +4,6 @@ cm:
   strategy: features
   allow-overrides: true
   features:
-    allow-overrides: false
+    allow-overrides: true
     bundle:
       - default

--- a/blt/01test.blt.yml
+++ b/blt/01test.blt.yml
@@ -4,6 +4,6 @@ cm:
   strategy: features
   allow-overrides: true
   features:
-    allow-overrides: false
+    allow-overrides: true
     bundle:
       - default

--- a/blt/blt.yml
+++ b/blt/blt.yml
@@ -56,7 +56,7 @@ cm:
   strategy: features
   allow-overrides: true
   features:
-    allow-overrides: false
+    allow-overrides: true
     bundle: [default]
 phpunit:
   -

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/cgov_article.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/cgov_article.info.yml
@@ -9,6 +9,7 @@ dependencies:
   - cgov_list
   - cgov_site_section
   - cgov_syndication
+  - content_moderation
   - content_translation
   - datetime
   - entity_browser

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/core.entity_form_display.node.cgov_article.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/core.entity_form_display.node.cgov_article.default.yml
@@ -25,11 +25,13 @@ dependencies:
     - field.field.node.cgov_article.field_search_engine_restrictions
     - field.field.node.cgov_article.field_site_section
     - node.type.cgov_article
+    - workflows.workflow.editorial_workflow
   enforced:
     module:
       - cgov_core
   module:
     - cgov_syndication
+    - content_moderation
     - datetime
     - entity_browser
     - paragraphs_asymmetric_translation_widgets


### PR DESCRIPTION
- cgov_article was being called out as out of sync,
  but it had not been modified since we enabled
  features. I re-exported it, as it was at least
  behaving that way locally.
- Error with cgov_article & cgov_application_page
  is still occurring on AH environments. Features
  diff indicates no differences, and local dev
  environment do not show any errors.
- Enabled config overrides as to not break the
  system too much.