### PR TITLE
(#2221, #2222, #2223, #2250, #2078) Spanish metatags, browser title org append, media content language, 403 and 404 page browser titles

### DIFF
--- a/docroot/lib/CgovPlatform/Tests/CgovSchemaExclusions.php
+++ b/docroot/lib/CgovPlatform/Tests/CgovSchemaExclusions.php
@@ -18,6 +18,23 @@ class CgovSchemaExclusions {
     'metatag.metatag_defaults.media',
     'metatag.metatag_defaults.403',
     'metatag.metatag_defaults.404',
+    'metatag.metatag_defaults.node__cgov_application_page',
+    'metatag.metatag_defaults.node__cgov_article',
+    'metatag.metatag_defaults.node__cgov_biography',
+    'metatag.metatag_defaults.node__cgov_blog_post',
+    'metatag.metatag_defaults.node__cgov_blog_series',
+    'metatag.metatag_defaults.node__cgov_cancer_center',
+    'metatag.metatag_defaults.node__cgov_cancer_research',
+    'metatag.metatag_defaults.node__cgov_cthp',
+    'metatag.metatag_defaults.node__cgov_event',
+    'metatag.metatag_defaults.node__cgov_home_landing',
+    'metatag.metatag_defaults.node__cgov_mini_landing',
+    'metatag.metatag_defaults.media__cgov_infographic',
+    'metatag.metatag_defaults.node__cgov_press_release',
+    'metatag.metatag_defaults.media__cgov_video',
+    'metatag.metatag_defaults.node__cgov_video',
+    'metatag.metatag_defaults.node__pdq_cancer_information_summary',
+    'metatag.metatag_defaults.node__pdq_drug_information_summary',
   ];
 
 }

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_application_page/config/install/metatag.metatag_defaults.node__cgov_application_page.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_application_page/config/install/metatag.metatag_defaults.node__cgov_application_page.yml
@@ -4,5 +4,20 @@ dependencies: {  }
 id: node__cgov_application_page
 label: 'Content: Application Page'
 tags:
+  canonical_url: '[node:url]'
+  content_language: '[node:langcode]'
+  description: '[node:field_page_description:value]'
   title: '[cgov_tokens:cgov-title] - [cgov_tokens:cgov-trans-org-name]'
+  dcterms_coverage: 'nciglobal,ncienterprise'
+  dcterms_issued: '[node:field_date_posted:date:short]'
+  dcterms_is_part_of: '[cgov_tokens:cgov-analytics-group]'
+  dcterms_is_referenced_by: event1
+  dcterms_subject: '[cgov_tokens:cgov-analytics-channel]'
   dcterms_type: nciAppModulePage
+  og_description: '[node:field_page_description:value]'
+  og_image: '[cgov_tokens:cgov-og-image]'
+  og_site_name: '[cgov_tokens:cgov-og-site-name]'
+  og_title: '[node:field_browser_title:value]'
+  og_type: Website
+  og_url: '[current-page:url]'
+  twitter_cards_type: summary

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/metatag.metatag_defaults.node__cgov_article.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/metatag.metatag_defaults.node__cgov_article.yml
@@ -4,5 +4,20 @@ dependencies: {  }
 id: node__cgov_article
 label: 'Content: Article'
 tags:
+  canonical_url: '[node:url]'
+  content_language: '[node:langcode]'
+  description: '[node:field_page_description:value]'
   title: '[cgov_tokens:cgov-title] - [cgov_tokens:cgov-trans-org-name]'
+  dcterms_coverage: 'nciglobal,ncienterprise'
+  dcterms_issued: '[node:field_date_posted:date:short]'
+  dcterms_is_part_of: '[cgov_tokens:cgov-analytics-group]'
+  dcterms_is_referenced_by: event1
+  dcterms_subject: '[cgov_tokens:cgov-analytics-channel]'
   dcterms_type: cgvArticle
