### PR TITLE
(#792) Generate site maps

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,6 +59,7 @@
         "drupal/role_delegation": "^1.0",
         "drupal/seckit": "^1.1",
         "drupal/shield": "^1.2",
+        "drupal/simple_sitemap": "^3.2",
         "drupal/simplesamlphp_auth": "3.0",
         "drupal/token": "^1.5",
         "drupal/token_filter": "^1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0956e806559d9df23b520727f9cff937",
+    "content-hash": "585cc7670852601c3c95d78f2746c8ac",
     "packages": [
         {
             "name": "acquia/acsf-tools",
@@ -6450,6 +6450,67 @@
             "homepage": "https://www.drupal.org/project/shield",
             "support": {
                 "source": "http://cgit.drupalcode.org/shield"
+            }
+        },
+        {
+            "name": "drupal/simple_sitemap",
+            "version": "3.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/simple_sitemap.git",
+                "reference": "8.x-3.2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/simple_sitemap-8.x-3.2.zip",
+                "reference": "8.x-3.2",
+                "shasum": "2f499e7133a2031f6372c2f3d12fbbb3a64120df"
+            },
+            "require": {
+                "drupal/core": "~8.0",
+                "ext-xmlwriter": "*"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "branch-alias": {
+                    "dev-3.x": "3.x-dev"
+                },
+                "drupal": {
+                    "version": "8.x-3.2",
+                    "datestamp": "1559004185",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                },
+                "drush": {
+                    "services": {
+                        "drush.services.yml": "^9"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "Pawel Ginalski (gbyte.co)",
+                    "homepage": "https://www.drupal.org/u/gbyte.co",
+                    "email": "contact@gbyte.co",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "gbyte.co",
+                    "homepage": "https://www.drupal.org/user/2381352"
+                }
+            ],
+            "description": "Creates a standard conform hreflang XML sitemap of the site content and provides a framework for developing other sitemap types.",
+            "homepage": "https://drupal.org/project/simple_sitemap",
+            "support": {
+                "source": "https://cgit.drupalcode.org/simple_sitemap",
+                "issues": "https://drupal.org/project/issues/simple_sitemap",
+                "irc": "irc://irc.freenode.org/drupal-contribute"
             }
         },
         {

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/cgov_article.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/cgov_article.info.yml
@@ -25,5 +25,6 @@ dependencies:
   - paragraphs_asymmetric_translation_widgets
   - path
   - pathauto
+  - simple_sitemap
   - text
   - user

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/simple_sitemap.bundle_settings.default.node.cgov_article.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/simple_sitemap.bundle_settings.default.node.cgov_article.yml
@@ -1,0 +1,4 @@
+index: true
+priority: '1.0'
+changefreq: weekly
+include_images: false

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_biography/cgov_biography.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_biography/cgov_biography.info.yml
@@ -22,6 +22,7 @@ dependencies:
   - paragraphs_asymmetric_translation_widgets
   - path
   - pathauto
+  - simple_sitemap
   - taxonomy
   - text
   - user

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_biography/config/install/simple_sitemap.bundle_settings.default.node.cgov_biography.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_biography/config/install/simple_sitemap.bundle_settings.default.node.cgov_biography.yml
@@ -1,0 +1,4 @@
+index: true
+priority: '0.5'
+changefreq: weekly
+include_images: false

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/cgov_blog.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/cgov_blog.info.yml
@@ -30,6 +30,7 @@ dependencies:
   - paragraphs_asymmetric_translation_widgets
   - path
   - pathauto
+  - simple_sitemap
   - system
   - taxonomy
   - text

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/config/install/simple_sitemap.bundle_settings.content.node.cgov_blog_post.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/config/install/simple_sitemap.bundle_settings.content.node.cgov_blog_post.yml
@@ -1,0 +1,4 @@
+index: true
+priority: '0.5'
+changefreq: weekly
+include_images: false

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/config/install/simple_sitemap.bundle_settings.content.node.cgov_blog_series.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/config/install/simple_sitemap.bundle_settings.content.node.cgov_blog_series.yml
@@ -1,0 +1,4 @@
+index: true
+priority: '0.5'
+changefreq: weekly
+include_images: false

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_center/cgov_cancer_center.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_center/cgov_cancer_center.info.yml
@@ -23,6 +23,7 @@ dependencies:
   - paragraphs_asymmetric_translation_widgets
   - path
   - pathauto
+  - simple_sitemap
   - taxonomy
   - text
   - user

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_center/config/install/simple_sitemap.bundle_settings.default.node.cgov_cancer_center.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_center/config/install/simple_sitemap.bundle_settings.default.node.cgov_cancer_center.yml
@@ -1,0 +1,4 @@
+index: true
+priority: '0.5'
+changefreq: weekly
+include_images: false

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_research/cgov_cancer_research.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_research/cgov_cancer_research.info.yml
@@ -23,5 +23,6 @@ dependencies:
   - paragraphs
   - path
   - pathauto
+  - simple_sitemap
   - text
   - user

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_research/config/install/simple_sitemap.bundle_settings.default.node.cgov_cancer_research.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_research/config/install/simple_sitemap.bundle_settings.default.node.cgov_cancer_research.yml
@@ -1,0 +1,4 @@
+index: true
+priority: '1.0'
+changefreq: weekly
+include_images: false

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.features.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.features.yml
@@ -8,3 +8,6 @@ excluded:
   - core.entity_view_mode.node.token
   - core.entity_view_mode.taxonomy_term.token
   - cgov_core.frontend_globals
+required:
+  - simple_sitemap.settings
+  - simple_sitemap.variants.default_hreflang

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.info.yml
@@ -36,6 +36,7 @@ dependencies:
   - paragraphs_asymmetric_translation_widgets
   - pathauto
   - redirect
+  - simple_sitemap
   - system
   - taxonomy
   - text

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/config/install/simple_sitemap.settings.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/config/install/simple_sitemap.settings.yml
@@ -1,0 +1,16 @@
+max_links: 2000
+cron_generate: true
+cron_generate_interval: 0
+generate_duration: 10000
+remove_duplicates: true
+skip_untranslated: true
+xsl: true
+base_url: ''
+default_variant: default
+custom_links_include_images: false
+excluded_languages: {  }
+enabled_entity_types:
+  - node
+  - taxonomy_term
+  - menu_link_content
+  - media

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/config/install/simple_sitemap.variants.default_hreflang.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/config/install/simple_sitemap.variants.default_hreflang.yml
@@ -1,0 +1,4 @@
+variants:
+  default:
+    label: Default
+    weight: 0

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/config/install/workflows.workflow.editorial_workflow.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/config/install/workflows.workflow.editorial_workflow.yml
@@ -45,7 +45,7 @@ type_settings:
       weight: -3
   transitions:
     approve:
-      label: 'Publish'
+      label: Publish
       from:
         - post_publication_review
       to: published

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/config/schema/cgov_core.schema.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/config/schema/cgov_core.schema.yml
@@ -18,3 +18,12 @@ cgov_core.frontend_globals:
     config_object:
       type: string
       label: 'Frontend Globals JSON Config Object'
+
+# Missing from the crop module. Without this, the unit tests fail.
+media.type.*.third_party.crop:
+  type: mapping
+  label: 'Crop settings'
+  mapping:
+    image_field:
+      type: string
+      label: 'Field storing image to be cropped'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/cgov_cthp.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/cgov_cthp.info.yml
@@ -29,5 +29,6 @@ dependencies:
   - path
   - pathauto
   - pdq_cancer_information_summary
+  - simple_sitemap
   - text
   - user

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/simple_sitemap.bundle_settings.default.node.cgov_cthp.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/simple_sitemap.bundle_settings.default.node.cgov_cthp.yml
@@ -1,0 +1,4 @@
+index: true
+priority: '1.0'
+changefreq: weekly
+include_images: false

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_event/cgov_event.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_event/cgov_event.info.yml
@@ -23,6 +23,7 @@ dependencies:
   - path
   - pathauto
   - pdq_core
+  - simple_sitemap
   - taxonomy
   - text
   - user

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_event/config/install/simple_sitemap.bundle_settings.default.node.cgov_event.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_event/config/install/simple_sitemap.bundle_settings.default.node.cgov_event.yml
@@ -1,0 +1,4 @@
+index: true
+priority: '0.5'
+changefreq: weekly
+include_images: false

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_file/cgov_file.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_file/cgov_file.info.yml
@@ -9,6 +9,7 @@ dependencies:
   - cgov_site_section
   - content_moderation
   - content_translation
+  - crop
   - ctools
   - datetime
   - entity_browser
@@ -20,5 +21,6 @@ dependencies:
   - options
   - path
   - pathauto
+  - simple_sitemap
   - user
 hidden: false

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_file/config/install/media.type.cgov_file.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_file/config/install/media.type.cgov_file.yml
@@ -1,6 +1,11 @@
 langcode: en
 status: true
-dependencies: {  }
+dependencies:
+  module:
+    - crop
+third_party_settings:
+  crop:
+    image_field: _none
 id: cgov_file
 label: File
 description: 'Used to upload all downloadable file types, such as PDFs, Excel spreadsheets, and Word docs. '

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_file/config/install/simple_sitemap.bundle_settings.default.media.cgov_file.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_file/config/install/simple_sitemap.bundle_settings.default.media.cgov_file.yml
@@ -1,0 +1,4 @@
+index: true
+priority: '0.5'
+changefreq: weekly
+include_images: false

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/cgov_home_landing.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/cgov_home_landing.info.yml
@@ -27,5 +27,6 @@ dependencies:
   - paragraphs_asymmetric_translation_widgets
   - path
   - pathauto
+  - simple_sitemap
   - text
   - user

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/config/install/simple_sitemap.bundle_settings.default.node.cgov_home_landing.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/config/install/simple_sitemap.bundle_settings.default.node.cgov_home_landing.yml
@@ -1,0 +1,4 @@
+index: true
+priority: '1.0'
+changefreq: weekly
+include_images: false

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/config/install/simple_sitemap.bundle_settings.default.node.cgov_mini_landing.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/config/install/simple_sitemap.bundle_settings.default.node.cgov_mini_landing.yml
@@ -1,0 +1,4 @@
+index: true
+priority: '0.5'
+changefreq: weekly
+include_images: false

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_infographic/cgov_infographic.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_infographic/cgov_infographic.info.yml
@@ -9,6 +9,7 @@ dependencies:
   - cgov_site_section
   - content_moderation
   - content_translation
+  - crop
   - ctools
   - datetime
   - embed
@@ -24,6 +25,7 @@ dependencies:
   - options
   - path
   - pathauto
+  - simple_sitemap
   - text
   - user
   - views

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_infographic/config/install/media.type.cgov_infographic.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_infographic/config/install/media.type.cgov_infographic.yml
@@ -1,6 +1,11 @@
 langcode: en
 status: false
-dependencies: {  }
+dependencies:
+  module:
+    - crop
+third_party_settings:
+  crop:
+    image_field: _none
 id: cgov_infographic
 label: Infographic
 description: 'Media type for visual representations of information and data. This content type creates a page for the infographic.'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_infographic/config/install/simple_sitemap.bundle_settings.default.media.cgov_infographic.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_infographic/config/install/simple_sitemap.bundle_settings.default.media.cgov_infographic.yml
@@ -1,0 +1,4 @@
+index: true
+priority: '0.5'
+changefreq: weekly
+include_images: false

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/cgov_press_release.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/cgov_press_release.info.yml
@@ -23,6 +23,7 @@ dependencies:
   - path
   - pathauto
   - pdq_core
+  - simple_sitemap
   - text
   - user
   - views

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/simple_sitemap.bundle_settings.default.node.cgov_press_release.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/simple_sitemap.bundle_settings.default.node.cgov_press_release.yml
@@ -1,0 +1,4 @@
+index: true
+priority: '0.5'
+changefreq: weekly
+include_images: false

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/cgov_video.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/cgov_video.info.yml
@@ -12,6 +12,7 @@ dependencies:
   - cgov_site_section
   - content_moderation
   - content_translation
+  - crop
   - ctools
   - datetime
   - embed
@@ -28,6 +29,7 @@ dependencies:
   - paragraphs
   - path
   - pathauto
+  - simple_sitemap
   - text
   - user
   - views

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/media.type.cgov_video.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/media.type.cgov_video.yml
@@ -1,6 +1,11 @@
 langcode: en
 status: true
-dependencies: {  }
+dependencies:
+  module:
+    - crop
+third_party_settings:
+  crop:
+    image_field: null
 id: cgov_video
 label: Video
 description: 'While videos are hosted on YouTube, this content type is used to embed a YouTube video on a cancer.gov page. If a video is hosted on YouTube, it must be on cancer.gov.'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/simple_sitemap.bundle_settings.default.media.cgov_video.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/simple_sitemap.bundle_settings.default.media.cgov_video.yml
@@ -1,0 +1,4 @@
+index: true
+priority: '0.5'
+changefreq: weekly
+include_images: false

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/simple_sitemap.bundle_settings.default.node.pdq_cancer_information_summary.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/simple_sitemap.bundle_settings.default.node.pdq_cancer_information_summary.yml
@@ -1,0 +1,4 @@
+index: true
+priority: '1.0'
+changefreq: weekly
+include_images: false

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/pdq_cancer_information_summary.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/pdq_cancer_information_summary.info.yml
@@ -26,6 +26,7 @@ dependencies:
   - pdq_core
   - rest
   - serialization
+  - simple_sitemap
   - text
   - user
   - views

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_drug_information_summary/config/install/simple_sitemap.bundle_settings.default.node.pdq_drug_information_summary.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_drug_information_summary/config/install/simple_sitemap.bundle_settings.default.node.pdq_drug_information_summary.yml
@@ -1,0 +1,4 @@
+index: true
+priority: '1.0'
+changefreq: weekly
+include_images: false

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_drug_information_summary/pdq_drug_information_summary.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_drug_information_summary/pdq_drug_information_summary.info.yml
@@ -21,5 +21,6 @@ dependencies:
   - pdq_drug_information_summary
   - rest
   - serialization
+  - simple_sitemap
   - text
   - user


### PR DESCRIPTION
Closes #792 

* add the `simple_sitemap` module
* override the default configuration for that module
* configure which content types should be mapped with which settings
* register the configuration changes with the `features` module