### PR TITLE
(#2078)  Browser title for 404 and 403 pages

### DIFF
--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/config/install/metatag.metatag_defaults.403.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/config/install/metatag.metatag_defaults.403.yml
@@ -4,7 +4,8 @@ dependencies: {  }
 id: '403'
 label: '403 access denied'
 tags:
-  shortlink: '[site:url]'
   canonical_url: '[site:url]'
-  dcterms_type: errorpage
+  shortlink: '[site:url]'
+  title: 'Page Not Found - [cgov_tokens:cgov-trans-org-name]'
   dcterms_subject: 'Error Pages'
+  dcterms_type: errorpage

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/config/install/metatag.metatag_defaults.404.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/config/install/metatag.metatag_defaults.404.yml
@@ -4,7 +4,8 @@ dependencies: {  }
 id: '404'
 label: '404 page not found'
 tags:
-  shortlink: '[site:url]'
   canonical_url: '[site:url]'
-  dcterms_type: errorpage
+  shortlink: '[site:url]'
+  title: 'Page Not Found - [cgov_tokens:cgov-trans-org-name]'
   dcterms_subject: 'Error Pages'
+  dcterms_type: errorpage


### PR DESCRIPTION

Closes #2078 

Adds default browser title for of 'Page Not Found' for both 404 and 403 pages. 