### PR TITLE
NCI-000: ConfigOverrider for Workflows

### DIFF
--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_application_page/cgov_application_page.install
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_application_page/cgov_application_page.install
@@ -18,6 +18,5 @@ function cgov_application_page_install() {
 
   // Add content type permissions.
   $siteHelper->addContentTypePermissions('cgov_application_page', ['site_admin']);
-  $siteHelper->attachContentTypeToWorkflow('cgov_application_page', 'editorial_workflow');
 
 }

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/cgov_article.install
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/cgov_article.install
@@ -18,6 +18,5 @@ function cgov_article_install() {
 
   // Add content type permissions.
   $siteHelper->addContentTypePermissions('cgov_article', ['content_author']);
-  $siteHelper->attachContentTypeToWorkflow('cgov_article', 'editorial_workflow');
 
 }

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_biography/cgov_biography.install
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_biography/cgov_biography.install
@@ -22,7 +22,6 @@ function cgov_biography_install() {
 
   // Add content type permissions.
   $siteHelper->addContentTypePermissions('cgov_biography', ['content_author']);
-  $siteHelper->attachContentTypeToWorkflow('cgov_biography', 'editorial_workflow');
 
   $campusItems = [
     'NCI Shady Grove Campus',

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/cgov_blog.install
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/cgov_blog.install
@@ -21,8 +21,6 @@ function cgov_blog_install() {
   // Add content type permissions.
   $siteHelper->addContentTypePermissions('cgov_blog_post', ['content_author']);
   $siteHelper->addContentTypePermissions('cgov_blog_series', ['blog_manager']);
-  $siteHelper->attachContentTypeToWorkflow('cgov_blog_post', 'editorial_workflow');
-  $siteHelper->attachContentTypeToWorkflow('cgov_blog_series', 'editorial_workflow');
 
   // Install permissions for this module.
   _cgov_blog_install_permissions($siteHelper);

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_center/cgov_cancer_center.install
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_center/cgov_cancer_center.install
@@ -5,7 +5,7 @@
  * Contains cgov_cancer_center.install.
  */
 
- use Drupal\taxonomy\Entity\Term;
+use Drupal\taxonomy\Entity\Term;
 
 /**
  * Implements hook_install().
@@ -20,7 +20,6 @@ function cgov_cancer_center_install() {
 
   // Add content type permissions.
   $siteHelper->addContentTypePermissions('cgov_cancer_center', ['content_author']);
-  $siteHelper->attachContentTypeToWorkflow('cgov_cancer_center', 'editorial_workflow');
 
   $typeItems = [
     'Cancer Center',

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_research/cgov_cancer_research.install
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_research/cgov_cancer_research.install
@@ -18,5 +18,4 @@ function cgov_cancer_research_install() {
 
   // Add content type permissions.
   $siteHelper->addContentTypePermissions('cgov_cancer_research', ['content_author']);
-  $siteHelper->attachContentTypeToWorkflow('cgov_cancer_research', 'editorial_workflow');
 }

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.install
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.install
@@ -58,6 +58,8 @@ function _cgov_core_install_permissions(CgovCoreTools $siteHelper) {
       'delete content translations',
       'use editorial_workflow transition quick_publish_replace',
       'use editorial_workflow transition quick_publish',
+      'use simple_workflow transition create_new_draft',
+      'use simple_workflow transition publish',
     ],
     'authenticated' => [
       'access content',

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.services.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.services.yml
@@ -39,3 +39,7 @@ services:
     arguments: ['@path.alias_manager', '@language_manager', '@service_container']
     tags:
       - { name: path_processor_outbound, priority: 600 }
+  cgov_core.config_overrider:
+    class: Drupal\cgov_core\CgovConfigOverrider
+    tags:
+      - {name: config.factory.override, priority: 5}

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/CgovConfigOverrider.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/CgovConfigOverrider.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Drupal\cgov_core;
+
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Config\ConfigFactoryOverrideInterface;
+use Drupal\Core\Config\StorageInterface;
+
+/**
+ * CgovConfigOverrider - Overrides configurations for cgov_core.
+ */
+class CgovConfigOverrider implements ConfigFactoryOverrideInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function loadOverrides($names) {
+    $overrides = [];
+    // Editorial Workflow for all node types & non-image media items.
+    if (in_array('workflows.workflow.editorial_workflow', $names)) {
+      // phpcs:disable
+      $content_types = \Drupal::service('entity_type.bundle.info')->getBundleInfo('node');
+      // phpcs:enable
+      foreach ($content_types as $type => $info) {
+        if (strpos($type, 'cgov_') !== FALSE) {
+          $overrides['workflows.workflow.editorial_workflow']['type_settings']['entity_types']['node'][] = $type;
+        }
+      }
+
+      // phpcs:disable
+      $media_types = \Drupal::service('entity_type.bundle.info')->getBundleInfo('media');
+      // phpcs:enable
+      foreach ($media_types as $type => $info) {
+        if (strpos($type, 'cgov_') !== FALSE && strpos($type, '_image') === FALSE) {
+          $overrides['workflows.workflow.editorial_workflow']['type_settings']['entity_types']['media'][] = $type;
+        }
+      }
+    }
+    // Simple Workflow is only for Custom Block Types and Images.
+    if (in_array('workflows.workflow.simple_workflow', $names)) {
+      // phpcs:disable
+      $custom_block_types = \Drupal::service('entity_type.bundle.info')->getBundleInfo('block_content');
+      // phpcs:enable
+      foreach ($custom_block_types as $type => $info) {
+        // Do not check for a prefix for block content as all block_content
+        // should follow the simple workflow.
+        $overrides['workflows.workflow.simple_workflow']['type_settings']['entity_types']['block_content'][] = $type;
+      }
+
+      // phpcs:disable
+      $media_types = \Drupal::service('entity_type.bundle.info')->getBundleInfo('media');
+      // phpcs:enable
+      foreach ($media_types as $type => $info) {
+        // Only check for image media items.
+        if (strpos($type, 'cgov_') !== FALSE && strpos($type, '_image') !== FALSE) {
+          $overrides['workflows.workflow.simple_workflow']['type_settings']['entity_types']['media'][] = $type;
+        }
+      }
+    }
+    return $overrides;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheSuffix() {
+    return 'CgovConfigOverrider';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheableMetadata($name) {
+    return new CacheableMetadata();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function createConfigObject($name, $collection = StorageInterface::DEFAULT_COLLECTION) {
+    return NULL;
+  }
+
+}

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/CgovCoreTools.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/CgovCoreTools.php
@@ -162,18 +162,6 @@ class CgovCoreTools {
   }
 
   /**
-   * Links a content type to a workflow.
-   *
-   * See https://github.com/NCIOCPL/cgov-digital-platform/issues/127.
-   */
-  public function attachContentTypeToWorkflow($type_name, $workflow_name) {
-    $workflows = $this->entityTypeManager->getStorage('workflow')->loadMultiple();
-    $workflow = $workflows[$workflow_name];
-    $workflow->getTypePlugin()->addEntityTypeAndBundle('node', $type_name);
-    $workflow->save(TRUE);
-  }
-
-  /**
    * Links a media type to a workflow.
    *
    * See https://github.com/NCIOCPL/cgov-digital-platform/issues/127.

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/tests/src/Kernel/WorkflowTest.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/tests/src/Kernel/WorkflowTest.php
@@ -8,6 +8,7 @@ use Drupal\node\Entity\NodeType;
 use Drupal\Tests\node\Traits\NodeCreationTrait;
 use Drupal\Tests\user\Traits\UserCreationTrait;
 use CgovPlatform\Tests\CgovSchemaExclusions;
+use Drupal\Tests\cgov_core\Traits;
 
 /**
  * Ensure that cgov_site workflows conform to requirements.
@@ -17,6 +18,7 @@ use CgovPlatform\Tests\CgovSchemaExclusions;
  */
 class WorkflowTest extends KernelTestBase {
 
+  use Traits\CGovWorkflowAttachmentTrait;
   use NodeCreationTrait;
   use UserCreationTrait;
 
@@ -66,10 +68,9 @@ class WorkflowTest extends KernelTestBase {
       'delete any pony content',
       'edit any pony content',
     ];
-    $tools = $this->container->get('cgov_core.tools');
     $node_type = NodeType::create(['type' => 'pony', 'label' => 'Pony']);
     $node_type->save();
-    $tools->attachContentTypeToWorkflow('pony', 'editorial_workflow');
+    $this->attachContentTypeToWorkflow('pony', 'editorial_workflow');
     $this->users['admin'] = $this->createUser([], NULL, TRUE);
     $this->users['author'] = $this->createUser($perms);
     $this->users['author']->addRole('content_author');

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/tests/src/Traits/CGovWorkflowAttachmentTrait.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/tests/src/Traits/CGovWorkflowAttachmentTrait.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Drupal\Tests\cgov_core\Traits;
+
+/**
+ * Provides test assertions for testing config entity synchronization.
+ *
+ * Can be used by test classes that extend \Drupal\Tests\BrowserTestBase or
+ * \Drupal\KernelTests\KernelTestBase.
+ */
+trait CGovWorkflowAttachmentTrait {
+
+  /**
+   * Assigns an entity type to a workflow.
+   *
+   * @param string $type_name
+   *   Entity name.
+   * @param string $workflow_name
+   *   Workflow name.
+   */
+  public function attachContentTypeToWorkflow($type_name, $workflow_name) {
+    $workflows = \Drupal::entityTypeManager()->getStorage('workflow')->loadMultiple();
+    $workflow = $workflows[$workflow_name];
+    $workflow->getTypePlugin()->addEntityTypeAndBundle('node', $type_name);
+    $workflow->save(TRUE);
+  }
+
+}

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/cgov_cthp.install
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/cgov_cthp.install
@@ -18,6 +18,5 @@ function cgov_cthp_install() {
 
   // Add content type permissions.
   $siteHelper->addContentTypePermissions('cgov_cthp', ['content_author']);
-  $siteHelper->attachContentTypeToWorkflow('cgov_cthp', 'editorial_workflow');
 
 }

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_event/cgov_event.install
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_event/cgov_event.install
@@ -18,5 +18,4 @@ function cgov_event_install() {
 
   // Add content type permissions.
   $siteHelper->addContentTypePermissions('cgov_event', ['content_author']);
-  $siteHelper->attachContentTypeToWorkflow('cgov_event', 'editorial_workflow');
 }

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/cgov_home_landing.install
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/cgov_home_landing.install
@@ -19,10 +19,8 @@ function cgov_home_landing_install() {
   // Add content type permissions.
   // Home and Landing.
   $siteHelper->addContentTypePermissions('cgov_home_landing', ['content_author']);
-  $siteHelper->attachContentTypeToWorkflow('cgov_home_landing', 'editorial_workflow');
 
   // Mini Landing.
   $siteHelper->addContentTypePermissions('cgov_mini_landing', ['content_author']);
-  $siteHelper->attachContentTypeToWorkflow('cgov_mini_landing', 'editorial_workflow');
 
 }

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/cgov_press_release.install
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/cgov_press_release.install
@@ -21,7 +21,6 @@ function cgov_press_release_install() {
 
   // Add content type permissions.
   $siteHelper->addContentTypePermissions('cgov_press_release', ['content_author']);
-  $siteHelper->attachContentTypeToWorkflow('cgov_press_release', 'editorial_workflow');
 }
 
 /**

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/pdq_cancer_information_summary.install
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/pdq_cancer_information_summary.install
@@ -21,7 +21,6 @@ function pdq_cancer_information_summary_install() {
 
   // Add content type permissions and assign to workflow.
   $siteHelper->addContentTypePermissions('pdq_cancer_information_summary', ['pdq_importer'], CgovCoreTools::DEFAULT_PERMISSIONS);
-  $siteHelper->attachContentTypeToWorkflow('pdq_cancer_information_summary', 'pdq_workflow');
 
   // Install permissions for this module.
   pdq_cancer_information_summary_install_permissions($siteHelper);

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_core/pdq_core.services.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_core/pdq_core.services.yml
@@ -1,0 +1,5 @@
+services:
+  pdq_core.config_overrider:
+    class: Drupal\pdq_core\PDQConfigOverrider
+    tags:
+      - {name: config.factory.override, priority: 5}

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_core/src/PDQConfigOverrider.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_core/src/PDQConfigOverrider.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Drupal\pdq_core;
+
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Config\ConfigFactoryOverrideInterface;
+use Drupal\Core\Config\StorageInterface;
+
+/**
+ * PDQConfigOverrider - Overrides workflow config for PDQ.
+ */
+class PDQConfigOverrider implements ConfigFactoryOverrideInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function loadOverrides($names) {
+    $overrides = [];
+    if (in_array('workflows.workflow.pdq_workflow', $names)) {
+      // phpcs:disable
+      $content_types = \Drupal::service('entity_type.bundle.info')->getBundleInfo('node');
+      // phpcs:enable
+      foreach ($content_types as $type => $info) {
+        if (strpos($type, 'pdq_') !== FALSE) {
+          $overrides['workflows.workflow.pdq_workflow']['type_settings']['entity_types']['node'][] = $type;
+        }
+      }
+      // phpcs:disable
+      $media_types = \Drupal::service('entity_type.bundle.info')->getBundleInfo('media');
+      // phpcs:enable
+      foreach ($media_types as $type => $info) {
+        if (strpos($type, 'pdq_') !== FALSE) {
+          $overrides['workflows.workflow.pdq_workflow']['type_settings']['entity_types']['media'][] = $type;
+        }
+      }
+    }
+    return $overrides;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheSuffix() {
+    return 'PDQConfigOverrider';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheableMetadata($name) {
+    return new CacheableMetadata();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function createConfigObject($name, $collection = StorageInterface::DEFAULT_COLLECTION) {
+    return NULL;
+  }
+
+}

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_core/tests/src/Kernel/WorkflowTest.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_core/tests/src/Kernel/WorkflowTest.php
@@ -7,6 +7,7 @@ use Drupal\node\Entity\NodeType;
 use Drupal\Tests\node\Traits\NodeCreationTrait;
 use Drupal\Tests\user\Traits\UserCreationTrait;
 use CgovPlatform\Tests\CgovSchemaExclusions;
+use Drupal\Tests\cgov_core\Traits;
 
 /**
  * Ensure that PDQ workflows conform to requirements.
@@ -16,6 +17,7 @@ use CgovPlatform\Tests\CgovSchemaExclusions;
  */
 class WorkflowTest extends KernelTestBase {
 
+  use Traits\CGovWorkflowAttachmentTrait;
   use NodeCreationTrait;
   use UserCreationTrait;
 
@@ -52,12 +54,11 @@ class WorkflowTest extends KernelTestBase {
     // the permissions for the roles we are testing below.
     \Drupal::service('module_installer')->install(['pdq_core']);
 
-    $tools = $this->container->get('cgov_core.tools');
     $node_type = NodeType::create(['type' => 'pony']);
     $node_type->save();
     $node_type = NodeType::create(['type' => 'unicorn']);
     $node_type->save();
-    $tools->attachContentTypeToWorkflow('unicorn', 'pdq_workflow');
+    $this->attachContentTypeToWorkflow('unicorn', 'pdq_workflow');
   }
 
   /**

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_drug_information_summary/pdq_drug_information_summary.install
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_drug_information_summary/pdq_drug_information_summary.install
@@ -26,5 +26,4 @@ function pdq_drug_information_summary_install() {
   ];
   $siteHelper->addContentTypePermissions('pdq_drug_information_summary', ['pdq_importer'], CgovCoreTools::DEFAULT_PERMISSIONS);
   $siteHelper->addRolePermissions(['pdq_importer' => $restfulPermissions]);
-  $siteHelper->attachContentTypeToWorkflow('pdq_drug_information_summary', 'pdq_workflow');
 }

--- a/tests/behat/features/ContentWorkflow.feature
+++ b/tests/behat/features/ContentWorkflow.feature
@@ -1,33 +1,65 @@
-@smoke @regression
+@smoke @regression @javascript @api
 Feature: Perform tasks related to a Content Editor
   As a content editor
   I want the ability to publish content in the CMS
   so that I can make it available to external users.
 
-  Background:
-    Given I am logged in as a user with the "content_author,content_editor,admin_ui" role
-
-
-  @javascript @api @errors
-  Scenario Outline: Use Workflow Transitions
+  Scenario Outline: Editorial Workflow Enabled on Nodes
     # Tests that Content Moderation is enabled.
-    Given I should be able to edit a "<Content Type>"
-    And I should see "Draft" in the "#edit-moderation-state-0-state" element
+    Given I am logged in as a user with the "<Roles>" roles
+    And I should be able to edit a "<Content Type>"
+    Then I should see "Draft" in the "#edit-moderation-state-0-state" element
     And I should see "Review" in the "#edit-moderation-state-0-state" element
 
     Examples:
-      | Content Type                   |
-      | cgov_article                   |
-      | cgov_biography                 |
-#      | cgov_blog_post     |
-#      | cgov_blog_series   |
-      | cgov_cancer_center             |
-      | cgov_event                     |
-      | cgov_home_landing              |
-      | cgov_mini_landing              |
-      | cgov_press_release             |
+      | Content Type                   | Roles                                        |
+      | cgov_application_page          | site_admin,content_author,admin_ui         |
+      | cgov_article                   | content_author,admin_ui         |
+      | cgov_biography                 | content_author,admin_ui         |
+      | cgov_blog_post                 | content_author,admin_ui         |
+      | cgov_blog_series               | blog_manager,content_author,admin_ui         |
+      | cgov_cancer_research           | content_author,admin_ui         |
+      | cgov_cancer_center             | content_author,admin_ui         |
+      | cgov_event                     | content_author,admin_ui         |
+      | cgov_home_landing              | content_author,admin_ui         |
+      | cgov_mini_landing              | content_author,admin_ui         |
+      | cgov_press_release             | content_author,admin_ui         |
 
-  @javascript @api @errors @todo
-  Scenario: Ability to move an item through all workflow states
-    # Tests that all workflow states exist and are transitionable.
-    # TODO: Implement for Article.
+  Scenario Outline: Editorial Workflow Enabled on Media
+    # Tests that Content Moderation is enabled.
+    Given I am logged in as a user with the "<Roles>" roles
+    And I am on "<URL>"
+    Then I should see "Draft" in the "#edit-moderation-state-0-state" element
+    And I should see "Review" in the "#edit-moderation-state-0-state" element
+
+  Examples:
+    | URL                            | Roles                           |
+    | /media/add/cgov_infographic               | content_author,admin_ui         |
+    | /media/add/cgov_video                     | content_author,admin_ui         |
+    | /media/add/cgov_file                      | content_author,admin_ui         |
+
+  Scenario Outline: Simple Workflow Enabled - Media
+    # Tests that Content Moderation is enabled.
+    Given I am logged in as a user with the "<Roles>" roles
+    And I am on "<URL>"
+    Then I should see "Draft" in the "#edit-moderation-state-0-state" element
+    And I should see "Published" in the "#edit-moderation-state-0-state" element
+
+    Examples:
+      | URL                                       | Roles                                         |
+      | /media/add/cgov_image                     | image_manager,content_author,admin_ui         |
+      | /media/add/cgov_contextual_image          | image_manager,content_author,admin_ui         |
+
+  Scenario Outline: Simple Workflow Enabled - Blocks
+    # Tests that Content Moderation is enabled.
+    Given I am logged in as a user with the "<Roles>" roles
+    And I am on "<URL>"
+    Then I should see "Draft" in the "#edit-moderation-state-0-state" element
+    And I should see "Published" in the "#edit-moderation-state-0-state" element
+
+    Examples:
+      | URL                                       | Roles                                           |
+      | /block/add/content_block                  | advanced_editor,content_author,admin_ui         |
+      | /block/add/raw_html_block                 | advanced_editor,content_author,admin_ui         |
+      | /block/add/cgov_image_carousel            | advanced_editor,content_author,admin_ui         |
+      | /block/add/cgov_video_carousel            | advanced_editor,content_author,admin_ui         |

--- a/tests/behat/features/PDQ.feature
+++ b/tests/behat/features/PDQ.feature
@@ -1,25 +1,22 @@
-@smoke @regression @pdq
+@smoke @regression @pdq @javascript @api
 Feature: Perform tasks related to PDQ Import
   In order to utilize the PDQ importer
   the system must allow PDQ items to be created and translated
   so that the migration system can import PDQ elements.
 
-  Background:
-    Given I am logged in as a user with the "pdq_importer,admin_ui" role
-
-
-  @javascript @api @todo
   Scenario Outline: Ability to Translate Content
+    Given I am logged in as a user with the "<Roles>" roles
     Given I should be able to edit a "<Content Type>"
-    Then I fill in the text "Translate"
+    And I should see "Draft" in the "#edit-moderation-state-0-state" element
+    And I should see "Published" in the "#edit-moderation-state-0-state" element
 
     Examples:
-      | Content Type                   |
-      | pdq_cancer_information_summary |
-      | pdq_drug_information_summary   |
+      | Content Type                   | Roles  |
+      | pdq_cancer_information_summary | pdq_importer,admin_ui |
+      | pdq_drug_information_summary   | pdq_importer,admin_ui |
 
-  @javascript @api @errors
   Scenario: Validate fields on PDQ Cancer Summary
+    Given I am logged in as a user with the "pdq_importer,admin_ui" role
     Given I should be able to edit a "pdq_cancer_information_summary"
     Then I fill in "Title" with "Test Title"
     Then I fill in "Browser Title" with "Test Browser Title"
@@ -38,8 +35,8 @@ Feature: Perform tasks related to PDQ Import
     Then I fill in "PDQ Summary URL" with "/pdq/testpage"
     Then press "Save"
 
-  @javascript @api @errors
   Scenario: Validate fields on PDQ Drug Information Summary
+    Given I am logged in as a user with the "pdq_importer,admin_ui" role
     Given I should be able to edit a "pdq_drug_information_summary"
     Then I fill in "Title" with "Test Title"
     Then I fill in "CDR ID" with "1234"
@@ -53,7 +50,3 @@ Feature: Perform tasks related to PDQ Import
     Then I fill in "PDQ Summary URL" with "/pdq/testpage"
     Then press "Save"
 
-  @javascript @api @errors @todo
-  Scenario: Ability to move an item through all workflow states
-    # PDQ Items have unique workdlows. Test it here.
-    # TODO: Implement for PDQ Summary.

--- a/tests/behat/features/Translation.feature
+++ b/tests/behat/features/Translation.feature
@@ -1,38 +1,36 @@
-@smoke @regression
+@smoke @regression @javascript @api
 Feature: Perform tasks related to Content Translation
   In order to provide value to our users
   content authors should have the ability to translate content
   so that content can be available to non english speaking users.
 
-  Background:
-    Given I am logged in as a user with the "content_author,admin_ui" role
-
-  @javascript @api @errors
   Scenario Outline: Ability to Translate Content
-    Given I should be able to edit a "<Content Type>"
+    Given I am logged in as a user with the "<Roles>" roles
+    And I should be able to edit a "<Content Type>"
     Then I should see the text "Translate"
 
     Examples:
-      | Content Type                   |
-      | cgov_article                   |
-      | cgov_biography                 |
-#      | cgov_blog_post     |
-#      | cgov_blog_series   |
-      | cgov_cancer_center             |
-      | cgov_event                     |
-      | cgov_home_landing              |
-      | cgov_mini_landing              |
-      | cgov_press_release             |
+      | Content Type                   | Roles                                        |
+      | cgov_article                   | content_author,admin_ui         |
+      | cgov_biography                 | content_author,admin_ui         |
+      | cgov_blog_post                 | content_author,admin_ui         |
+      | cgov_blog_series               | blog_manager,content_author,admin_ui         |
+      | cgov_cancer_center             | content_author,admin_ui         |
+      | cgov_event                     | content_author,admin_ui         |
+      | cgov_home_landing              | content_author,admin_ui         |
+      | cgov_mini_landing              | content_author,admin_ui         |
+      | cgov_press_release             | content_author,admin_ui         |
 
-  @javascript @api @errors @todo
+  @todo
   Scenario: Ability to Create a Spanish Translation
     # Marking this as @TODO since default content isnt added to CI.
     # To fix this, may need to create sample taxonomy for site section.
-    Given I should be able to edit a "cgov_article"
+    Given I am logged in as a user with the "content_author,admin_ui" role
+    And I should be able to edit a "cgov_article"
     Then I should see the text "Translate"
     And I click "Translate"
     And I click "Add"
-    Then I should see the text "Crear traducción Spanish de"
+    Then I should see the text "Create Spanish translation"
     And I press "field_site_section_entity_browser_entity_browser"
     And I wait for AJAX to finish
     When I enter the "entity_browser_iframe_cgov_site_section_browser" frame


### PR DESCRIPTION
Overriding workflow config for applying workflow to entities so that it ignores all config import/export settings.

### Changes
Commit 1:
1. Provides a ConfigOverride class for cgov_core and pdq_core. 
2. Overrides configuration for workflow `['type_settings']['entity_types']` which are removed from exports as they create dependency chains we do not want. 
3. Handles all 3 workflows (based on the most reusable patterns I could find). 

Commit 2:
1. Removes workflow assignment from install hooks on modules. 
2. Moves workflow helper function to custom trait for tests.

Commit 3: 
1. Updates existing behat tests to actually run.
2. Adds new tests for coverage of workflows across all ctypes.
3. Fixes issue w/ Advanced Editor not being able to use workflow on blocks.

### Additional Notes
1. Right now this is built so CGov determines patterns for workflow. This effectively makes the install hooks to enable workflow on content types obsolete (as it will be ignored and use the config defined in this class). 
  a. I will push up a new commit with the removal of those hooks. 
3. Added a few phpcs:disable/enable lines because: 
Dependency Injection does not work properly in ConfigOverride classes due to circular dependencies. There may be a way around this, but I did not find it yet. Example here: https://www.drupal.org/project/key/issues/2924257
