### PR TITLE
(#2320) Need to allow access denied routes

### DIFF
--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/EventSubscriber/CmsProtectionSubscriber.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/EventSubscriber/CmsProtectionSubscriber.php
@@ -148,6 +148,8 @@ class CmsProtectionSubscriber implements EventSubscriberInterface {
       'user.login',
       'user.login.http',
       'simplesamlphp_auth.saml_login',
+      'system.403',
+      'system.401',
     ];
     return in_array($route_name, $login_routes);
   }


### PR DESCRIPTION
- Throwing a 403 exception on the saml_login page was not good
   enough to be considered the login route. Hopefully this will stop
   saml_login from redirecting to saml_login when SSO user is not
   in Drupal.

Try number 2