### PR TITLE
(#2123, #2125, #2155) Metatag updates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -209,6 +209,9 @@
             "drupal/features": {
                 "2834130 : Updates Features Diff to Include Alters" : "https://www.drupal.org/files/issues/2019-06-09/features-detect-overrides-update-2834130-4-D8.patch"
             },
+            "drupal/metatag": {
+                "2981793 : Allow metatag configuration to be disabled" : "https://www.drupal.org/files/issues/2019-02-27/allow-metatags-to-be-disabled.2981793.11_0.patch"
+            },
             "drupal/page_manager": {
                 "2820218 : Page manager does not respect existing route defaults for title callbacks": "https://www.drupal.org/files/issues/2018-03-21/2820218-50.patch",
                 "2876880 : page_variant entity type does not exist when installing or enabling": "https://www.drupal.org/files/issues/2876880-page-varient-cache-2.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "715b1fac176aece2db889a3116a0f079",
+    "content-hash": "3063fbd173d93d5ed22d1f194de6fbe2",
     "packages": [
         {
             "name": "acquia/acsf-tools",
@@ -5309,6 +5309,9 @@
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
                     }
+                },
+                "patches_applied": {
+                    "2981793 : Allow metatag configuration to be disabled": "https://www.drupal.org/files/issues/2019-02-27/allow-metatags-to-be-disabled.2981793.11_0.patch"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -8002,6 +8005,7 @@
                 "translation",
                 "twig"
             ],
+            "abandoned": "simplesamlphp/twig-configurable-i18n",
             "time": "2018-10-10T09:12:46+00:00"
         },
         {

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_application_page/config/install/metatag.metatag_defaults.node__cgov_application_page.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_application_page/config/install/metatag.metatag_defaults.node__cgov_application_page.yml
@@ -1,8 +1,8 @@
 langcode: en
 status: true
 dependencies: {  }
-id: node__cgov_biography
-label: 'Content: Biography'
+id: node__cgov_application_page
+label: 'Content: Application Page'
 tags:
   title: '[cgov_tokens:cgov-title] - [cgov_tokens:cgov-trans-org-name]'
-  dcterms_type: cgvBiography
+  dcterms_type: nciAppModulePage

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/metatag.metatag_defaults.node__cgov_article.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/metatag.metatag_defaults.node__cgov_article.yml
@@ -4,4 +4,5 @@ dependencies: {  }
 id: node__cgov_article
 label: 'Content: Article'
 tags:
+  title: '[cgov_tokens:cgov-title] - [cgov_tokens:cgov-trans-org-name]'
   dcterms_type: cgvArticle

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/config/install/metatag.metatag_defaults.node__cgov_blog_post.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/config/install/metatag.metatag_defaults.node__cgov_blog_post.yml
@@ -4,5 +4,6 @@ dependencies: {  }
 id: node__cgov_blog_post
 label: 'Content: Blog Post'
 tags:
-  dcterms_is_referenced_by: 'event1,event53'
+  title: '[cgov_tokens:cgov-title] - [cgov_tokens:cgov-trans-org-name]'
   dcterms_type: cgvBlogPost
+  dcterms_is_referenced_by: 'event1,event53'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/config/install/metatag.metatag_defaults.node__cgov_blog_series.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/config/install/metatag.metatag_defaults.node__cgov_blog_series.yml
@@ -4,4 +4,5 @@ dependencies: {  }
 id: node__cgov_blog_series
 label: 'Content: Blog Series'
 tags:
+  title: '[cgov_tokens:cgov-title] - [cgov_tokens:cgov-trans-org-name]'
   dcterms_type: cgvBlogSeries

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_center/config/install/metatag.metatag_defaults.node__cgov_cancer_center.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_center/config/install/metatag.metatag_defaults.node__cgov_cancer_center.yml
@@ -4,4 +4,5 @@ dependencies: {  }
 id: node__cgov_cancer_center
 label: 'Content: Cancer Center'
 tags:
+  title: '[cgov_tokens:cgov-title] - [cgov_tokens:cgov-trans-org-name]'
   dcterms_type: cgvCancerCenter

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_research/config/install/metatag.metatag_defaults.node__cgov_cancer_research.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_research/config/install/metatag.metatag_defaults.node__cgov_cancer_research.yml
@@ -4,4 +4,5 @@ dependencies: {  }
 id: node__cgov_cancer_research
 label: 'Content: Cancer Research List Page'
 tags:
+  title: '[cgov_tokens:cgov-title] - [cgov_tokens:cgov-trans-org-name]'
   dcterms_type: cgvCancerResearch

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/config/install/metatag.metatag_defaults.front.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/config/install/metatag.metatag_defaults.front.yml
@@ -1,0 +1,8 @@
+langcode: en
+status: false
+dependencies: {  }
+id: front
+label: 'Front page'
+tags:
+  shortlink: '[site:url]'
+  canonical_url: '[site:url]'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/metatag.metatag_defaults.node__cgov_cthp.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/metatag.metatag_defaults.node__cgov_cthp.yml
@@ -4,5 +4,6 @@ dependencies: {  }
 id: node__cgov_cthp
 label: 'Content: Cancer Type Homepage'
 tags:
+  title: '[cgov_tokens:cgov-title] - [cgov_tokens:cgov-trans-org-name]'
   dcterms_type: cgvCancerTypeHome
   dcterms_audience: '[node:field_audience:value]'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_event/config/install/metatag.metatag_defaults.node__cgov_event.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_event/config/install/metatag.metatag_defaults.node__cgov_event.yml
@@ -4,4 +4,5 @@ dependencies: {  }
 id: node__cgov_event
 label: 'Content: Event'
 tags:
+  title: '[cgov_tokens:cgov-title] - [cgov_tokens:cgov-trans-org-name]'
   dcterms_type: cgvEvent

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/config/install/metatag.metatag_defaults.node__cgov_home_landing.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/config/install/metatag.metatag_defaults.node__cgov_home_landing.yml
@@ -4,4 +4,5 @@ dependencies: {  }
 id: node__cgov_home_landing
 label: 'Content: Home and Landing'
 tags:
+  title: '[cgov_tokens:cgov-title] - [cgov_tokens:cgov-trans-org-name]'
   dcterms_type: cgvHomeLanding

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/config/install/metatag.metatag_defaults.node__cgov_mini_landing.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/config/install/metatag.metatag_defaults.node__cgov_mini_landing.yml
@@ -4,4 +4,5 @@ dependencies: {  }
 id: node__cgov_mini_landing
 label: 'Content: Mini Landing Page'
 tags:
+  title: '[cgov_tokens:cgov-title] - [cgov_tokens:cgov-trans-org-name]'
   dcterms_type: cgvMiniLanding

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_infographic/config/install/metatag.metatag_defaults.media__cgov_infographic.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_infographic/config/install/metatag.metatag_defaults.media__cgov_infographic.yml
@@ -4,4 +4,5 @@ dependencies: {  }
 id: media__cgov_infographic
 label: 'Media: Infographic'
 tags:
+  title: '[cgov_tokens:cgov-title] - [cgov_tokens:cgov-trans-org-name]'
   dcterms_type: cgvInfographic

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/metatag.metatag_defaults.node__cgov_press_release.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/metatag.metatag_defaults.node__cgov_press_release.yml
@@ -4,4 +4,5 @@ dependencies: {  }
 id: node__cgov_press_release
 label: 'Content: Press Release'
 tags:
+  title: '[cgov_tokens:cgov-title] - [cgov_tokens:cgov-trans-org-name]'
   dcterms_type: cgvPressRelease

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/metatag.metatag_defaults.media__cgov_video.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/metatag.metatag_defaults.media__cgov_video.yml
@@ -4,4 +4,5 @@ dependencies: {  }
 id: media__cgov_video
 label: 'Media: Video'
 tags:
+  title: '[cgov_tokens:cgov-title] - [cgov_tokens:cgov-trans-org-name]'
   dcterms_type: cgvVideo

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/metatag.metatag_defaults.node__cgov_video.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/metatag.metatag_defaults.node__cgov_video.yml
@@ -4,4 +4,5 @@ dependencies: {  }
 id: node__cgov_video
 label: 'Content: Video'
 tags:
+  title: '[cgov_tokens:cgov-title] - [cgov_tokens:cgov-trans-org-name]'
   dcterms_type: cgvVideo

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/metatag.metatag_defaults.node__pdq_cancer_information_summary.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/metatag.metatag_defaults.node__pdq_cancer_information_summary.yml
@@ -4,6 +4,6 @@ dependencies: {  }
 id: node__pdq_cancer_information_summary
 label: 'Content: PDQ Cancer Information Summary'
 tags:
-  title: '[cgov_tokens:cgov-title] - [cgov_tokens:cgov-trans-org-name]'
+  title: '[current-page:title] - [cgov_tokens:cgov-trans-org-name]'
   dcterms_type: pdqCancerInfoSummary
   dcterms_audience: '[node:field_pdq_audience:value]'

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/metatag.metatag_defaults.node__pdq_cancer_information_summary.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/metatag.metatag_defaults.node__pdq_cancer_information_summary.yml
@@ -4,5 +4,6 @@ dependencies: {  }
 id: node__pdq_cancer_information_summary
 label: 'Content: PDQ Cancer Information Summary'
 tags:
+  title: '[cgov_tokens:cgov-title] - [cgov_tokens:cgov-trans-org-name]'
   dcterms_type: pdqCancerInfoSummary
   dcterms_audience: '[node:field_pdq_audience:value]'

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_drug_information_summary/config/install/metatag.metatag_defaults.node__pdq_drug_information_summary.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_drug_information_summary/config/install/metatag.metatag_defaults.node__pdq_drug_information_summary.yml
@@ -4,4 +4,5 @@ dependencies: {  }
 id: node__pdq_drug_information_summary
 label: 'Content: PDQ Drug Information Summary'
 tags:
+  title: '[cgov_tokens:cgov-title] - [cgov_tokens:cgov-trans-org-name]'
   dcterms_type: pdqDrugInfoSummary


### PR DESCRIPTION
(#2123) Update metatag defaults to include title metatag

(#2155) Update og_title metatag on home pages (for use in social media links)

(#2125) Fix browser title on PDQ CIS pages to show full page title