### PR TITLE
Ticket/dceg styling

### DIFF
--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/entrypoints/blogPost/BlogPost.scss
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/entrypoints/blogPost/BlogPost.scss
@@ -57,14 +57,33 @@
   margin-top: 3em;
 }
 
-.embedded-entity[data-entity-embed-display*="_medium"]{
-  margin: 0;
-  figure.image-medium {
-    margin-left: 1em;
-    padding-left: 2.5em;
-    background-color: transparent;
-  }
-} 
+// #2179: there were some styles scoped specifically to embedded images.  Fixed so that styles are properly applied for all the embeddeds
+.cgvblogpost {
+  // wrapped specifically to this content type so that it doesn't cause side effects elsewhere on the site
+  .embedded-entity{
+    &.align-center,
+      &.align-left,
+      &.align-right {
+        margin: 0 0 2.5em 0;
+      }
+  
+    &.align-left {
+      margin-right: 2.5em;
+    }
+  
+    &.align-right {
+      margin-left: 2.5em;
+    }
+  
+    &.align-center {
+      margin: 2.5em auto;
+    }
+  
+    figure.image-medium {
+      background-color: transparent;
+    }
+  } 
+}
 
 @include bp(medium-up) {
 	// set width of blog intro text for tablet and desktop, depending on size of image
@@ -100,13 +119,11 @@
 }
 
 @include bp(small) {
-	// remove extra padding (used for intro text on desktop/tablet only)
-	.embedded-entity[data-entity-embed-display*="_medium"] {
-    float: none;
-    margin: 0;
-		figure.image-medium {
-			padding-left: 0;
-			margin-left: 0;
-		}
-	}
+  // remove extra padding (used for intro text on desktop/tablet only)
+  .cgvblogpost{
+    .embedded-entity {
+      float: none;
+      margin: 0;
+    }
+  }
 }

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/entrypoints/global/Common.js
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/entrypoints/global/Common.js
@@ -55,6 +55,9 @@ import charts from 'Libraries/charts';
 
 DeepLinkPatch();
 
+// Check if floatingDelighters are enabled on the global config
+const shouldShowFloatingDelighters = window.CDEConfig.showFloatingDelighters;
+
 //DOM Ready event
 const onDOMContentLoaded = () => {
 
@@ -159,7 +162,10 @@ const onDOMContentLoaded = () => {
 
   imageCarousel();
 
-  floatingDelighter();
+  // Check global config as to whether floatingDelighters should be instantiated (#2229)
+  if(shouldShowFloatingDelighters) {
+  	floatingDelighter();
+  }
 
   charts();
 

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/variants/green/entrypoints/Green.scss
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/variants/green/entrypoints/Green.scss
@@ -159,7 +159,6 @@ $footer-svg-youtube-hover: youtube-hover-green-theme;
 .main-content .feature-card a,
 .feature-card.cgvArticle a h3,
 .section-nav .contains-current > div a,
-.feature-primary a h3,
 ul.breadcrumbs > * a,
 .topic-feature a h3,
 .pullquote,
@@ -472,10 +471,15 @@ figure a.article-image-enlarge:hover {
       background-color: $landing-page-feature-card-background;
     }
   }
+  // 2240: hovering over the feature card should change the linked heading to the golden color
+  .feature-card a h3 {
+    color: $default-link-color;
+  }
+  .feature-card a:hover h3 {
+    color: $default-link-color-hover;
+  }
 }
 
-.feature-primary .feature-card a h3,
-.feature-primary .feature-card a:hover h3,
 .main-content .feature-card a {
   color: $landing-page-feature-card-link-color;
 }

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/variants/green/entrypoints/Green.scss
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/variants/green/entrypoints/Green.scss
@@ -823,3 +823,25 @@ form button[type="submit"]:hover {
     float: left !important;
   }
 }
+
+//#2262 Request from DCEG2 to change background color of inputs to white
+input[type="text"],
+input[type="password"],
+input[type="date"],
+input[type="datetime"],
+input[type="datetime-local"],
+input[type="month"],
+input[type="week"],
+input[type="email"],
+input[type="number"],
+input[type="search"],
+input[type="tel"],
+input[type="time"],
+input[type="url"],
+textarea {
+  background: #fff;
+
+  &:focus {
+    background: #fff;
+  }
+}

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/press_release/pager--press-releases--pr-archive-block.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/press_release/pager--press-releases--pr-archive-block.html.twig
@@ -31,30 +31,43 @@
  */
 #}
 {% if items %}
