### PR TITLE
NCI-000: Initial commit for CGOV Redirect Manager.

### DIFF
--- a/docker/web/runtime/php.ini
+++ b/docker/web/runtime/php.ini
@@ -806,7 +806,7 @@ file_uploads = On
 
 ; Maximum allowed size for uploaded files.
 ; http://php.net/upload-max-filesize
-upload_max_filesize = 2M
+upload_max_filesize = 20M
 
 ; Maximum number of files that can be uploaded via a single request
 max_file_uploads = 20

--- a/docker/web/runtime/php_apache2.ini
+++ b/docker/web/runtime/php_apache2.ini
@@ -822,7 +822,7 @@ file_uploads = On
 
 ; Maximum allowed size for uploaded files.
 ; http://php.net/upload-max-filesize
-upload_max_filesize = 2M
+upload_max_filesize = 20M
 
 ; Maximum number of files that can be uploaded via a single request
 max_file_uploads = 20

--- a/docker/web/runtime/php_cli.ini
+++ b/docker/web/runtime/php_cli.ini
@@ -822,7 +822,7 @@ file_uploads = On
 
 ; Maximum allowed size for uploaded files.
 ; http://php.net/upload-max-filesize
-upload_max_filesize = 2M
+upload_max_filesize = 20M
 
 ; Maximum number of files that can be uploaded via a single request
 max_file_uploads = 20

--- a/docroot/profiles/custom/cgov_site/cgov_site.info.yml
+++ b/docroot/profiles/custom/cgov_site/cgov_site.info.yml
@@ -90,6 +90,7 @@ install:
   - cgov_event
   - cgov_infographic
   - cgov_cancer_research
