### PR TITLE
(#2251) Added caching headers to files

### DIFF
--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_file/cgov_file.services.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_file/cgov_file.services.yml
@@ -1,6 +1,6 @@
 services:
   cgov_file.direct_file_download:
     class: Drupal\cgov_file\EventSubscriber\DirectFileDownloadSubscriber
-    arguments: ['@entity_type.manager', '@current_route_match', '@request_stack']
+    arguments: ['@entity_type.manager', '@current_route_match', '@request_stack', '@config.factory', '@service_container']
     tags:
       - { name: event_subscriber }


### PR DESCRIPTION
- Allows for better control of downstream caching in Akamai
- Allows for cache invalidation based on media on all
   external cache layers

Closes #2251