-  <div>
-      {# Print previous item if we are not on the first page. #}
-      {% if items.previous %}
-        <a href="{{ items.previous.href }}" rel="prev"{{ items.previous.attributes|without('href', 'title', 'rel') }}>&lt;&nbsp;{{- 'Previous'|t -}}</a>
-        &nbsp;
-      {% endif %}
+    <nav aria-labelledby="pagination-heading" class="pager" role="navigation">
+        <h4 class="visually-hidden" id="pagination-heading">Pagination</h4>
+        <ul
+            class="pager__items">
+            {# Print previous item if we are not on the first page. #}
+            {% if items.previous %}
+                <li class=" pager__item pager__item--previous">
+                    <a href="{{ items.previous.href }}" rel="prev" {{ items.previous.attributes|without('href', 'title', 'rel') }} title="Go to previous page">
+                        <span class="visually-hidden">Previous page</span>
+                        <span aria-hidden="true">&lt;&nbsp;{{- 'Previous'|t -}}</span>
+                    </a>
+                </li>
+            {% endif %}
+            {# Now generate the actual pager piece. #}
+            {% for key, item in items.pages %}
+                {% set itemClass = (current == key)? 'pager__item is-active' : 'pager__item' %}
+                <li class="{{- itemClass -}}">
+                    {% if current == key %}
+                      <span class="visually-hidden">Current Page</span>
+                    {% else %}
+                      <span class="visually-hidden">Page</span>
+                    {% endif %}
+                    <a href="{{ item.href }}" {{ item.attributes|without('href', 'title') }}>
+                      {{- key -}}
+                    </a>
+                </li>
+            {% endfor %}
 
-      {# Now generate the actual pager piece. #}
-      {% for key, item in items.pages %}
-
-        {% if current == key %}
-          <span class="pager-SelectedPage">{{- key -}}</span>
-        {% else %}
-          <a class="pager-SelectedPage" href="{{ item.href }}" {{ item.attributes|without('href', 'title') }}>
-            {{- key -}}
-          </a>
-        {% endif %}
-
-      {% endfor %}
-
-      {# Print next item if we are not on the last page. #}
-      {% if items.next %}
-        &nbsp;
-        <a href="{{ items.next.href }}" rel="next"{{ items.next.attributes|without('href', 'title', 'rel') }}>{{- 'Next'|t -}}&nbsp;&gt;</a>
-      {% endif %}
-  </div>
+            {# Print next item if we are not on the last page. #}
+            {% if items.next %}
+                <li class="pager__item  pager__item--next">
+                    <a href="{{ items.next.href }}" rel="next" {{ items.next.attributes|without('href', 'title', 'rel') }} title="Go to next page">
+                        <span class="visually-hidden">Next page</span>
+                        <span aria-hidden="true">{{- 'Next'|t -}}&nbsp;&gt;</span>
+                    </a>
+                </li>
+            {% endif %}
+        </ul>
+    </nav>
 {% endif %}

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/src/styles/_pagination.scss
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/src/styles/_pagination.scss
@@ -1,38 +1,48 @@
 /********** BEGIN Pagination Styles ******************************************/
 /* Desktop pagination styles */
 .pager {
-  float: right;
   font-size: 16px;
-  a, span {
-    padding: 3px 6px 3px 6px;
-    border-radius: 3px;
-    font-weight: normal;
-    text-decoration: none;
-  }
-  .pager-link:link, .pager-link:active {
-    text-decoration: none;
-  }
-  .pager-current, .pager-link:hover {
-    color: white;
-    font-weight: normal;
-    background-color: #2A71A5;
-    text-decoration: none;
-  }
-}
-/* Mobile pagination styles */
-@media only screen and (max-width: 765px) {
-  .pager {
-    line-height: 32px;
-    width: 100%;
+  float: none;
 
-    a, span {
-      padding: 0px 12px 0px 12px;
+  h4 {
+    margin: 0;
+  }
+  
+  &__item {
+    display: inline-block;
+    margin: 10px;
+
+    a {
+      text-align: center;
+      color: $color-link;
+      padding: 3px 6px;
+      border-radius: 3px;
+      font-weight: normal;
+      text-decoration: none;
     }
-    .pager-current, .pager-link:hover {
-      padding-top: 5px;
-      padding-bottom: 5px;
+
+    &--first,
+    &--last,
+    &--ellipsis {
+      display: none;
+    }
+
+    &.is-active a {
+      color: $default-text;
+      text-decoration: none;
+      pointer-events: none;
+    }
+
+    &--previous a,
+    &--next a {
+      display: block;
+      margin: 0 auto;
+      width: 100%;
+    }
+
+    &:first-child a {
+      padding-left: 0;
     }
   }
-
 }
 /********** BEGIN Pagination Styles ******************************************/


### PR DESCRIPTION
Closes #2179 .
Closes #2224 .
Closes #2240 .
Closes #2229 .
Closes #2262 .

2179: BlogPosts.scss had some pretty specific styling for medium sized embedded images and was only applying margins as if there were only right-aligned images.  Added margins matching those found in articles.

2224: Applied missing styling to pager that was coming from core.  Also refactored the news pager to match the one coming from core

2229: Added conditional instantiation for floating delighters.  **NOTE: This does require that the cgov global config file needs to be updated with a new key**

**DCEG-specific**
2240: Needed to update css for feature cards to get desired link coloring
2262: Backgrounds of input fields changed to white instead of gray(which make the fields look disabled)
