### PR TITLE
PDQ Restful API patches

### DIFF
--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/src/Plugin/rest/resource/PDQResource.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/src/Plugin/rest/resource/PDQResource.php
@@ -195,7 +195,7 @@ class PDQResource extends ResourceBase {
   public function post(array $summary) {
 
     // Extract the bits we'll use frequently.
-    $nid = $summary['nid'];
+    $nid = $summary['nid'] ?? '';
     $language = $summary['language'];
     $cdr_id = $summary['cdr_id'];
 

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_drug_information_summary/src/Plugin/rest/resource/PDQResource.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_drug_information_summary/src/Plugin/rest/resource/PDQResource.php
@@ -170,7 +170,7 @@ class PDQResource extends ResourceBase {
   public function post(array $drug) {
 
     // Extract the bits we'll use more than once.
-    $nid = $drug['nid'];
+    $nid = $drug['nid'] ?? '';
 
     // If the node doesn't already exist, create it.
     if (empty($nid)) {


### PR DESCRIPTION
* Assign `$nid` defensively in case the 'nid' index is not present in `$summary`
* Allow simultaneous deletion of multiple temporary publish preview nodes
* Closes #2318 
* Closes #2319 
