### PR TITLE
(#2417) Create App Module Plugin System

### DIFF
--- a/docroot/modules/custom/app_module/app_module.services.yml
+++ b/docroot/modules/custom/app_module/app_module.services.yml
@@ -1,0 +1,4 @@
+services:
+  plugin.manager.app_module:
+    class: Drupal\app_module\Plugin\AppModulePluginManager
+    arguments: ['@container.namespaces', '@cache.discovery', '@module_handler']

--- a/docroot/modules/custom/app_module/config/schema/app_module.schema.yml
+++ b/docroot/modules/custom/app_module/config/schema/app_module.schema.yml
@@ -8,6 +8,9 @@ app_module.app.*:
     label:
       type: label
       label: 'Label'
+    app_module_plugin_id:
+      type: string
+      label: 'App module plugin id'
 
 field.storage_settings.app_module_reference:
   type: mapping

--- a/docroot/modules/custom/app_module/src/Annotation/AppModulePlugin.php
+++ b/docroot/modules/custom/app_module/src/Annotation/AppModulePlugin.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Drupal\app_module\Annotation;
+
+use Drupal\Component\Annotation\AnnotationInterface;
+use Drupal\Component\Annotation\Plugin;
+
+/**
+ * Defines a Plugin annotation object for AppModule plugins.
+ *
+ * @see \Drupal\app_module\Plugin\app_module\AppModulePluginBase
+ *
+ * @Annotation
+ */
+class AppModulePlugin extends Plugin implements AnnotationInterface {
+
+  /**
+   * The plugin ID.
+   *
+   * @var string
+   */
+  public $id;
+
+  /**
+   * The plugin label used in the AppModule entity forms.
+   *
+   * @var \Drupal\Core\Annotation\Translation
+   *
+   * @ingroup plugin_translatable
+   */
+  public $label = '';
+
+}

--- a/docroot/modules/custom/app_module/src/AppModuleInterface.php
+++ b/docroot/modules/custom/app_module/src/AppModuleInterface.php
@@ -3,10 +3,19 @@
 namespace Drupal\app_module;
 
 use Drupal\Core\Config\Entity\ConfigEntityInterface;
+use Drupal\Core\Entity\EntityWithPluginCollectionInterface;
 
 /**
  * Provides an interface defining an App Module entity.
  */
-interface AppModuleInterface extends ConfigEntityInterface {
-  // Add get/set methods for your configuration properties here.
+interface AppModuleInterface extends ConfigEntityInterface, EntityWithPluginCollectionInterface {
+
+  /**
+   * Gets the application module plugin.
+   *
+   * @return \Drupal\app_module\Plugin\AppModulePluginInterface|null
+   *   The AppModule plugin or NULL if the plugin id was not set yet.
+   */
+  public function getAppModulePlugin();
+
 }

--- a/docroot/modules/custom/app_module/src/Entity/AppModule.php
+++ b/docroot/modules/custom/app_module/src/Entity/AppModule.php
@@ -3,6 +3,7 @@
 namespace Drupal\app_module\Entity;
 
 use Drupal\Core\Config\Entity\ConfigEntityBase;
+use Drupal\Core\Plugin\DefaultSingleLazyPluginCollection;
 use Drupal\app_module\AppModuleInterface;
 
 /**
@@ -28,6 +29,7 @@ use Drupal\app_module\AppModuleInterface;
  *   config_export = {
  *     "id",
  *     "label",
+ *     "app_module_plugin_id",
  *   },
  *   links = {
  *     "edit-form" = "/admin/config/system/app_module/{app_module}",
@@ -42,13 +44,90 @@ class AppModule extends ConfigEntityBase implements AppModuleInterface {
    *
    * @var string
    */
-  public $id;
+  protected $id;
 
   /**
    * The App Module label.
    *
    * @var string
    */
-  public $label;
+  protected $label;
+
+  /**
+   * The ID of the App Module plugin.
+   *
+   * @var string
+   */
+  protected $app_module_plugin_id;
+
+  /**
+   * The app module plugin manager.
+   *
+   * @var \Drupal\Component\Plugin\PluginManagerInterface
+   */
+  protected $pluginManager;
+
+  /**
+   * The application module plugin collection.
+   *
+   * @var \Drupal\Core\Plugin\DefaultSingleLazyPluginCollection
+   */
+  protected $appModulePluginCollection;
+
+  /**
+   * Gets the app module plugin identifier.
+   *
+   * @var string
+   */
+  public function appModulePluginId() {
+    return $this->app_module_plugin_id;
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * NOTE: This makes assumptions that the *will* be a plugin id if it is
+   * called. This is a fair assumption given the fact that an AppModule
+   * entity cannot be saved if the app module is bogus. So anything that
+   * would interact with this method would be interacting with a valid
+   * AppModule entity.
+   */
+  public function getAppModulePlugin() {
+    return $this->appModulePluginCollection()->get($this->app_module_plugin_id);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getPluginCollections() {
+    return [
+      'app_module' => $this->appModulePluginCollection(),
+    ];
+  }
+
+  /**
+   * Gets the application module lazy plugin collection.
+   *
+   * This comes from EntityWithPluginCollectionInterface, which
+   * is necessary because ConfigEntityBase looks for that interface
+   * in order to call this method when calculatingdependencies as well
+   * as the presave method to ensure your plugin actually exists. It
+   * is also the Drupal best practice for managing plugins in a
+   * config. DefaultSingleLazyPluginCollection is the implementation
+   * for when you only will have 1 plugin.
+   *
+   * @return \Drupal\Core\Plugin\DefaultSingleLazyPluginCollection|null
+   *   The tag plugin collection or NULL if the plugin ID was not set yet.
+   */
+  protected function appModulePluginCollection() {
+    if (!$this->appModulePluginCollection && $this->app_module_plugin_id) {
+      $this->appModulePluginCollection = new DefaultSingleLazyPluginCollection(
+        \Drupal::service('plugin.manager.app_module'),
+        $this->app_module_plugin_id,
+        []
+      );
+    }
+    return $this->appModulePluginCollection;
+  }
 
 }

--- a/docroot/modules/custom/app_module/src/Plugin/AppModulePluginManager.php
+++ b/docroot/modules/custom/app_module/src/Plugin/AppModulePluginManager.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Drupal\app_module\Plugin;
+
+use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Plugin\DefaultPluginManager;
+
+/**
+ * Plugin type manager for all Application Module plugins.
+ */
+class AppModulePluginManager extends DefaultPluginManager {
+
+  /**
+   * Constructs a AppModulePluginManager object.
+   *
+   * @param \Traversable $namespaces
+   *   An object that implements \Traversable which contains the root paths
+   *   keyed by the corresponding namespace to look for plugin implementations.
+   * @param \Drupal\Core\Cache\CacheBackendInterface $cache_backend
+   *   Cache backend instance to use.
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
+   *   The module handler to invoke the alter hook with.
+   */
+  public function __construct(\Traversable $namespaces, CacheBackendInterface $cache_backend, ModuleHandlerInterface $module_handler) {
+    parent::__construct(
+      "Plugin/app_module",
+      $namespaces,
+      $module_handler,
+      'Drupal\app_module\Plugin\app_module\AppModulePluginInterface',
+      'Drupal\app_module\Annotation\AppModulePlugin'
+    );
+
+    $this->setCacheBackend($cache_backend, "app_module:plugins");
+    $this->alterInfo('app_module_plugin_info');
+  }
+
+}

--- a/docroot/modules/custom/app_module/src/Plugin/Field/FieldFormatter/AppModuleReferenceFieldFormatter.php
+++ b/docroot/modules/custom/app_module/src/Plugin/Field/FieldFormatter/AppModuleReferenceFieldFormatter.php
@@ -48,8 +48,9 @@ class AppModuleReferenceFieldFormatter extends FormatterBase {
        * 3. We then return the build objject from the display
        *    handler.
        */
+      $plugin = $app_module->getAppModulePlugin();
       $elements[$delta]['contents'] = [
-        '#markup' => "<div>App Module: $app_id</div>",
+        '#markup' => "<div>App Module: " . $plugin->pluginTitle() . " </div>",
       ];
     }
 

--- a/docroot/modules/custom/app_module/src/Plugin/Field/FieldWidget/AppModuleReferenceSelectWidget.php
+++ b/docroot/modules/custom/app_module/src/Plugin/Field/FieldWidget/AppModuleReferenceSelectWidget.php
@@ -50,7 +50,7 @@ class AppModuleReferenceSelectWidget extends OptionsSelectWidget {
     $app_modules = AppModules::getEnabledAppModules();
     $options = [];
     foreach ($app_modules as $app_module) {
-      $options[$app_module->id] = $app_module->label;
+      $options[$app_module->id()] = $app_module->label();
     }
     return $options;
   }

--- a/docroot/modules/custom/app_module/src/Plugin/app_module/AppModulePluginBase.php
+++ b/docroot/modules/custom/app_module/src/Plugin/app_module/AppModulePluginBase.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Drupal\app_module\Plugin\app_module;
+
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Plugin\PluginBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Base class for Application Module plugin types.
+ */
+abstract class AppModulePluginBase extends PluginBase implements AppModulePluginInterface, ContainerFactoryPluginInterface {
+
+  /**
+   * Plugins's definition.
+   *
+   * @var array
+   */
+  public $definition;
+
+  /**
+   * Constructs a AppModulePluginBase object.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->definition = $plugin_definition + $configuration;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static($configuration, $plugin_id, $plugin_definition);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function pluginTitle() {
+    return $this->definition['label'];
+  }
+
+}

--- a/docroot/modules/custom/app_module/src/Plugin/app_module/AppModulePluginInterface.php
+++ b/docroot/modules/custom/app_module/src/Plugin/app_module/AppModulePluginInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Drupal\app_module\Plugin\app_module;
+
+use Drupal\Component\Plugin\PluginInspectionInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Provides an interface for all Application Module plugins.
+ */
+interface AppModulePluginInterface extends PluginInspectionInterface {
+
+  /**
+   * Return the human readable name of the display.
+   *
+   * This appears on the ui in plugin selection interfaces.
+   *
+   * @return string
+   *   The human readable name.
+   */
+  public function pluginTitle();
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition);
+
+}

--- a/docroot/modules/custom/app_module/tests/modules/app_module_test/config/install/app_module.app.test_app_module.yml
+++ b/docroot/modules/custom/app_module/tests/modules/app_module_test/config/install/app_module.app.test_app_module.yml
@@ -1,2 +1,3 @@
 id: test_app_module
 label: 'App module test'
+app_module_plugin_id: 'test_app_module_plugin'

--- a/docroot/modules/custom/app_module/tests/modules/app_module_test/src/Plugin/app_module/TestAppModulePlugin.php
+++ b/docroot/modules/custom/app_module/tests/modules/app_module_test/src/Plugin/app_module/TestAppModulePlugin.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Drupal\app_module_test\Plugin\app_module;
+
+use Drupal\app_module\Plugin\app_module\AppModulePluginBase;
+
+/**
+ * Test App Module Plugin.
+ *
+ * App Module used for discovery tests.
+ *
+ * @AppModulePlugin(
+ *   id = "test_app_module_plugin",
+ *   label = @Translation("Test App Module Plugin")
+ * )
+ */
+class TestAppModulePlugin extends AppModulePluginBase {
+
+}

--- a/docroot/modules/custom/app_module/tests/src/Functional/AppModuleEntityTest.php
+++ b/docroot/modules/custom/app_module/tests/src/Functional/AppModuleEntityTest.php
@@ -104,6 +104,7 @@ class AppModuleEntityTest extends BrowserTestBase {
       [
         'label' => $app_machine_name,
         'id' => $app_machine_name,
+        'app_module_plugin_id' => 'test_app_module_plugin',
       ],
       'Save'
     );
@@ -122,6 +123,7 @@ class AppModuleEntityTest extends BrowserTestBase {
       [
         'label' => $app2_label,
         'id' => $app2_machine_name,
+        'app_module_plugin_id' => 'test_app_module_plugin',
       ],
       'Save'
     );
@@ -136,6 +138,7 @@ class AppModuleEntityTest extends BrowserTestBase {
       [
         'label' => $app2_label,
         'id' => $app2_machine_name,
+        'app_module_plugin_id' => 'test_app_module_plugin',
       ],
       'Save'
     );

--- a/docroot/modules/custom/app_module/tests/src/Functional/AppModuleFieldBrowserTestBase.php
+++ b/docroot/modules/custom/app_module/tests/src/Functional/AppModuleFieldBrowserTestBase.php
@@ -51,7 +51,13 @@ abstract class AppModuleFieldBrowserTestBase extends BrowserTestBase {
    *
    * @var array
    */
-  public static $modules = ['block', 'node', 'field_ui', 'app_module'];
+  public static $modules = [
+    'block',
+    'node',
+    'field_ui',
+    'app_module',
+    'app_module_test',
+  ];
 
   /**
    * {@inheritdoc}
@@ -86,6 +92,7 @@ abstract class AppModuleFieldBrowserTestBase extends BrowserTestBase {
       [
         'label' => $this->appModuleId,
         'id' => $this->appModuleId,
+        'app_module_plugin_id' => 'test_app_module_plugin',
       ],
       'Save'
     );

--- a/docroot/modules/custom/app_module/tests/src/Functional/AppModuleReferenceFieldFormatterTest.php
+++ b/docroot/modules/custom/app_module/tests/src/Functional/AppModuleReferenceFieldFormatterTest.php
@@ -47,7 +47,7 @@ class AppModuleReferenceFieldFormatterTest extends AppModuleFieldBrowserTestBase
     // Verity the web page is displaying the formatter. NOTE: Our formatter
     // right now just spits out the machine id of the app module.
     // TODO: Fix this when we get real formatters.
-    $assert->pageTextContains('App Module: ' . $this->appModuleId);
+    $assert->pageTextContains('App Module: Test App Module Plugin');
   }
 
 }

--- a/docroot/modules/custom/app_module/tests/src/Functional/AppModuleReferenceSelectWidgetTest.php
+++ b/docroot/modules/custom/app_module/tests/src/Functional/AppModuleReferenceSelectWidgetTest.php
@@ -49,8 +49,8 @@ class AppModuleReferenceSelectWidgetTest extends AppModuleFieldBrowserTestBase {
     $this->drupalPostForm(NULL, $edit, 'Save');
     $assert->pageTextContains((string) new FormattableMarkup('@type @title has been created', ['@type' => $this->contentTypeName, '@title' => $title]));
 
-    // Verity the web page is displaying the formatter.
-    $assert->pageTextContains('App Module: ' . $this->appModuleId);
+    // Verify the web page is displaying the formatter.
+    $assert->pageTextContains('App Module: Test App Module Plugin');
   }
 
 }


### PR DESCRIPTION
- This implements the necessary classes to create app
   module plugin implementations. It does not contain
   any code to make them do anything other than to
   display a label. (e.g. no rendering, no fetching data)
- Includes the changes to tests to test the items.

Closes #2417 