### PR TITLE
(#2291) Correct entity ID for Test Tier IDP

### DIFF
--- a/simplesamlphp/config/authsources.php
+++ b/simplesamlphp/config/authsources.php
@@ -10,10 +10,11 @@ switch ( $_ENV['AH_SITE_ENVIRONMENT'] ) {
 
   case '01test':
   case '01testup':
-    // This may not be correct.
-    $idp = 'https://authtest.nih.gov/SAML2/IDP';
+    $idp = 'https://authtest.nih.gov/IDP';
     break;
 
+  case '01dev':
+  case '01dev':
   default:
     $idp = 'https://authdev.nih.gov/SAML2/IDP';
 }


### PR DESCRIPTION
- Correct the IDP entity ID for the ACSF test tier.
- Make the selection of IDP for ACSF dev tier explicit.