### PR TITLE
(#2456) Fix schema.org markup on non-FAQ pages

### DIFF
--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/cgov_article.module
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/cgov_article.module
@@ -31,3 +31,29 @@ function cgov_article_update_8003() {
     $installer->install(['cgov_schema_org']);
   }
 }
+
+/**
+ * Preprocess function for field templates.
+ */
+function cgov_article_preprocess_field(&$variables) {
+  if ($variables['element']['#field_name'] == 'field_article_body') {
+    // Get the schema.org type for use in field templates.
+    $node = \Drupal::routeMatch()->getParameter('node');
+    $schema_org_type = $node->field_schema_org_data->page_itemtype;
+    if ($schema_org_type == 'faq_page') {
+      $variables['schema_org_type'] = $schema_org_type;
+    }
+  }
+}
+
+/**
+ * Preprocess function for paragraph templates.
+ */
+function cgov_article_preprocess_paragraph__body_section(&$variables) {
+  // Get the schema.org type for use in paragraph templates.
+  $parent = $variables['paragraph']->getParentEntity();
+  $schema_org_type = $parent->field_schema_org_data->page_itemtype;
+  if ($schema_org_type == 'faq_page') {
+    $variables['schema_org_type'] = $schema_org_type;
+  }
+}

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/cgov_common.theme
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/cgov_common.theme
@@ -127,23 +127,6 @@ function cgov_common_preprocess_field(&$variables) {
     $nid = $variables['element']['#object']->id();
     $variables['node_id'] = $nid;
   }
-
-  if ($variables['element']['#field_name'] == 'field_article_body') {
-    // Get the schema.org type for use in field templates.
-    $node = \Drupal::routeMatch()->getParameter('node');
-    $schema_org_type = $node->field_schema_org_data->page_itemtype;
-    $variables['schema_org_type'] = $schema_org_type;
-  }
-}
-
-/**
- * Preprocess function for paragraph templates.
- */
-function cgov_common_preprocess_paragraph__body_section(&$variables) {
-  // Get the schema.org type for use in paragraph templates.
-  $parent = $variables['paragraph']->getParentEntity();
-  $schema_org_type = $parent->field_schema_org_data->page_itemtype;
-  $variables['schema_org_type'] = $schema_org_type;
 }
 
 /**

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/article/field--field-article-body.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/article/field--field-article-body.html.twig
@@ -40,13 +40,17 @@ Common.js #}
       <section>
     {% endif %}
   {% else %}
-    <div itemscope itemprop="mainEntity" itemtype="https://schema.org/Question">
+    {% if schema_org_type %}
+      <div itemscope itemprop="mainEntity" itemtype="https://schema.org/Question">
+    {% endif %}
   {% endif %}
     {{ item.content }}
   {% if items | length > 1 %}
     </section>
   {% else %}
-    </div>
+    {% if schema_org_type %}
+      </div>
+    {% endif %}
   {% endif %}
 {% endfor %}
 {% if items | length > 1 %}


### PR DESCRIPTION
* Logic for correct markup on single-section article pages
* Move preprocessor functions to cgov_article
* Closes #2456