+  og_description: '[node:field_page_description:value]'
+  og_image: '[cgov_tokens:cgov-og-image]'
+  og_site_name: '[cgov_tokens:cgov-og-site-name]'
+  og_title: '[node:field_browser_title:value]'
+  og_type: Website
+  og_url: '[current-page:url]'
+  twitter_cards_type: summary

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_biography/config/install/metatag.metatag_defaults.node__cgov_biography.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_biography/config/install/metatag.metatag_defaults.node__cgov_biography.yml
@@ -4,5 +4,20 @@ dependencies: {  }
 id: node__cgov_biography
 label: 'Content: Biography'
 tags:
+  canonical_url: '[node:url]'
+  content_language: '[node:langcode]'
+  description: '[node:field_page_description:value]'
   title: '[cgov_tokens:cgov-title] - [cgov_tokens:cgov-trans-org-name]'
+  dcterms_coverage: 'nciglobal,ncienterprise'
+  dcterms_issued: '[node:field_date_posted:date:short]'
+  dcterms_is_part_of: '[cgov_tokens:cgov-analytics-group]'
+  dcterms_is_referenced_by: event1
+  dcterms_subject: '[cgov_tokens:cgov-analytics-channel]'
   dcterms_type: cgvBiography
+  og_description: '[node:field_page_description:value]'
+  og_image: '[cgov_tokens:cgov-og-image]'
+  og_site_name: '[cgov_tokens:cgov-og-site-name]'
+  og_title: '[node:field_browser_title:value]'
+  og_type: Website
+  og_url: '[current-page:url]'
+  twitter_cards_type: summary

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/config/install/metatag.metatag_defaults.node__cgov_blog_post.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/config/install/metatag.metatag_defaults.node__cgov_blog_post.yml
@@ -4,6 +4,20 @@ dependencies: {  }
 id: node__cgov_blog_post
 label: 'Content: Blog Post'
 tags:
+  canonical_url: '[node:url]'
+  content_language: '[node:langcode]'
+  description: '[node:field_page_description:value]'
   title: '[cgov_tokens:cgov-title] - [cgov_tokens:cgov-trans-org-name]'
-  dcterms_type: cgvBlogPost
+  dcterms_coverage: 'nciglobal,ncienterprise'
+  dcterms_issued: '[node:field_date_posted:date:short]'
+  dcterms_is_part_of: '[cgov_tokens:cgov-analytics-group]'
   dcterms_is_referenced_by: 'event1,event53'
+  dcterms_subject: '[cgov_tokens:cgov-analytics-channel]'
+  dcterms_type: cgvBlogPost
+  og_description: '[node:field_page_description:value]'
+  og_image: '[cgov_tokens:cgov-og-image]'
+  og_site_name: '[cgov_tokens:cgov-og-site-name]'
+  og_title: '[node:field_browser_title:value]'
+  og_type: Website
+  og_url: '[current-page:url]'
+  twitter_cards_type: summary

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/config/install/metatag.metatag_defaults.node__cgov_blog_series.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/config/install/metatag.metatag_defaults.node__cgov_blog_series.yml
@@ -4,5 +4,20 @@ dependencies: {  }
 id: node__cgov_blog_series
 label: 'Content: Blog Series'
 tags:
+  canonical_url: '[node:url]'
+  content_language: '[node:langcode]'
+  description: '[node:field_page_description:value]'
   title: '[cgov_tokens:cgov-title] - [cgov_tokens:cgov-trans-org-name]'
+  dcterms_coverage: 'nciglobal,ncienterprise'
+  dcterms_issued: '[node:field_date_posted:date:short]'
+  dcterms_is_part_of: '[cgov_tokens:cgov-analytics-group]'
+  dcterms_is_referenced_by: 'event1,event53'
+  dcterms_subject: '[cgov_tokens:cgov-analytics-channel]'
   dcterms_type: cgvBlogSeries