+  - cgov_redirect_manager
 themes:
   - cgov_common
   - cgov_admin

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.install
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.install
@@ -54,6 +54,7 @@ function _cgov_core_install_permissions(CgovCoreTools $siteHelper) {
       'access taxonomy overview',
       'administer taxonomy',
       'administer blocks',
+      'administer redirects',
       'translate block_content',
       'administer menu',
       'delete content translations',

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_redirect_manager/cgov_redirect_manager.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_redirect_manager/cgov_redirect_manager.info.yml
@@ -1,0 +1,6 @@
+name: CGov Redirect Manager
+type: module
+description: Manages redirects for the CGov Platform.
+core: 8.x
+dependencies:
+  - redirect

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_redirect_manager/cgov_redirect_manager.links.menu.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_redirect_manager/cgov_redirect_manager.links.menu.yml
@@ -1,0 +1,6 @@
+cgov_redirect_manager.import_redirects:
+  title: 'CGov Redirect Manager'
+  route_name: cgov_redirect_manager.redirect_import
+  description: 'Provides administration ui for importing redirect map.'
+  parent: redirect.list
+  weight: 0

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_redirect_manager/cgov_redirect_manager.links.task.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_redirect_manager/cgov_redirect_manager.links.task.yml
@@ -1,0 +1,5 @@
+cgov_redirect_manager.import_redirects:
+  route_name: cgov_redirect_manager.redirect_import
+  base_route: redirect.list
+  title: 'Bulk Import'
+  weight: 10

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_redirect_manager/cgov_redirect_manager.module
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_redirect_manager/cgov_redirect_manager.module
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * @file
+ * Contains cgov_redirect_manager.module.
+ */
+
+/**
+ * Implements hook_cron().
+ */
+function cgov_redirect_manager_cron() {
+
+  // This takes too long to run in the web interface.
+  // Only run in drush.
+  $isDrush = (PHP_SAPI == 'cli' && function_exists('drush_main'));
+  if (!$isDrush) {
+    return;
+  }
+
+  // Throttle redirect imports to happen at most once ever minute.
+  $tooSoon = (\Drupal::time()->getRequestTime() >= \Drupal::state()->get('system.cron_last') + 60);
+  if (!$tooSoon) {
+    return FALSE;
+  }
+
+  /** @var QueueFactory $queue_factory */
+  $queue_factory = \Drupal::service('queue');
+  /** @var QueueWorkerManager $queue_manager */
+  $queue_manager = \Drupal::service('plugin.manager.queue_worker');
+
+  $queue = $queue_factory->get('cgov_redirect_manager_queue_worker');
+  $queue_worker = $queue_manager->createInstance('cgov_redirect_manager_queue_worker');
+
+  $time_limit = 1200;
+  $end = time() + $time_limit;
+
+  // Process all cgov_redirect_manager_queue_worker in the given time.
+  while ((!$time_limit || time() < $end) && ($item = $queue->claimItem())) {
+    try {
+      $queue_worker->processItem($item->data);
+      $queue->deleteItem($item);
+    }
+    catch (RequeueException $e) {
+      // The worker requested the task to be immediately requeued.
+      $queue->releaseItem($item);
+    }
+    catch (SuspendQueueException $e) {
+      // If the worker indicates there is a problem with the whole queue,
+      // release the item.
+      $queue->releaseItem($item);
+      throw new \Exception($e->getMessage());
+    }
+  }
+}

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_redirect_manager/cgov_redirect_manager.routing.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_redirect_manager/cgov_redirect_manager.routing.yml
@@ -1,0 +1,9 @@
+cgov_redirect_manager.redirect_import:
+  path: '/admin/config/search/cgov-redirect-manager'
+  defaults:
+    _form: '\Drupal\cgov_redirect_manager\Form\RedirectImport'
+    _title: 'Redirect Import Manager'
+  requirements:
+    _permission: 'administer redirects'
+  options:
+    _admin_route: TRUE

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_redirect_manager/cgov_redirect_manager.services.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_redirect_manager/cgov_redirect_manager.services.yml
@@ -1,0 +1,7 @@
+services:
+  cgov_redirect_manager.importer:
+    class: Drupal\cgov_redirect_manager\CgovImporterService
+    arguments: ['@database', '@language_manager', '@logger.channel.cgov_redirect_manager']
+  logger.channel.cgov_redirect_manager:
+    parent: logger.channel_base
+    arguments: ['cgov_redirect_manager']

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_redirect_manager/src/CgovImporterService.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_redirect_manager/src/CgovImporterService.php
@@ -1,0 +1,517 @@
+<?php
+
+namespace Drupal\cgov_redirect_manager;
+
+use Drupal\Core\Database\Connection;
+use Drupal\redirect\Entity\Redirect;
+use Drupal\Component\Utility\UrlHelper;
+use Drupal\Core\Url;
+use Drupal\Core\Language\LanguageManagerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Class CGovImporterService.
+ *
+ * @package Drupal\cgov_redirect_manager
+ */
+class CGovImporterService {
+
+  public static $messages = [];
+
+  public static $options = [];
+
+  /**
+   * The database connection service.
+   *
+   * @var \Drupal\Core\Database\Connection
+   */
+  protected $connection;
+
+  /**
+   * The language manager to get all languages for to get all aliases.
+   *
+   * @var \Drupal\Core\Language\LanguageManagerInterface
+   */
+  protected $languageManager;
+
+  /**
+   * A logger instance.
+   *
+   * @var \Psr\Log\LoggerInterface
+   */
+  protected $logger;
+
+  /**
+   * Constructs a Google Analytics Counter object.
+   *
+   * @param \Drupal\Core\Database\Connection $connection
+   *   A database connection.
+   *   The path matcher.
+   * @param \Drupal\Core\Language\LanguageManagerInterface $language
+   *   The language manager.
+   * @param \Psr\Log\LoggerInterface $logger
+   *   A logger instance.
+   */
+  public function __construct(
+    Connection $connection,
+    LanguageManagerInterface $language,
+    LoggerInterface $logger
+  ) {
+    $this->connection = $connection;
+    $this->languageManager = $language;
+    $this->logger = $logger;
+  }
+
+  /**
+   * Main method: execute parsing and saving of redirects.
+   *
+   * @param mixed $file
+   *   Either a Drupal file object (ui) or a path to a file (drush).
+   * @param str[] $options
+   *   User-supplied default flags.
+   */
+  public static function import($file, array $options) {
+    // Parse the CSV file into a readable array.
+    $data = self::read($file, $options);
+    self::$options = $options;
+    // Perform Drupal-specific validation logic on each row.
+    $data = array_filter($data, ['self', 'preSave']);
+    $count = 0;
+
+    if ($options['suppress_messages'] != 1) {
+      // Messaging/logging is separated out in case we want to suppress these.
+      foreach (self::$messages['warning'] as $warning) {
+        drupal_set_message($warning, 'warning');
+      }
+    }
+
+    if (empty($data)) {
+      drupal_set_message(t('The uploaded file contains no rows with compatible redirect data. No redirects have imported. Compare your file to <a href=":sample">this sample data.</a>', [':sample' => '/' . drupal_get_path('module', 'path_redirect_import') . '/redirect-example-file.csv']), 'warning');
+    }
+    else {
+      if (PHP_SAPI == 'cli' && function_exists('drush_main')) {
+        foreach ($data as $redirect_array) {
+          self::save($redirect_array, $options['override'], []);
+          $count++;
+        }
+      }
+      else {
+        // This case should never happen...
+      }
+    }
+    drupal_set_message(t('Successfully imported "@count" items.', ['@count' => $count]));
+  }
+
+  /**
+   * Batch API callback.
+   */
+  public static function finish($success, $results, $operations) {
+    if ($success) {
+      $message = t('Redirects processed.');
+    }
+    else {
+      $message = t('Finished with an error.');
+    }
+    drupal_set_message($message, 'status');
+  }
+
+  /**
+   * Reads a line from the csv and handles language and type.
+   *
+   * The input file will only be Source, Destination. A Redirect
+   * is actually Source, Destination, Status, Language. Because
+   * Drupal, Spanish URLs should not have /espanol in the url
+   * AND the language needs to be Spanish. So we will find those
+   * sources and destinations and manipulate appropriately.
+   *
+   * NOTE: In a really perfect world, this would use the language
+   * negotiation system to figure out the URL/Language. For now we
+   * shall make assumptions.
+   *
+   * @param resource $file
+   *   The file handle to read from.
+   * @param string $delimiter
+   *   The delimiter to use to separate the line.
+   * @param string $status
+   *   The default status code.
+   * @param string $lang
+   *   The default language if the url does not begin with /.
+   *
+   * @return mixed
+   *   Returns an indexed array containing the fields read. See fgetcsv.
+   */
+  public static function readExpandLine($file, $delimiter, $status, $lang) {
+    $line = fgetcsv($file, 0, $delimiter);
+
+    // Either EOF, Error or Empty Line.
+    if (!$line || !is_array($line)) {
+      return $line;
+    }
+
+    // Missing either source or destination.
+    if (empty($line[0]) || empty($line[1])) {
+      return $line;
+    }
+
+    // For some reason this row has the appropriate number of elements.
+    // Most likely this will be due to someone combining two rows, but
+    // let's hope for the best...
+    if (count($line) == 4) {
+      return $line;
+    }
+
+    $source = trim($line[0]);
+    $dest = trim($line[1]);
+
+    if (preg_match("/^\/espanol(\/.*)$/i", $source, $matches)) {
+      return [
+        $matches[1],
+        $dest,
+        $status,
+        'es',
+      ];
+    }
+    else {
+      return [
+        $source,
+        $dest,
+        $status,
+        $lang,
+      ];
+    }
+  }
+
+  /**
+   * Convert CSV file into readable PHP array.
+   *
+   * @param mixed $file
+   *   A Drupal file object.
+   * @param str[] $options
+   *   User-passed defaults.
+   *
+   * @return str[]
+   *   Keyed array of redirects, in the format
+   *    [source, redirect, status_code, language].
+   */
+  protected static function read($file, array $options = []) {
+
+    $filepath = \Drupal::service('file_system')->realpath($file->getFileUri());
+
+    if (!$f = fopen($filepath, 'r')) {
+      return ['success' => FALSE, 'message' => [t('Unable to read the file')]];
+    }
+    $options += [
+      'delimiter' => ',',
+      'no_headers' => TRUE,
+      'override' => TRUE,
+      'status_code' => '301',
+      'language' => 'en',
+    ];
+
+    $line_no = 0;
+    $data = [];
+    while ($line = self::readExpandLine($f, $options['delimiter'], $options['status_code'], $options['language'])) {
+      $line_no++;
+      if ($line_no == 1 && !$options['no_headers']) {
+        drupal_set_message(t('Skipping the header row.'));
+        continue;
+      }
+
+      if (!is_array($line)) {
+        self::$messages['warning'][] = t('Line @line_no is invalid; bypassed.', ['@line_no' => $line_no]);
+        continue;
+      }
+      if (empty($line[0]) || empty($line[1])) {
+        self::$messages['warning'][] = t('Line @line_no contains invalid data; bypassed.', ['@line_no' => $line_no]);
+        continue;
+      }
+      if (empty($line[2])) {
+        $line[2] = $options['status_code'];
+      }
+      else {
+        $redirect_options = redirect_status_code_options();
+        if (!isset($redirect_options[$line[2]])) {
+          self::$messages['warning'][] = t('Line @line_no contains invalid status code; bypassed.', ['@line_no' => $line_no]);
+          continue;
+        }
+      }
+
+      if (empty($line[3])) {
+        $line[3] = $options['language'];
+      }
+      elseif (!self::isValidLanguage($line[3])) {
+        self::$messages['warning'][] = t('Line @line_no contains an invalid language code; bypassed.', ['@line_no' => $line_no]);
+        continue;
+      }
+
+      // Build a row of data.
+      $data[$line_no] = [
+        'source' => self::stripLeadingSlash($line[0]),
+        'redirect' => isset($line[1]) ? self::stripLeadingSlash($line[1]) : NULL,
+        'status_code' => $line[2],
+        'language' => isset($line[3]) ? $line[3] : $options['language'],
+      ];
+
+    }
+    fclose($f);
+    return $data;
+  }
+
+  /**
+   * Check for problematic data and remove or clean up.
+   *
+   * @param str[] $row
+   *   Keyed array of redirects, in the format
+   *    [source, redirect, status_code, language].
+   *
+   * @return bool
+   *   A TRUE/FALSE value to be used by array_filter.
+   */
+  public static function preSave(array $row) {
+    // Disallow redirects from <front>.
+    if ($row['source'] == '<front>') {
+      self::$messages['warning'][] = t('You cannot create a redirect from the front page. Bypassing "@source".', ['@source' => $row['source']]);
+      return FALSE;
+    }
+
+    // Disallow redirects from anchor fragments.
+    if (strpos($row['source'], '#') !== FALSE) {
+      self::$messages['warning'][] = t('Redirects from anchor fragments (i.e., with "#) are not allowed. Bypassing "@source".', ['@source' => $row['source']]);
+      return FALSE;
+    }
+
+    // Disallow redirects to nonexistent internal paths.
+    if (self::internalPathMissing($row['redirect']) && self::$options['allow_nonexistent'] == 0) {
+      self::$messages['warning'][] = t('The destination path "@redirect" does not exist on the site. Redirect from "@source" bypassed.', [
+        '@redirect' => $row['redirect'],
+        '@source' => $row['source'],
+      ]);
+      return FALSE;
+    }
+
+    // Disallow infinite redirects.
+    if (self::sourceIsDestination($row)) {
+      self::$messages['warning'][] = t('You are attempting to redirect "@redirect" to itself. Bypassed, as this will result in an infinite loop.', ['@redirect' => $row['redirect']]);
+      return FALSE;
+    }
+
+    return TRUE;
+  }
+
+  /**
+   * Save an individual redirect entity, if no redirect already exists.
+   *
+   * @param str[] $redirect_array
+   *   Keyed array of redirects, in the format
+   *    [source, redirect, status_code, language].
+   * @param bool $override
+   *   A 1 indicates that existing redirects should be updated.
+   */
+  public static function save(array $redirect_array, $override) {
+    if ($redirects = self::redirectExists($redirect_array)) {
+      if ($override == 1) {
+        $redirect = reset($redirects);
+      }
+      else {
+        return;
+      }
+    }
+    else {
+      $parsed_url = UrlHelper::parse(trim($redirect_array['source']));
+      $path = isset($parsed_url['path']) ? $parsed_url['path'] : NULL;
+      $query = isset($parsed_url['query']) ? $parsed_url['query'] : NULL;
+
+      /** @var \Drupal\redirect\Entity\Redirect $redirect */
+      $redirectEntityManager = \Drupal::service('entity.manager')
+        ->getStorage('redirect');
+      $redirect = $redirectEntityManager->create();
+      $redirect->setSource($path, $query);
+    }
+    // Currently, the Redirect module's setRedirect function assumes
+    // all paths are internal. If external, we will use redirect_redirect->set.
+    if (parse_url($redirect_array['redirect'], PHP_URL_SCHEME)) {
+      $redirect->redirect_redirect->set(0, ['uri' => $redirect_array['redirect']]);
+    }
+    else {
+      $redirect->setRedirect($redirect_array['redirect']);
+    }
+    $redirect->setStatusCode($redirect_array['status_code']);
+    $redirect->setLanguage($redirect_array['language']);
+    $redirect->save();
+
+  }
+
+  /**
+   * Truncates redirect table.
+   */
+  public function deleteAll() {
+    $this->connection->truncate('redirect', [])->execute();
+  }
+
+  /**
+   * Remove leading slash, if present.
+   *
+   * @param string $path
+   *   A user-supplied URL path.
+   *
+   * @return string
+   *   A URL without the leading slash.
+   */
+  protected static function stripLeadingSlash($path) {
+    if (strpos($path, '/') === 0) {
+      return substr($path, 1);
+    }
+    return $path;
+  }
+
+  /**
+   * Add leading slash, if not present.
+   *
+   * @param string $path
+   *   A user-supplied URL path.
+   *
+   * @return string
+   *   A URL with the leading slash.
+   */
+  protected static function addLeadingSlash($path) {
+    if (strpos($path, '/') !== 0) {
+      return '/' . $path;
+    }
+    return $path;
+  }
+
+  /**
+   * Check if the path is internal, and if so, if it is missing.
+   *
+   * @param string $destination
+   *   A user-supplied URL path.
+   */
+  protected static function internalPathMissing($destination) {
+    if ($destination == '<front>') {
+      return FALSE;
+    }
+    $parsed = parse_url($destination);
+    if (!isset($parsed['scheme'])) {
+      // Check for aliases *including* named anchors/query strings.
+      $alias = self::addLeadingSlash($destination);
+      $normal_path = \Drupal::service('path.alias_manager')
+        ->getPathByAlias($alias);
+      if ($alias != $normal_path) {
+        return FALSE;
+      }
+      // Check for aliases *excluding* named anchors/query strings.
+      if (isset($parsed['path'])) {
+        $alias = self::addLeadingSlash($parsed['path']);
+        $normal_path = \Drupal::service('path.alias_manager')
+          ->getPathByAlias($alias);
+        if ($alias != $normal_path) {
+          return FALSE;
+        }
+      }
+    }
+    return FALSE;
+  }
+
+  /**
+   * Check for infinite loops.
+   *
+   * @param str[] $row
+   *   Keyed array of redirects, in the format
+   *    [source, redirect, status_code, language].
+   */
+  protected static function sourceIsDestination(array $row) {
+    // Check if the user-supplied source & redirect are identical.
+    if ($row['source'] == $row['redirect']) {
+      return TRUE;
+    }
+    // Now check if the the resulting Drupal location would be identical.
+    try {
+      $parsed = parse_url($row['redirect']);
+      if (!isset($parsed['scheme'])) {
+        // If the destination is an internal link, prepare it.
+        $row['redirect'] = 'internal:' . self::addLeadingSlash($row['redirect']);
+      }
+      $source_url = Url::fromUri('internal:/' . $row['source']);
+      $redirect_url = Url::fromUri($row['redirect']);
+      // It is relevant to do this comparison only in case the source path has
+      // a valid route. Otherwise the validation will fail on the redirect path
+      // being an invalid route.
+      if ($source_url->toString() == $redirect_url->toString()) {
+        return TRUE;
+      }
+      // We still need to check external links, if the user has entered
+      // /node/3 => http://example.com/node/3.
+      $host = \Drupal::request()->getSchemeAndHttpHost();
+      if ($host . $source_url->toString() == $redirect_url->toString()) {
+        return TRUE;
+      }
+    }
+    catch (\InvalidArgumentException $e) {
+      // Do nothing, we want to only compare the resulting URLs.
+    }
+  }
+
+  /**
+   * Check if a redirect already exists for this source path.
+   *
+   * @param str[] $row
+   *   Keyed array of redirects, in the format
+   *    [source, redirect, status_code, language].
+   *
+   * @return mixed
+   *   FALSE if the redirect does not exist, array of redirect objects
+   *    if it does.
+   */
+  protected static function redirectExists(array $row) {
+    // @todo memoize the query.
+    $parsed_url = UrlHelper::parse(trim($row['source']));
+    $path = isset($parsed_url['path']) ? $parsed_url['path'] : NULL;
+    $query = isset($parsed_url['query']) ? $parsed_url['query'] : NULL;
+    $hash = Redirect::generateHash($path, $query, $row['language']);
+
+    // Search for duplicate.
+    $redirects = \Drupal::entityManager()
+      ->getStorage('redirect')
+      ->loadByProperties(['hash' => $hash]);
+    if (!empty($redirects)) {
+      return $redirects;
+    }
+    return FALSE;
+  }
+
+  /**
+   * Check if the string is a valid langcode.
+   *
+   * @param string $langcode
+   *   A string to check.
+   *
+   * @return bool
+   *   Whether the langcode is valid.
+   */
+  protected static function isValidLanguage($langcode) {
+    if (\Drupal::moduleHandler()->moduleExists('language')) {
+      if (!empty($langcode) && in_array($langcode, self::validLanguages())) {
+        return TRUE;
+      }
+    }
+    return FALSE;
+  }
+
+  /**
+   * Retrieve languages in the system.
+   *
+   * @return str[]
+   *   A list of langcodes known to the system.
+   */
+  protected static function validLanguages() {
+    $languages = \Drupal::languageManager()->getLanguages();
+    $languages = array_keys($languages);
+
+    $defaultLockedLanguages = \Drupal::languageManager()
+      ->getDefaultLockedLanguages();
+    $defaultLockedLanguages = array_keys($defaultLockedLanguages);
+
+    return array_merge($languages, $defaultLockedLanguages);
+  }
+
+}

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_redirect_manager/src/Form/RedirectImport.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_redirect_manager/src/Form/RedirectImport.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Drupal\cgov_redirect_manager\Form;
+
+use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\Core\Queue\QueueFactory;
+use Drupal\Core\File\FileSystem;
+
+/**
+ * Class MigrateForm.
+ *
+ * @package Drupal\custom_migrate\Form
+ */
+class RedirectImport extends FormBase {
+
+  protected $filesystem;
+
+  /**
+   * Uploaded file entity.
+   *
+   * @var \Drupal\file\Entity\File
+   */
+  protected $file;
+
+  /**
+   * Drupal\Core\Queue\QueueFactory definition.
+   *
+   * @var \Drupal\Core\Queue\QueueFactory
+   */
+  protected $queue;
+
+  /**
+   * Constructs a new RedirectImport form object.
+   */
+  public function __construct(QueueFactory $queue, FileSystem $fileStorage) {
+    $this->queue = $queue;
+    $this->filesystem = $fileStorage;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('queue'),
+      $container->get('file_system')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'redirect_import_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $form['file'] = [
+      '#type' => 'file',
+      '#upload_location' => 'private://redirect-import',
+      '#title' => $this->t('CSV Redirect File'),
+      '#description' => $this->t('Please upload a CSV redirect file.'),
+      '#upload_validators' => [
+        'file_validate_extensions' => ['csv'],
+      ],
+      '#prefix' => '<p id="redirect-import">Upload a new CSV file.</p>',
+      '#suffix' => '<p>CSV file should be formatted:<ul>
+        <li>Two columns: From URL, To URL</li>
+        <li>From URLs should be relative</li>
+        <li>To URLs can be relative or absolute</li>
+        </ul></p>',
+    ];
+
+    $form['submit'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Upload Redirects'),
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateForm(array &$form, FormStateInterface $form_state) {
+    $uploadDirectory = $this->filesystem
+      ->realpath($form['file']['#upload_location']);
+
+    if (!is_dir($uploadDirectory)) {
+      $this->filesystem
+        ->mkdir($form['file']['#upload_location']);
+    }
+
+    $this->file = file_save_upload(
+      'file',
+      $form['file']['#upload_validators'],
+      $form['file']['#upload_location'],
+      0,
+      TRUE
+    );
+
+    if (!$this->file) {
+      $form_state->setErrorByName('file', $this->t('Please select a csv file of redirects to import.'));
+    }
+
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    if (empty($this->file)) {
+      $form_state->setErrorByName('file', $this->t('No file was found.'));
+      return;
+    }
+    drupal_set_message($this->t("Successfully uploaded redirect file."));
+
+    ini_set('auto_detect_line_endings', TRUE);
+    // Don't do anything if no valid file.
+    if (!isset($this->file)) {
+      drupal_set_message($this->t('No valid file was found. No redirects will be imported.'), 'warning');
+      return;
+    }
+
+    $queue = $this->queue->get('cgov_redirect_manager_queue_worker');
+    $queue->createItem(['type' => 'csv_import', 'file' => $this->file]);
+
+  }
+
+}

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_redirect_manager/src/Plugin/QueueWorker/RedirectManagerQueueWorker.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_redirect_manager/src/Plugin/QueueWorker/RedirectManagerQueueWorker.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Drupal\cgov_redirect_manager\Plugin\QueueWorker;
+
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Psr\Log\LoggerInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Queue\QueueWorkerBase;
+
+/**
+ * Processes migration imports on cron.
+ *
+ * @QueueWorker(
+ *   id = "cgov_redirect_manager_queue_worker",
+ *   title = @Translation("CGov Redirect Manager Queue Worker"),
+ * )
+ */
+class RedirectManagerQueueWorker extends QueueWorkerBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * The loggerFactory object.
+   *
+   * @var \Psr\Log\LoggerInterface
+   */
+  protected $loggerFactory;
+
+  /**
+   * Constructs a new LocaleTranslation object.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param array $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Psr\Log\LoggerInterface $loggerFactory
+   *   The module handler.
+   */
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    array $plugin_definition,
+    LoggerInterface $loggerFactory
+  ) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->loggerFactory = $loggerFactory;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(
+    ContainerInterface $container,
+    array $configuration,
+    $plugin_id,
+    $plugin_definition
+  ) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('logger.factory')->get('cgov_redirect_manager')
+    );
+  }
+
+  /**
+   * Processes items added to migration_import_queue_worker.
+   *
+   * @param mixed $data
+   *   Data to be processed by worker.
+   */
+  public function processItem($data) {
+    $this->loggerFactory->info('Executing CGov Redirect Imports...');
+    $options = [
+      'status_code' => '301',
+      'override' => TRUE,
+      'no_headers' => TRUE,
+      'delimiter' => ',',
+      'language' => 'en',
+      'suppress_messages' => TRUE,
+      'allow_nonexistent' => TRUE,
+    ];
+
+    if ($data['type'] == 'csv_import') {
+      \Drupal::service('cgov_redirect_manager.importer')->import($data['file'], $options);
+    }
+    $this->loggerFactory->info('CGov Redirect Imports finished...');
+  }
+
+}

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_redirect_manager/tests/src/Unit/CgovImporterServiceTest.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_redirect_manager/tests/src/Unit/CgovImporterServiceTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Drupal\Tests\cgov_redirect_manager\Unit;
+
+use Drupal\Tests\UnitTestCase;
+use Drupal\cgov_redirect_manager\CgovImporterService;
+use org\bovigo\vfs\vfsStream;
+
+/**
+ * Tests Unit Test Configuration.
+ *
+ * @group cgov_core
+ */
+class TestUnitTest extends UnitTestCase {
+
+  /**
+   * Tests truthy.
+   */
+  public function testReadExpandLine() {
+    $csv = <<<CSV
+/espanol/foo/bar,/espanol/bar/bazz
+/foo/bar,/bar/bazz
+/bazz/bob,/blee/bargh,301,en
+ /blee,  /blab
+CSV;
+
+    // Mock the file system with our content.
+    vfsStream::setup('tmp', NULL, [
+      'test.csv' => $csv,
+    ]);
+
+    // Open the fake file for reading.
+    $f = fopen('vfs://tmp/test.csv', 'r');
+
+    $actual = [];
+    while ($line = CgovImporterService::readExpandLine($f, ',', '301', 'en')) {
+      $actual[] = $line;
+    }
+
+    $expected = [
+      ['/foo/bar', '/espanol/bar/bazz', '301', 'es'],
+      ['/foo/bar', '/bar/bazz', '301', 'en'],
+      ['/bazz/bob', '/blee/bargh', '301', 'en'],
+      ['/blee', '/blab', '301', 'en'],
+    ];
+
+    $this->assertEquals($actual, $expected);
+  }
+
+}


### PR DESCRIPTION
### Changes
- Initial commit of Redirect Manager for Cgov
- Implements administration form for uploading, saving and queueing up file.
- Implements QueueWorker to process the newly created queue items on cron
- Implements Service for managing imports (taken and modified from path_redirect_import)
- Uploads PHP upload_max_filesize to 20MB on local docker (set to 256M on Acquia)

### Processing
1. Visit the administration page for importing redirects: `/admin/config/search/cgov-redirect-manager`
2. Upload your CSV file of redirects. (2 columns, no headers)
  1. This uploads your file to the files-private directory.
  2. This creates a new queue item to be processed: cgov_redirect_manager_queue_worker
3. The queue item will be picked up on the next cron run. 
4. Manual Override: 
  1. Manually execute a `drush cron`  OR
  2. A more targeted approach `drush queue:run cgov_redirect_manager_queue_worker`