### PR TITLE
(#2067) Fix issue with memcache and drupal install.

### DIFF
--- a/blt/src/Commands/SlevenCommand.php
+++ b/blt/src/Commands/SlevenCommand.php
@@ -63,4 +63,18 @@ class SlevenCommand extends BltTasks {
     return $result;
   }
 
+  /**
+   * Rebuild Drupal Cache.
+   *
+   * @command cgov:cache-rebuild
+   */
+  public function cacheRebuild() {
+    $this->say("Clearing Cache");
+    $task = $this->taskDrush()
+      ->drush('cr')
+      ->printOutput(TRUE);
+    $result = $task->interactive($this->input()->isInteractive())->run();
+    return $result;
+  }
+
 }

--- a/hooks/common/post-code-deploy/post-code-deploy.sh
+++ b/hooks/common/post-code-deploy/post-code-deploy.sh
@@ -32,6 +32,12 @@ if [[ $target_env =~ ^ode\d* ]]; then
   target_env="ode";
 fi
 
+## Clear Drupal Cache to get around Memcache issues? (A CR before an install does
+## not throw errors. BUt without an install is unsuccessful.) (Possibly because
+## the cached items are not longer installed in the database that gets dropped
+## before the installation.)
+blt cgov:rebuild-cache --environment=$target_env -v --yes --no-interaction -D drush.ansi=false
+
 ## Perform a fresh install.
 blt artifact:install:drupal --environment=$target_env -v --yes --no-interaction -D drush.ansi=false
 

--- a/hooks/common/post-code-update/post-code-update.sh
+++ b/hooks/common/post-code-update/post-code-update.sh
@@ -35,6 +35,12 @@ if [[ $target_env =~ ^ode\d* ]]; then
   target_env="ode";
 fi
 
+## Clear Drupal Cache to get around Memcache issues? (A CR before an install does
+## not throw errors. BUt without an install is unsuccessful.) (Possibly because
+## the cached items are not longer installed in the database that gets dropped
+## before the installation.)
+blt cgov:rebuild-cache --environment=$target_env -v --yes --no-interaction -D drush.ansi=false
+
 ## Perform a fresh install.
 blt artifact:install:drupal --environment=$target_env -v --yes --no-interaction -D drush.ansi=false
 


### PR DESCRIPTION
Deployments are failing, and I believe it is because memcache is holding onto the information after the sql-drop called in the artifact:install. A drush cr seems to fix it.  There may be a better way, and maybe it is calling memcache directly.