+  og_description: '[node:field_page_description:value]'
+  og_image: '[cgov_tokens:cgov-og-image]'
+  og_site_name: '[cgov_tokens:cgov-og-site-name]'
+  og_title: '[node:field_browser_title:value]'
+  og_type: Website
+  og_url: '[current-page:url]'
+  twitter_cards_type: summary

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_center/config/install/metatag.metatag_defaults.node__cgov_cancer_center.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_center/config/install/metatag.metatag_defaults.node__cgov_cancer_center.yml
@@ -4,5 +4,20 @@ dependencies: {  }
 id: node__cgov_cancer_center
 label: 'Content: Cancer Center'
 tags:
+  canonical_url: '[node:url]'
+  content_language: '[node:langcode]'
+  description: '[node:field_page_description:value]'
   title: '[cgov_tokens:cgov-title] - [cgov_tokens:cgov-trans-org-name]'
+  dcterms_coverage: 'nciglobal,ncienterprise'
+  dcterms_issued: '[node:field_date_posted:date:short]'
+  dcterms_is_part_of: '[cgov_tokens:cgov-analytics-group]'
+  dcterms_is_referenced_by: 'event1,event53'
+  dcterms_subject: '[cgov_tokens:cgov-analytics-channel]'
   dcterms_type: cgvCancerCenter
+  og_description: '[node:field_page_description:value]'
+  og_image: '[cgov_tokens:cgov-og-image]'
+  og_site_name: '[cgov_tokens:cgov-og-site-name]'
+  og_title: '[node:field_browser_title:value]'
+  og_type: Website
+  og_url: '[current-page:url]'
+  twitter_cards_type: summary

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_research/config/install/metatag.metatag_defaults.node__cgov_cancer_research.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_research/config/install/metatag.metatag_defaults.node__cgov_cancer_research.yml
@@ -4,5 +4,20 @@ dependencies: {  }
 id: node__cgov_cancer_research
 label: 'Content: Cancer Research List Page'
 tags:
+  canonical_url: '[node:url]'
+  content_language: '[node:langcode]'
+  description: '[node:field_page_description:value]'
   title: '[cgov_tokens:cgov-title] - [cgov_tokens:cgov-trans-org-name]'
+  dcterms_coverage: 'nciglobal,ncienterprise'
+  dcterms_issued: '[node:field_date_posted:date:short]'
+  dcterms_is_part_of: '[cgov_tokens:cgov-analytics-group]'
+  dcterms_is_referenced_by: 'event1,event53'
+  dcterms_subject: '[cgov_tokens:cgov-analytics-channel]'
   dcterms_type: cgvCancerResearch
+  og_description: '[node:field_page_description:value]'
+  og_image: '[cgov_tokens:cgov-og-image]'
+  og_site_name: '[cgov_tokens:cgov-og-site-name]'
+  og_title: '[node:field_browser_title:value]'
+  og_type: Website
+  og_url: '[current-page:url]'
+  twitter_cards_type: summary

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/config/install/metatag.metatag_defaults.403.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/config/install/metatag.metatag_defaults.403.yml
@@ -4,7 +4,8 @@ dependencies: {  }
 id: '403'
 label: '403 access denied'
 tags:
-  shortlink: '[site:url]'
   canonical_url: '[site:url]'
-  dcterms_type: errorpage
+  shortlink: '[site:url]'
+  title: 'Page Not Found - [cgov_tokens:cgov-trans-org-name]'
   dcterms_subject: 'Error Pages'
+  dcterms_type: errorpage

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/config/install/metatag.metatag_defaults.404.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/config/install/metatag.metatag_defaults.404.yml
@@ -4,7 +4,8 @@ dependencies: {  }
 id: '404'
 label: '404 page not found'
 tags:
-  shortlink: '[site:url]'
   canonical_url: '[site:url]'
-  dcterms_type: errorpage
+  shortlink: '[site:url]'
+  title: 'Page Not Found - [cgov_tokens:cgov-trans-org-name]'
   dcterms_subject: 'Error Pages'
+  dcterms_type: errorpage

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/metatag.metatag_defaults.node__cgov_cthp.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/metatag.metatag_defaults.node__cgov_cthp.yml
@@ -4,6 +4,21 @@ dependencies: {  }
 id: node__cgov_cthp
 label: 'Content: Cancer Type Homepage'
 tags:
