### PR TITLE
(#2219) Fixes sitemaps on microsites.

### DIFF
--- a/docroot/sites/settings/cgov_core.settings.php
+++ b/docroot/sites/settings/cgov_core.settings.php
@@ -19,3 +19,26 @@
  */
 $config['locale.settings']['translation']['use_source'] = 'local';
 $config['locale.settings']['translation']['path'] = DRUPAL_ROOT . '/translations';
+
+// Pass in the correct ACSF site name to build the sitemap.xml.
+// The base_url is picked up from, well, who knows what actually. It should be
+// what is passed in for the --uri flag to drush for the cron, but then again
+// it should appear as the site factory name? In any case we want to find the
+// preferred domain, which should always be the public facing one. This is
+// the name that shows on the card for the site. Anyway, you should always
+// add that one as the first domain when creating a site, and then we will
+// make sure that shows up in the sitemap.xml with the following code.
+if ($is_acsf_env && $acsf_db_name) {
+  $domains = gardens_data_get_sites_from_file($GLOBALS['gardens_site_settings']['conf']['acsf_db_name']);
+  // Full disclosure, I don't know if the preferred_domain is always set.
+  $domain = array_keys($domains)[0];
+  foreach($domains as $site_name => $site_info) {
+    if (!empty($site_info['flags']['preferred_domain'])) {
+      $domain = $site_name;
+    }
+  }
+  $config['simple_sitemap.settings']['base_url'] = 'https://' . $domain;
+} else {
+  // NOTE: you can override this in your local.settings.php.
+  $config['simple_sitemap.settings']['base_url'] = 'https://www.cancer.gov';
+}


### PR DESCRIPTION
Closes #2219 
Note this still leaves an outstanding issue where the sitemap has a /espanol link even if there is no translated homepage.