### PR TITLE
(#2249) Prevent PDQ content from being stuck as drafts

### DIFF
--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/src/Plugin/rest/resource/PDQResource.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/src/Plugin/rest/resource/PDQResource.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\pdq_cancer_information_summary\Plugin\rest\resource;
 
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\node\Entity\Node;
 use Drupal\rest\Plugin\ResourceBase;
 use Drupal\rest\ResourceResponse;
@@ -36,6 +37,13 @@ class PDQResource extends ResourceBase {
   protected $currentUser;
 
   /**
+   * Access to entity storage.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
    * Constructs a new PdqResource object.
    *
    * @param array $configuration
@@ -50,6 +58,8 @@ class PDQResource extends ResourceBase {
    *   A logger instance.
    * @param \Drupal\Core\Session\AccountProxyInterface $current_user
    *   A current user instance.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   Used to find and load node revisions.
    */
   public function __construct(
     array $configuration,
@@ -57,10 +67,12 @@ class PDQResource extends ResourceBase {
     $plugin_definition,
     array $serializer_formats,
     LoggerInterface $logger,
-    AccountProxyInterface $current_user) {
+    AccountProxyInterface $current_user,
+    EntityTypeManagerInterface $entity_type_manager) {
     parent::__construct($configuration, $plugin_id, $plugin_definition, $serializer_formats, $logger);
 
     $this->currentUser = $current_user;
+    $this->entityTypeManager = $entity_type_manager;
   }
 
   /**
@@ -73,7 +85,8 @@ class PDQResource extends ResourceBase {
       $plugin_definition,
       $container->getParameter('serializer.formats'),
       $container->get('logger.factory')->get('pdq'),
-      $container->get('current_user')
+      $container->get('current_user'),
+      $container->get('entity_type.manager')
     );
   }
 
@@ -101,13 +114,13 @@ class PDQResource extends ResourceBase {
 
     // Make sure the client gave us something to look for.
     if (!$id) {
-      throw new BadRequestHttpException(t('No ID was provided'));
+      throw new BadRequestHttpException($this->t('No ID was provided'));
     }
 
     // We got a node ID, so return the corresponding node's values.
     $node = Node::load($id);
     if (empty($node)) {
-      $msg = t('Node @id not found', ['@id' => $id]);
+      $msg = $this->t('Node @id not found', ['@id' => $id]);
       throw new NotFoundHttpException($msg);
     }
     $fields = [
@@ -174,8 +187,10 @@ class PDQResource extends ResourceBase {
    * @return \Drupal\rest\ModifiedResourceResponse
    *   The response containing node ID(s) or a Drupal node
    *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   * @throws \Drupal\Core\Entity\EntityStorageException
    * @throws \Symfony\Component\HttpKernel\Exception\HttpException
-   *   Throws exception expected.
    */
   public function post(array $summary) {
 
@@ -201,7 +216,10 @@ class PDQResource extends ResourceBase {
     // The node already exists: fetch it and point to the entity
     // for the language being stored.
     else {
-      $node = Node::load($nid);
+      /** @var \Drupal\Core\Entity\ContentEntityStorageBase $storage */
+      $storage = $this->entityTypeManager->getStorage('node');
+      $vid = $storage->getLatestRevisionId($nid);
+      $node = $storage->loadRevision($vid);
       if ($node->hasTranslation($language)) {
         $node = $node->getTranslation($language);
       }

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_drug_information_summary/tests/src/Functional/ApiTest.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_drug_information_summary/tests/src/Functional/ApiTest.php
@@ -151,6 +151,14 @@ class ApiTest extends BrowserTestBase {
     // Make sure the pathauto mechanism is behaving correctly.
     $this->checkPathauto($this->drug);
 
+    // Make sure changes are published correctly. Fails without patch for #2249.
+    $this->drug['title'] = 'Jewel Weed';
+    $this->store($this->drug, 200);
+    $this->publish();
+    $h1 = "<h1>{$this->drug['title']}</h1>";
+    $page = $this->drupalGet("node/$nid");
+    $this->assertTrue(strpos($page, $h1) !== FALSE, 'Published changes OK');
+
     // Delete the drug summary.
     $this->delete($this->drug);
   }
@@ -168,6 +176,8 @@ class ApiTest extends BrowserTestBase {
    *
    * @return \Psr\Http\Message\ResponseInterface
    *   Object representing response from server.
+   *
+   * @throws \GuzzleHttp\Exception\GuzzleException
    */
   private function request(string $method, string $url, array $options = []) {
     $options['auth'] = $this->auth;
@@ -189,6 +199,8 @@ class ApiTest extends BrowserTestBase {
    * @return array
    *   Array with node ID (indexed by 'nid') if successful; error message
    *   (indexed by 'message') otherwise.
+   *
+   * @throws \GuzzleHttp\Exception\GuzzleException
    */
   private function store(array $values, $expected) {
     $response = $this->request('POST', $this->disUrl, ['json' => $values]);
@@ -204,6 +216,8 @@ class ApiTest extends BrowserTestBase {
    *
    * @return array
    *   Pairs of node ID and language code (must be only one pair).
+   *
+   * @throws \GuzzleHttp\Exception\GuzzleException
    */
   private function findNodes($cdr_id) {
     $response = $this->request('GET', "$this->pdqUrl/$cdr_id");
@@ -226,6 +240,8 @@ class ApiTest extends BrowserTestBase {
    *
    * @return array
    *   Values for the requested node (all languages).
+   *
+   * @throws \GuzzleHttp\Exception\GuzzleException
    */
   private function fetchNode($nid) {
     $response = $this->request('GET', "$this->disUrl/$nid");


### PR DESCRIPTION
Copy only the ticket/2249-stuck-pdq-drafts fixes from #2278.
(Replaces #2278)

Replace the use of the flawed entity query API with a direct call to get the latest revision
Explicitly set the revision_translation_effective flag when publishing
Add missing @throws statements
Replace t(...) with $this->t(...)
Closes #2249