+  canonical_url: '[node:url]'
+  content_language: '[node:langcode]'
+  description: '[node:field_page_description:value]'
   title: '[cgov_tokens:cgov-title] - [cgov_tokens:cgov-trans-org-name]'
-  dcterms_type: cgvCancerTypeHome
   dcterms_audience: '[node:field_audience:value]'
+  dcterms_coverage: 'nciglobal,ncienterprise'
+  dcterms_issued: '[node:field_date_posted:date:short]'
+  dcterms_is_part_of: '[cgov_tokens:cgov-analytics-group]'
+  dcterms_is_referenced_by: 'event1,event53'
+  dcterms_subject: '[cgov_tokens:cgov-analytics-channel]'
+  dcterms_type: cgvCancerTypeHome
+  og_description: '[node:field_page_description:value]'
+  og_image: '[cgov_tokens:cgov-og-image]'
+  og_site_name: '[cgov_tokens:cgov-og-site-name]'
+  og_title: '[node:field_browser_title:value]'
+  og_type: Website
+  og_url: '[current-page:url]'
+  twitter_cards_type: summary

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_event/config/install/metatag.metatag_defaults.node__cgov_event.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_event/config/install/metatag.metatag_defaults.node__cgov_event.yml
@@ -4,5 +4,20 @@ dependencies: {  }
 id: node__cgov_event
 label: 'Content: Event'
 tags:
+  canonical_url: '[node:url]'
+  content_language: '[node:langcode]'
+  description: '[node:field_page_description:value]'
   title: '[cgov_tokens:cgov-title] - [cgov_tokens:cgov-trans-org-name]'
+  dcterms_coverage: 'nciglobal,ncienterprise'
+  dcterms_issued: '[node:field_date_posted:date:short]'
+  dcterms_is_part_of: '[cgov_tokens:cgov-analytics-group]'
+  dcterms_is_referenced_by: 'event1,event53'
+  dcterms_subject: '[cgov_tokens:cgov-analytics-channel]'
   dcterms_type: cgvEvent
+  og_description: '[node:field_page_description:value]'
+  og_image: '[cgov_tokens:cgov-og-image]'
+  og_site_name: '[cgov_tokens:cgov-og-site-name]'
+  og_title: '[node:field_browser_title:value]'
+  og_type: Website
+  og_url: '[current-page:url]'
+  twitter_cards_type: summary

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/config/install/metatag.metatag_defaults.node__cgov_home_landing.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/config/install/metatag.metatag_defaults.node__cgov_home_landing.yml
@@ -4,5 +4,20 @@ dependencies: {  }
 id: node__cgov_home_landing
 label: 'Content: Home and Landing'
 tags:
+  canonical_url: '[node:url]'
+  content_language: '[node:langcode]'
+  description: '[node:field_page_description:value]'
   title: '[cgov_tokens:cgov-title] - [cgov_tokens:cgov-trans-org-name]'
+  dcterms_coverage: 'nciglobal,ncienterprise'
+  dcterms_issued: '[node:field_date_posted:date:short]'
+  dcterms_is_part_of: '[cgov_tokens:cgov-analytics-group]'
+  dcterms_is_referenced_by: 'event1,event53'
+  dcterms_subject: '[cgov_tokens:cgov-analytics-channel]'
   dcterms_type: cgvHomeLanding
+  og_description: '[node:field_page_description:value]'
+  og_image: '[cgov_tokens:cgov-og-image]'
+  og_site_name: '[cgov_tokens:cgov-og-site-name]'
+  og_title: '[node:field_browser_title:value]'
+  og_type: Website
+  og_url: '[current-page:url]'
+  twitter_cards_type: summary

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/config/install/metatag.metatag_defaults.node__cgov_mini_landing.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/config/install/metatag.metatag_defaults.node__cgov_mini_landing.yml
@@ -4,5 +4,20 @@ dependencies: {  }
 id: node__cgov_mini_landing
 label: 'Content: Mini Landing Page'
 tags:
