### PR TITLE
(#2315, #2206) - Add CT cache tags, Update Site Section tag logic

### DIFF
--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.module
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.module
@@ -601,4 +601,19 @@ function cgov_core_preprocess_image_formatter(&$variables) {
   ) {
     $variables['image']['#alt'] = "";
   }
+
+}
+
+/**
+ * Implements hook_entity_build_defaults_alter().
+ */
+function cgov_core_entity_build_defaults_alter(array &$build, EntityInterface $entity, $view_mode) {
+  // Add the bundle as a cache tag to help simplify cache invalidation.
+  if ($entity->getEntityTypeId() === 'node' || $entity->getEntityTypeId() === 'media') {
+    $tags = $view_mode == 'full' ? [$entity->bundle() . ':full'] : [];
+    $tags[] = $entity->bundle() . ':all-view-modes';
+    $build['#cache'] = [
+      'tags' => Cache::mergeTags($entity->getCacheTags(), $tags),
+    ];
+  }
 }

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/NavItem.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/NavItem.php
@@ -247,6 +247,16 @@ class NavItem {
   }
 
   /**
+   * Return the term.
+   *
+   * @return enttity
+   *   Site Section Term.
+   */
+  public function getTerm() {
+    return $this->term;
+  }
+
+  /**
    * Determine whether NavItem has filter rule.
    *
    * @param string $rule

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_site_section/cgov_site_section.module
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_site_section/cgov_site_section.module
@@ -10,6 +10,7 @@ use Drupal\cgov_site_section\FieldStorageDefinition;
 use Drupal\Core\Field\FieldDefinition;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\taxonomy\Entity\Term;
+use Drupal\Core\Cache\Cache;
 
 /**
  * Implements hook_entity_field_storage_info().
@@ -95,6 +96,60 @@ function cgov_site_section_taxonomy_term_presave(EntityInterface $entity) {
 
 /**
  * Implements hook_ENTITY_TYPE_update().
+ */
+function cgov_site_section_entity_update(EntityInterface $entity) {
+
+  $entityType = $entity->getEntityType()->id();
+
+  // If this is a Site Sectiion, invalidate if it meets the criteria for
+  // cache tag invalidation.
+  if ($entityType === 'taxonomy_term' && $entity->hasField('field_site_section')) {
+    if (_will_trigger_cache_tag_invalidation($entity)) {
+      invalidate_section_cache_tag($entity);
+    }
+  }
+
+  /*
+   * If this is a node or media item and has changed its section parent or
+   * pretty url name, if it displays in navigation, cascade those changes
+   *  to any subsections and pages within those subsections.
+   *
+   */
+
+  if (
+    $entity->getEntityTypeId() === 'node' &&
+    $entity->hasField('field_site_section')
+  ) {
+    // Check for moderation state AFTER determining its a node instead
+    // of before due to https://www.drupal.org/project/wbm2cm/issues/3042445.
+    $current_entity_lang = $entity->get('langcode')->value;
+    $translated_entity = $entity->getTranslation($current_entity_lang);
+    $current_state = $translated_entity->get('moderation_state')->value;
+    if ($current_state === 'published' && _will_trigger_cache_tag_invalidation($entity)) {
+      // Get the Sections where it's a landing page. Note: This could be none.
+      $section_entities = \Drupal::entityTypeManager()
+        ->getStorage('taxonomy_term')
+        ->loadByProperties([
+          'field_landing_page.target_id' => $entity->id(),
+        ]);
+
+      if (count($section_entities) > 0) {
+        // This item is set as the landing page for at least one Site Section.
+        // Invalidate the Nav Root cache tag set on the Site Section(s).
+        foreach ($section_entities as $section) {
+          $navRoot = get_root_nav_section($section);
+          if ($navRoot) {
+            invalidate_section_cache_tag($navRoot);
+          }
+        }
+      }
+    }
+
+  }
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_update().
  *
  * If a term has either changed its parent or pretty url name,
  * then we need to cascade those changes to any subsections and
@@ -119,35 +174,193 @@ function cgov_site_section_taxonomy_term_update(EntityInterface $entity) {
     _cgov_site_section_attempt_set_front_page($entity);
   }
 
-  // TODO: This comparison should be done somewhere else and less messy.
-  // Do not do unnessesary updates, so only cascade if a change was
-  // made to a significant field.
-  if (
-    $entity->original->get('computed_path')->value ===
-    $entity->get('computed_path')->value &&
-    $entity->original->get('parent')->target_id ===
-    $entity->get('parent')->target_id &&
-    $entity->original->get('field_pretty_url')->value ===
-    $entity->get('field_pretty_url')->value &&
-    $entity->original->get('langcode')->value ===
-    $entity->get('langcode')->value
-  ) {
-    return;
+  // Save the term children if this term update meets the criteria.
+  if (will_trigger_save_children($entity)) {
+    save_term_children($entity);
   }
-  $term_storage = \Drupal::service('entity_type.manager')->getStorage("taxonomy_term");
-
-  // Update immediate child sections.
-  $subsections = $term_storage->loadChildren($entity->id(), 'cgov_site_sections');
-
-  // Resave the sections. This should trigger the presave above with will set
-  // the computed_path to the new path.
-  foreach ($subsections as $section) {
-    $section->save();
+  // Determine if this term update meets the criteria for tag invalidation.
+  if (_will_trigger_cache_tag_invalidation($entity)) {
+    invalidate_section_cache_tag($entity);
   }
 
   // TODO: Figure out how to get pathauto to update all the aliases using
   // pathauto. To do it here is A) too slow, and B) fraught with
   // issue regarding workflow and the various entity types we would have to hit.
+}
+
+/**
+ * Invalidate the cache tag equal to the given Site Sections ID.
+ *
+ * @param \Drupal\Core\Entity\EntityInterface $site_section_entity
+ *   The Site Section to invalidate.
+ */
+function invalidate_section_cache_tag(EntityInterface $site_section_entity) {
+  $section_id = $site_section_entity->id();
+  // Get the sections ID and invalidate the cache tag.
+  if ($section_id) {
+    Cache::invalidateTags(['site_section:' . $section_id]);
+  }
+}
+
+/**
+ * Saves the children of the given Site Section taxonomy term.
+ *
+ * @param \Drupal\Core\Entity\EntityInterface $updated_section_entity
+ *   The site section entity with its pending value updates.
+ */
+function save_term_children(EntityInterface $updated_section_entity) {
+  $term_storage = \Drupal::service('entity_type.manager')
+    ->getStorage("taxonomy_term");
+  // Update immediate child sections.
+  $subsections = $term_storage->loadChildren($updated_section_entity->id(), 'cgov_site_sections');
+
+  // Re-save the sections. This should trigger the presave above with will set
+  // the computed_path to the new path.
+  foreach ($subsections as $section) {
+    $section->save();
+  }
+}
+
+/**
+ * Determines if a section should trigger a re-save of its children terms.
+ *
+ * @param \Drupal\Core\Entity\EntityInterface $updated_section_entity
+ *   The site section entity with its pending value updates.
+ *
+ * @return bool
+ *   A TRUE or FALSE as to whether to trigger a re-save.
+ */
+function will_trigger_save_children(EntityInterface $updated_section_entity) {
+
+  $fields = [
+    'computed_path',
+    'parent',
+    'field_pretty_url',
+    'langcode',
+  ];
+  return entity_fields_modified($fields, $updated_section_entity);
+}
+
+/**
+ * Determine if an entity should trigger a cache tag invalidation.
+ *
+ * Fields which trigger a cache tag invalidation for a section when modified:
+ *  name
+ *  field_landing_page
+ *  field_pretty_url
+ *  field_section_nav_root
+ *  field_navigation_label
+ *  field_navigation_display_options
+ *  weight.
+ *
+ * For a node or media item:
+ * field_site_section
+ * field_pretty_url
+ *
+ * @param \Drupal\Core\Entity\EntityInterface $updated_entity
+ *   The entity just updated.
+ *
+ * @return bool
+ *   A TRUE or FALSE as to whether to trigger a cache clear.
+ */
+function _will_trigger_cache_tag_invalidation(EntityInterface $updated_entity) {
+
+  $entityType = $updated_entity->getEntityTypeId();
+
+  // Exit early for Media items.
+  if ($entityType === 'media') {
+    return FALSE;
+  }
+
+  $values = [];
+  // Invalidation check for Nodes.
+  if ($entityType === 'node') {
+    // Exit early if this entity doesn't have site sections.
+    if (!$updated_entity->hasField('field_site_section')) {
+      return FALSE;
+    }
+    // Set entity Fields which trigger invalidation when modified.
+    $values =
+      [
+        'field_site_section',
+        'field_pretty_url',
+      ];
+  }
+
+  // Invalidation Check for Site Sections.
+  if ($entityType === 'taxonomy_term' &&
+    $updated_entity->bundle() == 'cgov_site_sections') {
+
+    // Early exit. Yes,trigger a cache invalidation if weight modified.
+    $weightModified = $updated_entity->original->getWeight() !== $updated_entity->getWeight();
+    if ($weightModified) {
+      return TRUE;
+    }
+
+    // Set Site Section Fields which trigger invalidation.
+    $values =
+      [
+        'name',
+        'field_landing_page',
+        'field_pretty_url',
+        'field_section_nav_root',
+        'field_navigation_label',
+        'field_navigation_display_options',
+      ];
+  }
+  // Compare the values and check if any have been modified.
+  return entity_fields_modified($values, $updated_entity);
+}
+
+/**
+ * Checks to see if an entities values have changed compared to it's original.
+ *
+ * @param array $fields
+ *   The fields which trigger a cache invalidation.
+ * @param \Drupal\Core\Entity\EntityInterface $entity
+ *   The updated entity.
+ *
+ * @return bool
+ *   A TRUE or FALSE as to whether the fields were modified.
+ */
+function entity_fields_modified(array $fields, EntityInterface $entity) {
+  // Exit early if no fields were passed.
+  if (empty($fields)) {
+    return FALSE;
+  }
+  // Store the original entity for comparison.
+  $original = $entity->original;
+
+  // Setup closures for comparison functions.
+  $get_er_value = function ($field_name) use ($entity, $original) {
+    // Type-casting since target ID sometimes returns as a string,
+    // and PHP conversion isn't reliable here.
+    return (int) $original->get($field_name)->target_id !== (int) $entity->get($field_name)->target_id;
+  };
+  $get_value = function ($field_name) use ($entity, $original) {
+    return $original->get($field_name)->value !== $entity->get($field_name)->value;
+  };
+
+  // Loop though the given fields to check for modification.
+  foreach ($fields as $field_name) {
+    $field_type = $entity->get($field_name)->getFieldDefinition()->getType();
+
+    // Select the function depending on the field type.
+    switch ($field_type) {
+      case 'entity_reference':
+        $wasModified = $get_er_value;
+        break;
+
+      default:
+        $wasModified = $get_value;
+    }
+
+    // If a field has been modified exit and return true.
+    if ($wasModified($field_name)) {
+      return TRUE;
+    }
+  }
+  return FALSE;
 }
 
 /**
@@ -180,17 +393,15 @@ function _cgov_site_section_attempt_set_front_page(EntityInterface $site_section
   if ($front_page !== $config->get('page.front')) {
     $config->set('page.front', $front_page)->save();
   }
-
 }
 
 /**
  * Implements hook_entity_presave().
- *
- * Prior to saving a node, formats the field..
  */
 function cgov_site_section_entity_presave($entity) {
+  // Prior to saving a node, formats the field.
   $entityType = $entity->getEntityType()->id();
-  if ($entityType == 'node'|| $entityType == 'media') {
+  if ($entityType === 'node' || $entityType === 'media') {
 
     if ($entity->hasField('field_pretty_url') && !empty($entity->get('field_pretty_url'))) {
       $field_pretty_url = $entity->get('field_pretty_url')->value;
@@ -280,4 +491,54 @@ function cgov_site_section_views_data() {
   ];
 
   return $data;
+}
+
+/**
+ * Returns the Root Nav Section.
+ *
+ * @param mixed $term
+ *   The section term or NULL.
+ *
+ * @return bool|mixed
+ *   The root term or False.
+ *
+ * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+ * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+ */
+function get_root_nav_section($term) {
+  // Base Case.
+  if (!$term) {
+    return FALSE;
+  }
+
+  // Get the parent, return it if it's the root.
+  $parent = get_section_parent($term);
+  $isRoot = (int) $parent->field_section_nav_root->value;
+  if ($isRoot) {
+    return $parent;
+  }
+  // If its not the root, recursively call this function.
+  return get_root_nav_section($parent);
+}
+
+/**
+ * Returns a Site Section Terms Parent.
+ *
+ * @param \Drupal\taxonomy\Entity\Term $term
+ *   The Site Section.
+ *
+ * @return mixed
+ *   The Site Sections Parent or FALSE.
+ *
+ * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+ * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+ */
+function get_section_parent(Term $term) {
+  $termStorage = \Drupal::entityTypeManager()->getStorage('taxonomy_term');
+
+  if ($term) {
+    $parents = $termStorage->loadParents($term->id());
+    return $parents[array_keys($parents)[0]];
+  }
+  return FALSE;
 }

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/block/section_nav/block--cgov-section-nav.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/block/section_nav/block--cgov-section-nav.html.twig
@@ -1,3 +1,5 @@
+{% set nav_tree = content['#nav_tree']%}
+{% set catch_cache = content|render %}
 {% macro nav_level(links) %}
   {% import _self as macros %}
   {% for link in links %}
@@ -22,18 +24,18 @@
 {% endmacro %}
 
 {% import _self as macros %}
-{% if content.nav_tree.label %}
+{% if nav_tree.label %}
   <div id="nvcgSlSectionNav" class="medium-3 columns local-navigation">
     <div class="slot-item only-SI">
       <div class="section-nav">
         <ul>
-          <li class="{{ content.nav_tree.class }}">
-            <div class="{{ content.nav_tree.isCurrentSectionLandingPage ? 'current-page' : '' }}">
-              <a href="{{ content.nav_tree.href }}">{{ content.nav_tree.label }}</a>
+          <li class="{{ nav_tree.class }}">
+            <div class="{{ nav_tree.isCurrentSectionLandingPage ? 'current-page' : '' }}">
+              <a href="{{ nav_tree.href }}">{{ nav_tree.label }}</a>
             </div>
-            {% if content.nav_tree.children|length > 0 %}
+            {% if nav_tree.children|length > 0 %}
               <ul>
-                {{ macros.nav_level(content.nav_tree.children) }}
+                {{ macros.nav_level(nav_tree.children) }}
               </ul>
             {% endif %}
           </li>


### PR DESCRIPTION
ODE: ncigovcdode268.prod.acquia-sites.com

Closes #2206 
Closes #2315 

Note: Acceptance Criteria are on the individual tickets.

- Adds the node bundle ID to the nodes cache tags. e.g:
   - cgov_article:full 
   - cgov_article:all-view-modes 
   - cgov_blog:all-view-modes 

- Adds the Section NavRoot ID to the Section Nav blocks cache tags. e.g:
    -  site_section:11844

- Adds logic to invalidate a given Section Nav root ID -- under the right circumstances.
    -  When relevant Site Section Fields are updated
    -  When Site Section or Pretty URL changes on a node 

- Cleans up / extracts the term re-save logic into a function.

