### PR TITLE
(#2493) Include field_levels_to_display as a trigger for cache tag clearing.

### DIFF
--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_site_section/cgov_site_section.module
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_site_section/cgov_site_section.module
@@ -389,6 +389,7 @@ function _will_trigger_cache_tag_invalidation(EntityInterface $updated_entity) {
         'field_section_nav_root',
         'field_navigation_label',
         'field_navigation_display_options',
+        'field_levels_to_display',
       ];
   }
   // Compare the values and check if any have been modified.


### PR DESCRIPTION
Closes #2493
ODE: ncigovcdode279.prod.acquia-sites.com