+  canonical_url: '[node:url]'
+  content_language: '[node:langcode]'
+  description: '[node:field_page_description:value]'
   title: '[cgov_tokens:cgov-title] - [cgov_tokens:cgov-trans-org-name]'
+  dcterms_coverage: 'nciglobal,ncienterprise'
+  dcterms_issued: '[node:field_date_posted:date:short]'
+  dcterms_is_part_of: '[cgov_tokens:cgov-analytics-group]'
+  dcterms_is_referenced_by: 'event1,event53'
+  dcterms_subject: '[cgov_tokens:cgov-analytics-channel]'
   dcterms_type: cgvMiniLanding
+  og_description: '[node:field_page_description:value]'
+  og_image: '[cgov_tokens:cgov-og-image]'
+  og_site_name: '[cgov_tokens:cgov-og-site-name]'
+  og_title: '[node:field_browser_title:value]'
+  og_type: Website
+  og_url: '[current-page:url]'
+  twitter_cards_type: summary

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_infographic/config/install/metatag.metatag_defaults.media__cgov_infographic.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_infographic/config/install/metatag.metatag_defaults.media__cgov_infographic.yml
@@ -4,5 +4,18 @@ dependencies: {  }
 id: media__cgov_infographic
 label: 'Media: Infographic'
 tags:
+  canonical_url: '[media:url]'
+  content_language: '[media:langcode]'
+  description: '[media:field_page_description:value]'
   title: '[cgov_tokens:cgov-title] - [cgov_tokens:cgov-trans-org-name]'
+  dcterms_coverage: 'nciglobal,ncienterprise'
+  dcterms_subject: '[cgov_tokens:cgov-analytics-channel]'
+  dcterms_is_part_of: '[cgov_tokens:cgov-analytics-group]'
   dcterms_type: cgvInfographic
+  og_description: '[media:field_page_description:value]'
+  og_image: '[cgov_tokens:cgov-og-image]'
+  og_site_name: '[cgov_tokens:cgov-og-site-name]'
+  og_title: '[media:field_browser_title:value]'
+  og_type: Website
+  og_url: '[current-page:url]'
+  twitter_cards_type: summary

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_infographic/config/install/metatag.metatag_defaults.media__cgov_infographic.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_infographic/config/install/metatag.metatag_defaults.media__cgov_infographic.yml
@@ -5,7 +5,7 @@ id: media__cgov_infographic
 label: 'Media: Infographic'
 tags:
   canonical_url: '[media:url]'
-  content_language: '[media:langcode]'
+  content_language: '[cgov_tokens:cgov-media-content-language]'
   description: '[media:field_page_description:value]'
   title: '[cgov_tokens:cgov-title] - [cgov_tokens:cgov-trans-org-name]'
   dcterms_coverage: 'nciglobal,ncienterprise'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_metatag/cgov_metatag.tokens.inc
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_metatag/cgov_metatag.tokens.inc
@@ -37,6 +37,11 @@ function cgov_metatag_token_info() {
           'name' => t('Cgov og:site_name Meta Tag'),
           'description' => t('The value to use for the og:site_name meta tag.'),
         ];
+  $info['tokens']['cgov_tokens']['cgov-media-content-language'] =
+        [
+          'name' => t('Cgov Media content-language Meta Tag'),
+          'description' => t('The value to use for the media content-language meta tag.'),
+        ];
 
   return $info;
 }
@@ -63,6 +68,10 @@ function cgov_metatag_tokens($type, $tokens, array $data, array $options, $bubbl
 
         case 'cgov-og-site-name':
           $replacements[$original] = get_meta_og_site_name_token(t('National Cancer Institute'));
+          break;
+
+        case 'cgov-media-content-language':
+          $replacements[$original] = get_media_meta_content_language_token($data);
           break;
       }
     }
