### PR TITLE
(#2083) Add hook alter to disable Acquia Connector Toolbar 

### DIFF
--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.module
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.module
@@ -565,3 +565,19 @@ function _cgov_core_form_moderation_sidebar_quick_transition_form_submit(array $
 
   $form_state->setRedirectUrl($entity->toUrl('edit-form'));
 }
+
+/**
+ * Implements hook_toolbar_alter().
+ *
+ * Unset the acquia_connector toolbar for non-site-admins.
+ */
+function cgov_core_toolbar_alter(&$items) {
+
+  $user_roles = \Drupal::currentUser()->getRoles();
+  // We can assume that only administrator should see the status message.
+  if (!empty($user_roles) && !in_array("site_admin", $user_roles)) {
+
+    unset($items['acquia_connector']);
+  }
+
+}


### PR DESCRIPTION
Closes #2083 

*  Adds a hook alter to disable Acquia Connector Toolbar for non 'site_admin" users. 

http://ncigovcdode207.prod.acquia-sites.com/

To test, log in as siteadmin and compare to any other user (admin, auth0r, etc..).


