### PR TITLE
(#2571) Display trial site's contact phone and email 

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1767,6 +1767,7 @@
             ],
             "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
             "homepage": "https://github.com/container-interop/container-interop",
+            "abandoned": "psr/container",
             "time": "2017-02-14T19:40:03+00:00"
         },
         {
@@ -8950,12 +8951,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/NCIOCPL/clinical-trials-search-client.php.git",
-                "reference": "a696fc3aafa382727fa4c2a8642db43b848a3ed5"
+                "reference": "9dbf44f62db06cdeabc341132d1f5ee88432befb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/NCIOCPL/clinical-trials-search-client.php/zipball/a696fc3aafa382727fa4c2a8642db43b848a3ed5",
-                "reference": "a696fc3aafa382727fa4c2a8642db43b848a3ed5",
+                "url": "https://api.github.com/repos/NCIOCPL/clinical-trials-search-client.php/zipball/9dbf44f62db06cdeabc341132d1f5ee88432befb",
+                "reference": "9dbf44f62db06cdeabc341132d1f5ee88432befb",
                 "shasum": ""
             },
             "require": {
@@ -8994,7 +8995,7 @@
                 "source": "https://github.com/NCIOCPL/clinical-trials-search-client.php/tree/master",
                 "issues": "https://github.com/NCIOCPL/clinical-trials-search-client.php/issues"
             },
-            "time": "2019-09-30T20:55:12+00:00"
+            "time": "2019-12-04T16:41:06+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -13698,6 +13699,7 @@
                 "GPL-2.0-or-later"
             ],
             "description": "require-dev dependencies from drupal/core",
+            "abandoned": "drupal/core-dev",
             "time": "2019-05-23T07:31:39+00:00"
         },
         {

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/app_module/cts/clinical-trial.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/app_module/cts/clinical-trial.html.twig
@@ -119,24 +119,24 @@
                         <h5>{{ key }}</h5>
                         {% for item in value %}
                           <div class="location">
-                            {% if item.Name is defined %}
+                            {% if item.Name is not empty %}
                               <strong class="location-name">{{ item.Name }}</strong>
                             {% endif %}
-                            {% if item.RecruitmentStatus is defined %}
+                            {% if item.RecruitmentStatus is not empty %}
                               <div>Status: {{ item.RecruitmentStatus }}</div>
                             {% endif %}
-                            {% if item.ContactName is defined %}
+                            {% if item.ContactName is not empty %}
                               <div>Contact: {{ item.ContactName }}</div>
                             {% endif %}
-                            {# {% if item.ContactPhone is defined and item.ContactPhone is not null %}
+                            {% if item.ContactPhone is not empty %}
                               <div>Phone: {{ item.ContactPhone }}</div>
                             {% endif %}
-                            {% if item.ContactEmail is defined %}
+                            {% if item.ContactEmail is not empty %}
                               <div>
                                 Email:
-                                <a href="mailto:{{ item.ContactEmail|striptags }}">{{ item.ContactEmail }}</a>
+                                <a href="mailto:{{ item.ContactEmail }}">{{ item.ContactEmail }}</a>
                               </div>
-                            {% endif %} #}
+                            {% endif %}
                           </div>
                           {% endfor %}
                       </div>
@@ -153,24 +153,24 @@
                         <h5>{{ key }}</h5>
                         {% for item in value %}
                           <div class="location">
-                            {% if item.Name is defined %}
+                            {% if item.Name is not empty %}
                               <strong class="location-name">{{ item.Name }}</strong>
                             {% endif %}
-                            {% if item.RecruitmentStatus is defined %}
+                            {% if item.RecruitmentStatus is not empty %}
                               <div>Status: {{ item.RecruitmentStatus }}</div>
                             {% endif %}
-                            {% if item.ContactName is defined %}
+                            {% if item.ContactName is not empty %}
                               <div>Contact: {{ item.ContactName }}</div>
                             {% endif %}
-                            {# {% if item.ContactPhone is defined %}
+                            {% if item.ContactPhone is not empty %}
                               <div>Phone: {{ item.ContactPhone }}</div>
                             {% endif %}
-                            {% if item.ContactEmail is defined %}
+                            {% if item.ContactEmail is not empty %}
                               <div>
                                 Email:
                                 <a href="mailto:{{ item.ContactEmail|raw }}">{{ item.ContactEmail }}</a>
                               </div>
-                            {% endif %} #}
+                            {% endif %}
                           </div>
                           {% endfor %}
                       </div>
@@ -187,24 +187,24 @@
                         <h5>{{ key }}</h5>
                         {% for item in value %}
                           <div class="location">
-                            {% if item.Name is defined %}
+                            {% if item.Name is not empty %}
                               <strong class="location-name">{{ item.Name }}</strong>
                             {% endif %}
-                            {% if item.RecruitmentStatus is defined %}
+                            {% if item.RecruitmentStatus is not empty %}
                               <div>Status: {{ item.RecruitmentStatus }}</div>
                             {% endif %}
-                            {% if item.ContactName is defined %}
+                            {% if item.ContactName is not empty %}
                               <div>Contact: {{ item.ContactName }}</div>
                             {% endif %}
-                            {# {% if item.ContactPhone is defined %}
+                            {% if item.ContactPhone is not empty %}
                               <div>Phone: {{ item.ContactPhone }}</div>
                             {% endif %}
-                            {% if item.ContactEmail is defined %}
+                            {% if item.ContactEmail is not empty %}
                               <div>
                                 Email:
                                 <a href="mailto:{{ item.ContactEmail }}">{{ item.ContactEmail }}</a>
                               </div>
-                            {% endif %} #}
+                            {% endif %}
                           </div>
                           {% endfor %}
                       </div>


### PR DESCRIPTION
- Update  nciocpl/clinical-trial-search-client.php
- Uncomment references for ContactName and ContactEmail properties.
- Replace 'is defined' condition with 'is not empty'.

Closes #2571 