@@ -254,4 +263,23 @@ function get_meta_og_site_name_token(string $transOrgName) {
   else {
     return $name;
   }
+}
+
+/**
+ * Sets up media-langcode metatag value.
+ */
+function get_media_meta_content_language_token(array $data) {
+
+  // Get the entity from the appropriate data key.
+  if (!empty($data['media'])) {
+    $entity = $data['media'];
+  }
+
+  if (empty($entity)) {
+    return;
+  }
+
+  $langcode = $entity->get('langcode')->value;
+
+  return $langcode;
 }

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/metatag.metatag_defaults.node__cgov_press_release.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/metatag.metatag_defaults.node__cgov_press_release.yml
@@ -4,5 +4,20 @@ dependencies: {  }
 id: node__cgov_press_release
 label: 'Content: Press Release'
 tags:
+  canonical_url: '[node:url]'
+  content_language: '[node:langcode]'
+  description: '[node:field_page_description:value]'
   title: '[cgov_tokens:cgov-title] - [cgov_tokens:cgov-trans-org-name]'
+  dcterms_coverage: 'nciglobal,ncienterprise'
+  dcterms_issued: '[node:field_date_posted:date:short]'
+  dcterms_is_part_of: '[cgov_tokens:cgov-analytics-group]'
+  dcterms_is_referenced_by: 'event1,event53'
+  dcterms_subject: '[cgov_tokens:cgov-analytics-channel]'
   dcterms_type: cgvPressRelease
+  og_description: '[node:field_page_description:value]'
+  og_image: '[cgov_tokens:cgov-og-image]'
+  og_site_name: '[cgov_tokens:cgov-og-site-name]'
+  og_title: '[node:field_browser_title:value]'
+  og_type: Website
+  og_url: '[current-page:url]'
+  twitter_cards_type: summary

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/metatag.metatag_defaults.media__cgov_video.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/metatag.metatag_defaults.media__cgov_video.yml
@@ -5,7 +5,7 @@ id: media__cgov_video
 label: 'Media: Video'
 tags:
   canonical_url: '[media:url]'
-  content_language: '[media:langcode]'
+  content_language: '[cgov_tokens:cgov-media-content-language]'
   description: '[media:field_page_description:value]'
   title: '[cgov_tokens:cgov-title] - [cgov_tokens:cgov-trans-org-name]'
   dcterms_coverage: 'nciglobal,ncienterprise'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/metatag.metatag_defaults.media__cgov_video.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/metatag.metatag_defaults.media__cgov_video.yml
@@ -4,5 +4,18 @@ dependencies: {  }
 id: media__cgov_video
 label: 'Media: Video'
 tags:
+  canonical_url: '[media:url]'
+  content_language: '[media:langcode]'
+  description: '[media:field_page_description:value]'
   title: '[cgov_tokens:cgov-title] - [cgov_tokens:cgov-trans-org-name]'
+  dcterms_coverage: 'nciglobal,ncienterprise'
+  dcterms_subject: '[cgov_tokens:cgov-analytics-channel]'
+  dcterms_is_part_of: '[cgov_tokens:cgov-analytics-group]'
   dcterms_type: cgvVideo
+  og_description: '[media:field_page_description:value]'
+  og_image: '[cgov_tokens:cgov-og-image]'
+  og_site_name: '[cgov_tokens:cgov-og-site-name]'
+  og_title: '[media:field_browser_title:value]'
+  og_type: Website
+  og_url: '[current-page:url]'
+  twitter_cards_type: summary

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/metatag.metatag_defaults.node__cgov_video.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/metatag.metatag_defaults.node__cgov_video.yml
@@ -4,5 +4,20 @@ dependencies: {  }
 id: node__cgov_video
 label: 'Content: Video'
 tags:
+  canonical_url: '[node:url]'
+  content_language: '[node:langcode]'
+  description: '[node:field_page_description:value]'
   title: '[cgov_tokens:cgov-title] - [cgov_tokens:cgov-trans-org-name]'
+  dcterms_coverage: 'nciglobal,ncienterprise'
+  dcterms_issued: '[node:field_date_posted:date:short]'
+  dcterms_is_part_of: '[cgov_tokens:cgov-analytics-group]'
+  dcterms_is_referenced_by: 'event1,event53'
+  dcterms_subject: '[cgov_tokens:cgov-analytics-channel]'
   dcterms_type: cgvVideo
