### PR TITLE
(#570) Prevent taxonomy term deletion if ever used in published revision

### DIFF
--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_biography/cgov_biography.module
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_biography/cgov_biography.module
@@ -4,3 +4,29 @@
  * @file
  * Contains cgov_biography.module.
  */
+
+use Drupal\Core\Access\AccessResult;
+use Drupal\cgov_core\CgovCoreTools;
+
+/**
+ * Implements hook_entity_type_access().
+ */
+function cgov_biography_taxonomy_term_access($entity, $operation, $account) {
+  // Prevent term deletion if used in default revision.
+  if ($entity->bundle() === 'cgov_biography_campuses') {
+    switch ($operation) {
+      case 'delete':
+        $references = CgovCoreTools::getTermRefsFromField($entity, ['field_campus']);
+        if (count($references) > 0) {
+          $reason = 'Unable to delete term. It is used in the following references: ';
+          return AccessResult::forbidden($reason);
+        }
+        break;
+
+      // Let other modules weigh in if we haven't vetoed the operation.
+      default:
+        return AccessResult::neutral();
+    }
+  }
+  return AccessResult::neutral();
+}

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_center/cgov_cancer_center.module
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_center/cgov_cancer_center.module
@@ -4,3 +4,29 @@
  * @file
  * Contains cgov_cancer_center.module.
  */
+
+use Drupal\Core\Access\AccessResult;
+use Drupal\cgov_core\CgovCoreTools;
+
+/**
+ * Implements hook_entity_type_access().
+ */
+function cgov_cancer_center_taxonomy_term_access($entity, $operation, $account) {
+  // Prevent term deletion if used in default revision.
+  if ($entity->bundle() === 'cgov_cancer_center_types' || $entity->bundle() === 'cgov_cancer_center_regions') {
+    switch ($operation) {
+      case 'delete':
+        $references = CgovCoreTools::getTermRefsFromField($entity, ['field_institution_type', 'field_region']);
+        if (count($references) > 0) {
+          $reason = 'Unable to delete term. It is used in the following references: ';
+          return AccessResult::forbidden($reason);
+        }
+        break;
+
+      // Let other modules weigh in if we haven't vetoed the operation.
+      default:
+        return AccessResult::neutral();
+    }
+  }
+  return AccessResult::neutral();
+}

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.services.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.services.yml
@@ -11,6 +11,7 @@ services:
       - '@config.factory'
       - '@language_negotiator'
       - '@entity_type.manager'
+      - '@database'
   # Defines a form service of which alters functionality and display of Cgov forms
   cgov_core.form_tools:
     class: Drupal\cgov_core\CgovFormTools

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_event/cgov_event.module
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_event/cgov_event.module
@@ -4,3 +4,29 @@
  * @file
  * Contains cgov_event.module.
  */
+
+use Drupal\Core\Access\AccessResult;
+use Drupal\cgov_core\CgovCoreTools;
+
+/**
+ * Implements hook_entity_type_access().
+ */
+function cgov_event_taxonomy_term_access($entity, $operation, $account) {
+  // Prevent term deletion if used in default revision.
+  if ($entity->bundle() === 'cgov_event_series' || $entity->bundle() === 'cgov_event_venue') {
+    switch ($operation) {
+      case 'delete':
+        $references = CgovCoreTools::getTermRefsFromField($entity, ['field_event_series']);
+        if (count($references) > 0) {
+          $reason = 'Unable to delete term. It is used in the following references: ';
+          return AccessResult::forbidden($reason);
+        }
+        break;
+
+      // Let other modules weigh in if we haven't vetoed the operation.
+      default:
+        return AccessResult::neutral();
+    }
+  }
+  return AccessResult::neutral();
+}

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_site_section/cgov_site_section.module
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_site_section/cgov_site_section.module
@@ -12,6 +12,7 @@ use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Url;
 use Drupal\taxonomy\Entity\Term;
 use Drupal\Core\Cache\Cache;
+use Drupal\Core\Access\AccessResult;
 
 /**
  * Implements hook_entity_field_storage_info().
@@ -313,17 +314,23 @@ function _will_trigger_cache_tag_invalidation(EntityInterface $updated_entity) {
   // Invalidation check for Nodes.
   if ($entityType === 'node') {
     // Exit early if this entity doesn't have site sections.
-    if (!$updated_entity->hasField('field_site_section')|| empty($updated_entity->get('field_site_section')->first())) {
+    if (!$updated_entity->hasField('field_site_section') || empty($updated_entity->get('field_site_section')
+      ->first())) {
       return FALSE;
     }
 
     // Get the language alias prefix.
-    $default_langcode = \Drupal::languageManager()->getDefaultLanguage()->getId();
-    $current_langcode = \Drupal::languageManager()->getCurrentLanguage()->getId();
+    $default_langcode = \Drupal::languageManager()
+      ->getDefaultLanguage()
+      ->getId();
+    $current_langcode = \Drupal::languageManager()
+      ->getCurrentLanguage()
+      ->getId();
     $prefix = '';
 
     if ($current_langcode != $default_langcode) {
-      $all_prefixes = \Drupal::config('language.negotiation')->get('url.prefixes');
+      $all_prefixes = \Drupal::config('language.negotiation')
+        ->get('url.prefixes');
       $prefix = '/' . $all_prefixes[$current_langcode];
     }
 
@@ -422,7 +429,8 @@ function entity_fields_modified(array $fields, EntityInterface $entity) {
     return (int) $original->get($field_name)->target_id !== (int) $entity->get($field_name)->target_id;
   };
   $get_value = function ($field_name) use ($entity, $original) {
-    return $original->get($field_name)->getValue() != $entity->get($field_name)->getValue();
+    return $original->get($field_name)->getValue() != $entity->get($field_name)
+      ->getValue();
   };
 
   // Loop though the given fields to check for modification.
@@ -716,4 +724,147 @@ function cgov_site_section_link_alter(&$variables) {
       }
     }
   }
+}
+
+/**
+ * Implements hook_entity_type_access().
+ */
+function cgov_site_section_taxonomy_term_access(EntityInterface $entity, $operation, $account) {
+  // Limit this to Site Sections.
+  if ($entity->bundle() === 'cgov_site_sections') {
+    switch ($operation) {
+
+      case 'delete':
+        $reason = 'Users not allowed to delete taxonomy items ';
+
+        // Check to see if this section and it's children are
+        // deletable based of business logic.
+        $reference_check = recursive_check($entity);
+        if (!$reference_check['is_deletable']) {
+          $reason = $reference_check['reason'];
+          return AccessResult::forbidden($reason);
+        }
+        break;
+
+      // Let other modules weigh in if we haven't vetoed the operation.
+      default:
+        return AccessResult::neutral();
+    }
+  }
+  return AccessResult::neutral();
+}
+
+/**
+ * Determine if a section is deletable. Return any content references to it.
+ *
+ * @param \Drupal\Core\Entity\EntityInterface $entity
+ *   The site section entity.
+ *
+ * @return array
+ *   The result array.
+ */
+function get_deletable_and_term_refs(EntityInterface $entity) {
+  $is_deletable = TRUE;
+  $node_references = [];
+  $media_references = [];
+  $reason = '';
+
+  // If the item is used in the default node it is not deletable.
+  $query = \Drupal::database()
+    ->select('node__field_site_section', 's');
+  $query->condition('s.field_site_section_target_id', $entity->id());
+  $query->addField('s', 'entity_id');
+  $query->addField('s', 'langcode');
+  $result = $query->execute();
+  $result_fields = $result->fetchAll();
+
+  // Keep track of the node references.
+  foreach ($result_fields as $ref) {
+    $node_references[] = [
+      'entity_id' => $ref->entity_id,
+      'langcode' => $ref->langcode,
+    ];
+  }
+
+  // If the item is used in the default media revision it is not deletable.
+  $query = \Drupal::database()
+    ->select('media__field_site_section', 's');
+  $query->condition('s.field_site_section_target_id', $entity->id());
+  $query->addField('s', 'entity_id');
+  $query->addField('s', 'langcode');
+  $result = $query->execute();
+  $result_fields = $result->fetchAll();
+
+  // Keep track of the media references.
+  foreach ($result_fields as $ref) {
+    $media_references[] = [
+      'entity_id' => $ref->entity_id,
+      'langcode' => $ref->langcode,
+    ];
+  }
+
+  $num_results = count($node_references) + count($media_references);
+  if ($num_results > 0) {
+    $is_deletable = FALSE;
+
+    $reason = 'The section ' . $entity->id() . ' cannot be deleted. It is in usage on the following:' . PHP_EOL;
+    foreach ($node_references as $ref) {
+      $reason .= 'Node: ' . $ref['entity_id'] . ' Language ' . $ref['langcode'] . PHP_EOL;
+    }
+    foreach ($media_references as $ref) {
+      $reason .= 'Media: ' . $ref['entity_id'] . ' Language ' . $ref['langcode'] . PHP_EOL;
+    }
+  }
+
+  // If the item has a landing page set, it is not deletable.
+  $landing_page = $entity->field_landing_page->target_id;
+  if ($landing_page != NULL) {
+    $reason .= 'The section can\'t be deleted, ' . $entity->id() .
+        ' has a reference to a landing page and it must first be removed.';
+    $is_deletable = FALSE;
+  }
+
+  // Return an array with the flag / references if they exist.
+  $result = [
+    'is_deletable' => $is_deletable,
+    'node_refs' => $node_references,
+    'media_refs' => $media_references,
+    'reason' => $reason,
+  ];
+
+  return $result;
+}
+
+/**
+ * Recurse over a term and its children to see if all sections are deletable.
+ *
+ * @param \Drupal\Core\Entity\EntityInterface $section
+ *   The parent term to start with.
+ *
+ * @return array
+ *   An array containing the is_deletable flag and any references.
+ */
+function recursive_check(EntityInterface $section) {
+  // Check if the first is deletable.
+  $result = get_deletable_and_term_refs($section);
+
+  // If it's not deletable exit early.
+  if (!$result['is_deletable']) {
+    return $result;
+  }
+  // Load the children.
+  $vid = 'cgov_site_sections';
+  $depth = 1;
+  $load_entities = TRUE;
+  $children = \Drupal::entityTypeManager()
+    ->getStorage('taxonomy_term')
+    ->loadTree($vid, $section->id(), $depth, $load_entities);
+
+  foreach ($children as $child) {
+    $child_result = recursive_check($child);
+    if (!$child_result['is_deletable']) {
+      break;
+    }
+  }
+  return $result;
 }

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_vocab_manager/src/Form/CgovVocabManagerForm.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_vocab_manager/src/Form/CgovVocabManagerForm.php
@@ -343,6 +343,7 @@ class CgovVocabManagerForm extends FormBase {
         'term' => $this->t('Name'),
         'children' => $this->t('Children'),
         'operations' => $this->t('Operations'),
+        'usage' => $this->t('Usage'),
         'weight' => $update_tree_access->isAllowed() ? $this->t('Weight') : NULL,
       ],
       '#attributes' => [
@@ -356,6 +357,7 @@ class CgovVocabManagerForm extends FormBase {
         'term' => [],
         'children' => [],
         'operations' => [],
+        'usage' => [],
         'weight' => $update_tree_access->isAllowed() ? [] : NULL,
       ];
       /** @var $term \Drupal\Core\Entity\EntityInterface */
@@ -437,6 +439,46 @@ class CgovVocabManagerForm extends FormBase {
           '#links' => $operations,
         ];
       }
+
+      // Get usages for this term.
+      $references = get_deletable_and_term_refs($term);
+      $ref_markup = '';
+      $prefixes = \Drupal::config('language.negotiation')->get('url.prefixes');
+
+      // Capture the node references.
+      if (count($references['node_refs']) > 0) {
+        $ref_markup .= "<p>Node:</p>" ;
+        foreach ($references['node_refs'] as $node) {
+
+          // Generate the edit link, taking language into account.
+          $prefix = $prefixes[$node['langcode']];
+          $url = "/${prefix}/node/${node['entity_id']}/edit";
+          $url = preg_replace('~/+~', '/', $url);
+          $link = "<a href='${url}'>${url}</a>";
+
+          $ref_markup .= "${link}<br/>";
+        }
+      }
+
+      /// Capture the media references
+      if (count($references['media_refs']) > 0) {
+        $ref_markup .="<p>Media: </p>" . '<br/>';
+        foreach ($references['media_refs'] as $media) {
+
+          // Generate the edit link, taking language into account.
+          $prefix = $prefixes[$node['langcode']];
+          $url = "/${prefix}/media/${media['entity_id']}/edit";
+          $url = preg_replace('/([^:])(\/{2,})/', '$1/', $url);
+          $link = "<a href='${url}'>${url}</a>";
+
+          $ref_markup .= "${link}<br/>";
+        }
+      }
+
+      // Add the usage list to the form.
+      $form['terms'][$key]['usage'] = [
+        '#markup' => $ref_markup,
+      ];
 
       if ($parent_fields) {
         $form['terms'][$key]['#attributes']['class'][] = 'draggable';


### PR DESCRIPTION
ODE: ncigovcdode278.prod.acquia-sites.com 
This ticket prevents taxonomy term deletion if used in the default revision for the following taxonomies:

cgov_event_series
cgov_event_venue
cgov_cancer_center_types
cgov_cancer_center_regions
cgov_biography_campuses

Add custom deletion logic for:
cgov_site_section

Closes #570