+  og_description: '[node:field_page_description:value]'
+  og_image: '[cgov_tokens:cgov-og-image]'
+  og_site_name: '[cgov_tokens:cgov-og-site-name]'
+  og_title: '[node:field_browser_title:value]'
+  og_type: Website
+  og_url: '[current-page:url]'
+  twitter_cards_type: summary

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/metatag.metatag_defaults.node__pdq_cancer_information_summary.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/metatag.metatag_defaults.node__pdq_cancer_information_summary.yml
@@ -4,6 +4,21 @@ dependencies: {  }
 id: node__pdq_cancer_information_summary
 label: 'Content: PDQ Cancer Information Summary'
 tags:
-  title: '[current-page:title] - [cgov_tokens:cgov-trans-org-name]'
-  dcterms_type: pdqCancerInfoSummary
+  canonical_url: '[node:url]'
+  content_language: '[node:langcode]'
+  description: '[node:field_page_description:value]'
+  title: '[cgov_tokens:cgov-title] - [cgov_tokens:cgov-trans-org-name]'
   dcterms_audience: '[node:field_pdq_audience:value]'
+  dcterms_coverage: 'nciglobal,ncienterprise'
+  dcterms_issued: '[node:field_date_posted:date:short]'
+  dcterms_is_part_of: '[cgov_tokens:cgov-analytics-group]'
+  dcterms_is_referenced_by: 'event1,event53'
+  dcterms_subject: '[cgov_tokens:cgov-analytics-channel]'
+  dcterms_type: pdqCancerInfoSummary
+  og_description: '[node:field_page_description:value]'
+  og_image: '[cgov_tokens:cgov-og-image]'
+  og_site_name: '[cgov_tokens:cgov-og-site-name]'
+  og_title: '[node:field_browser_title:value]'
+  og_type: Website
+  og_url: '[current-page:url]'
+  twitter_cards_type: summary

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_drug_information_summary/config/install/metatag.metatag_defaults.node__pdq_drug_information_summary.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_drug_information_summary/config/install/metatag.metatag_defaults.node__pdq_drug_information_summary.yml
@@ -4,5 +4,20 @@ dependencies: {  }
 id: node__pdq_drug_information_summary
 label: 'Content: PDQ Drug Information Summary'
 tags:
+  canonical_url: '[node:url]'
+  content_language: '[node:langcode]'
+  description: '[node:field_page_description:value]'
   title: '[cgov_tokens:cgov-title] - [cgov_tokens:cgov-trans-org-name]'
+  dcterms_coverage: 'nciglobal,ncienterprise'
+  dcterms_issued: '[node:field_date_posted:date:short]'
+  dcterms_is_part_of: '[cgov_tokens:cgov-analytics-group]'
+  dcterms_is_referenced_by: 'event1,event53'
+  dcterms_subject: '[cgov_tokens:cgov-analytics-channel]'
   dcterms_type: pdqDrugInfoSummary
+  og_description: '[node:field_page_description:value]'
+  og_image: '[cgov_tokens:cgov-og-image]'
+  og_site_name: '[cgov_tokens:cgov-og-site-name]'
+  og_title: '[node:field_browser_title:value]'
+  og_type: Website
+  og_url: '[current-page:url]'
+  twitter_cards_type: summary

--- a/docroot/profiles/custom/cgov_site/translations/cgov_site.es.po
+++ b/docroot/profiles/custom/cgov_site/translations/cgov_site.es.po
@@ -172,7 +172,7 @@ msgid "View more research"
 msgstr "Ver más investigaciones"
 
 msgid "National Cancer Institute"
-msgstr "Instituto Nacional Del Cáncer"
+msgstr "Instituto Nacional del Cáncer"
 
 msgid "Selected Reference"
 msgstr "Bibliografía selecta"


### PR DESCRIPTION
#2221, #2222: Fixes metatags so they all get set on Spanish pages

#2223: Lowercasing "del" in Spanish organization name translation

#2250: Adding content-language metatag for media items

#2078: 403 and 404 page browser titles