### PR TITLE
(#2562) Metadata support for App Modules

### DIFF
--- a/docroot/modules/custom/app_module/app_module.module
+++ b/docroot/modules/custom/app_module/app_module.module
@@ -5,6 +5,9 @@
  * Contains app_module.module.
  */
 
+use Drupal\Core\Render\BubbleableMetadata;
+use Drupal\app_module\Entity\AppModule;
+
 /**
  * Implements hook_theme().
  */
@@ -97,5 +100,114 @@ function app_module_path_delete($path) {
    */
   if ($path) {
     \Drupal::service('app_module.app_path_manager')->deleteByPath($path);
+  }
+}
+
+/*
+ * These are the hooks to allow our app module to interact with metadata.
+ */
+
+/**
+ * Implements hook_page_attachments_alter().
+ */
+function app_module_page_attachments_alter(array &$attachments) {
+  $app_module_id = \Drupal::request()->query->get('app_module_id');
+  $app_module_route = \Drupal::request()->query->get('app_module_route');
+  $app_module_data = \Drupal::request()->query->get('app_module_data');
+
+  // We are not rendering an app module, so exit.
+  if (!$app_module_id) {
+    return;
+  }
+
+  // Get the app module entity.
+  /* @var \Drupal\app_module\AppModuleInterface */
+  $app_module = AppModule::load($app_module_id);
+
+  if (!$app_module) {
+    // How could this happen exactly, I don't know.
+    throw new \Exception("Request parameters indicate app module loaded, but app module does not exist.");
+  }
+
+  // Load the app module plugin.
+  /* @var \Drupal\app_module\Plugin\app_module\AppModulePluginInterface */
+  $app_module_plugin = $app_module->getAppModulePlugin();
+
+  if (!$app_module_plugin) {
+    // How could this happen exactly, I don't know.
+    throw new \Exception("Request parameters indicate app module loaded, but app module plugin could not be loaded.");
+  }
+
+  if ($app_module_plugin) {
+    $app_module_plugin->alterPageAttachments($attachments, $app_module_route, (array) $app_module_data);
+  }
+
+}
+
+/**
+ * Implements hook_tokens_alter().
+ */
+function app_module_tokens_alter(array &$replacements, array $context, BubbleableMetadata $bubbleable_metadata) {
+  $app_module_id = \Drupal::request()->query->get('app_module_id');
+  $app_module_route = \Drupal::request()->query->get('app_module_route');
+  $app_module_data = \Drupal::request()->query->get('app_module_data');
+
+  // We are not rendering an app module, so exit.
+  if (!$app_module_id) {
+    return;
+  }
+
+  // Get the app module entity.
+  /* @var \Drupal\app_module\AppModuleInterface */
+  $app_module = AppModule::load($app_module_id);
+
+  if (!$app_module) {
+    // How could this happen exactly, I don't know.
+    throw new \Exception("Request parameters indicate app module loaded, but app module does not exist.");
+  }
+
+  // Load the app module plugin.
+  /* @var \Drupal\app_module\Plugin\app_module\AppModulePluginInterface */
+  $app_module_plugin = $app_module->getAppModulePlugin();
+
+  if (!$app_module_plugin) {
+    // How could this happen exactly, I don't know.
+    throw new \Exception("Request parameters indicate app module loaded, but app module plugin could not be loaded.");
+  }
+
+  /* @var \Drupal\app_module\AppModuleRenderArrayBuilderInterface */
+  $app_module_builder = \Drupal::service('app_module.builder');
+
+  if ($app_module_plugin) {
+    $tokensToAlter = $app_module_plugin->getTokensForAltering($app_module_route, (array) $app_module_data);
+
+    if (count(array_intersect($tokensToAlter, array_keys($replacements))) !== 0) {
+      $app_module_plugin->alterTokens($replacements, $context, $app_module_route, (array) $app_module_data);
+
+      // Add cache dependencies to bubble up because we are probably
+      // overwriting tokens that come from a node. If we are doing
+      // that, then we are probably need to vary the cache context.
+      // The app_module *SHOULD* already be doing this, so the cache
+      // metadata for the app_module build will be the same as what
+      // is needed here.
+      $bubbleable_metadata->addCacheableDependency(
+        $app_module_builder->getCacheDependencyForBuild($app_module, $app_module_route, (array) $app_module_data)
+      );
+    }
+  }
+}
+
+/**
+ * Implements hook_module_implements_alter().
+ *
+ * Make sure our page_attachments_alter comes at the very end of the
+ * implementation list. Also ensure tokens_alter comes at the very
+ * end too.
+ */
+function app_module_module_implements_alter(&$implementations, $hook) {
+  if ($hook === 'page_attachments_alter' || $hook === 'tokens_alter') {
+    $group = $implementations['app_module'];
+    unset($implementations['app_module']);
+    $implementations['app_module'] = $group;
   }
 }

--- a/docroot/modules/custom/app_module/src/AppModuleRenderArrayBuilderInterface.php
+++ b/docroot/modules/custom/app_module/src/AppModuleRenderArrayBuilderInterface.php
@@ -26,4 +26,19 @@ interface AppModuleRenderArrayBuilderInterface {
    */
   public function build(AppModuleInterface $app_module, array $options);
 
+  /**
+   * Gets a Cache Dependency for this App Module Route.
+   *
+   * @param AppModuleInterface $app_module
+   *   The AppModule Entity being viewed.
+   * @param string $path
+   *   The current app module route.
+   * @param array $options
+   *   The instance options for that app module.
+   *
+   * @return \Drupal\Core\Cache\CacheableDependencyInterface
+   *   The cache dependency.
+   */
+  public static function getCacheDependencyForBuild(AppModuleInterface $app_module, $path, array $options = []);
+
 }

--- a/docroot/modules/custom/app_module/src/PathProcessor/PathProcessorAppModule.php
+++ b/docroot/modules/custom/app_module/src/PathProcessor/PathProcessorAppModule.php
@@ -100,6 +100,8 @@ class PathProcessorAppModule implements InboundPathProcessorInterface {
     // Set the app_module_route parameter so the AppModuleRenderArrayBuilder
     // can pass it off to the plugin for rendering.
     $request->query->add(['app_module_route' => $app_route['app_module_route']]);
+    $request->query->add(['app_module_data' => $appPath['app_module_data']]);
+    $request->query->add(['app_module_id' => $appPath['app_module_id']]);
 
     // Add any additional params to the request object.
     foreach ($app_route['params'] as $param_name => $param_value) {

--- a/docroot/modules/custom/app_module/src/Plugin/app_module/AppModulePluginBase.php
+++ b/docroot/modules/custom/app_module/src/Plugin/app_module/AppModulePluginBase.php
@@ -121,4 +121,29 @@ abstract class AppModulePluginBase extends PluginBase implements AppModulePlugin
    */
   abstract protected function matchRouteInternal(array $path_components, array $options = []);
 
+  /**
+   * {@inheritdoc}
+   *
+   * The default implementation is a NOOP.
+   */
+  public function alterPageAttachments(array &$attachments, $path, array $options = []) {
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * The default implementation is a NOOP.
+   */
+  public function alterTokens(array &$replacements, array $context, $path, array $options = []) {
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * The default implementation is a NOOP.
+   */
+  public function getTokensForAltering($path, array $options = []) {
+    return [];
+  }
+
 }

--- a/docroot/modules/custom/app_module/src/Plugin/app_module/AppModulePluginInterface.php
+++ b/docroot/modules/custom/app_module/src/Plugin/app_module/AppModulePluginInterface.php
@@ -131,4 +131,76 @@ interface AppModulePluginInterface extends PluginInspectionInterface {
    */
   public function getCacheInfoForRoute($path, array $options = []);
 
+  /**
+   * Alter attachments (typically assets) to a page before it is rendered.
+   *
+   * Override this method when you want to remove or alter attachments on the
+   * page, or add attachments to the page that depend on another module's
+   * attachments. More specifically, implement this method to manipulate the
+   * page's metadata.
+   *
+   * If you try to add anything but #attached and #cache to the array, an
+   * exception is thrown.
+   *
+   * @param array &$attachments
+   *   Array of all attachments provided by hook_page_attachments()
+   *   implementations.
+   * @param string $path
+   *   The requested app module path as a string. This is relative to the
+   *   app module alias. For the node /foo/bar, if the url requested is
+   *   /foo/bar/bazz/blah then the $path would be /bazz/blah.
+   * @param array $options
+   *   The settings for this instance of the AppModule on an entity.
+   *
+   * @see hook_page_attachments()
+   */
+  public function alterPageAttachments(array &$attachments, $path, array $options = []);
+
+  /**
+   * Alter replacement values for tokens.
+   *
+   * Override this method when you want to change the contents for tokens for
+   * specific placeholder. More specifically, this is an easier way to
+   * manipulate the page's metadata rather than digging around page attachments.
+   *
+   * NOTE: The bubbleableMetadata will be taken care of by the app module
+   * framework. Just know that it will use getCacheInfo to get tags and
+   * contexts.
+   *
+   * @param array &$replacements
+   *   An associative array of replacements returned by hook_tokens().
+   * @param array $context
+   *   The context in which hook_tokens() was called. An associative array with
+   *   the following keys, which have the same meaning as the corresponding
+   *   parameters of hook_tokens():
+   *   - 'type'
+   *   - 'tokens'
+   *   - 'data'
+   *   - 'options'.
+   * @param string $path
+   *   The requested app module path as a string. This is relative to the
+   *   app module alias. For the node /foo/bar, if the url requested is
+   *   /foo/bar/bazz/blah then the $path would be /bazz/blah.
+   * @param array $options
+   *   The settings for this instance of the AppModule on an entity.
+   *
+   * @see hook_tokens()
+   */
+  public function alterTokens(array &$replacements, array $context, $path, array $options = []);
+
+  /**
+   * Gets the list of metadata tokens for this app module to alter.
+   *
+   * @param string $path
+   *   The requested app module path as a string. This is relative to the
+   *   app module alias. For the node /foo/bar, if the url requested is
+   *   /foo/bar/bazz/blah then the $path would be /bazz/blah.
+   * @param array $options
+   *   The settings for this instance of the AppModule on an entity.
+   *
+   * @return array
+   *   Returns an array with the tokens that this app module should alter.
+   */
+  public function getTokensForAltering($path, array $options = []);
+
 }

--- a/docroot/modules/custom/app_module/src/Plugin/app_module/MultiRouteAppModuleBuilderBase.php
+++ b/docroot/modules/custom/app_module/src/Plugin/app_module/MultiRouteAppModuleBuilderBase.php
@@ -29,4 +29,28 @@ abstract class MultiRouteAppModuleBuilderBase implements MultiRouteAppModuleBuil
     return CacheableMetadata::createFromObject(NULL);
   }
 
+  /**
+   * {@inheritdoc}
+   *
+   * The default implementation is a NOOP.
+   */
+  public function alterPageAttachments(array &$attachments, array $options = []) {
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * The default implementation is a NOOP.
+   */
+  public function alterTokens(array &$replacements, array $context, array $options = []) {
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * The default implementation is a NOOP.
+   */
+  public function getTokensForAltering(array $options = []) {
+  }
+
 }

--- a/docroot/modules/custom/app_module/src/Plugin/app_module/MultiRouteAppModuleBuilderInterface.php
+++ b/docroot/modules/custom/app_module/src/Plugin/app_module/MultiRouteAppModuleBuilderInterface.php
@@ -52,4 +52,61 @@ interface MultiRouteAppModuleBuilderInterface {
    */
   public function getCacheInfo(array $options);
 
+  /**
+   * Alter attachments (typically assets) to a page before it is rendered.
+   *
+   * Override this method when you want to remove or alter attachments on the
+   * page, or add attachments to the page that depend on another module's
+   * attachments. More specifically, implement this method to manipulate the
+   * page's metadata.
+   *
+   * If you try to add anything but #attached and #cache to the array, an
+   * exception is thrown.
+   *
+   * @param array &$attachments
+   *   Array of all attachments provided by hook_page_attachments()
+   *   implementations.
+   * @param array $options
+   *   The settings for this instance of the AppModule on an entity.
+   *
+   * @see hook_page_attachments()
+   */
+  public function alterPageAttachments(array &$attachments, array $options = []);
+
+  /**
+   * Alter replacement values for tokens.
+   *
+   * Override this method when you want to change the contents for tokens for
+   * specific placeholder. More specifically, this is an easier way to
+   * manipulate the page's metadata rather than digging around page attachments.
+   *
+   * NOTE: The bubbleableMetadata will be taken care of by the app module
+   * framework. Just know that it will use getCacheInfo to get tags and
+   * contexts.
+   *
+   * @param array &$replacements
+   *   An associative array of replacements returned by hook_tokens().
+   * @param array $context
+   *   The context in which hook_tokens() was called. An associative array with
+   *   the following keys, which have the same meaning as the corresponding
+   *   parameters of hook_tokens():
+   *   - 'type'
+   *   - 'tokens'
+   *   - 'data'
+   *   - 'options'.
+   * @param array $options
+   *   The settings for this instance of the AppModule on an entity.
+   *
+   * @see hook_tokens()
+   */
+  public function alterTokens(array &$replacements, array $context, array $options = []);
+
+  /**
+   * Gets the list of metadata tokens for this app module to alter.
+   *
+   * @return array
+   *   Returns an array with the tokens that this app module should alter.
+   */
+  public function getTokensForAltering(array $options = []);
+
 }

--- a/docroot/modules/custom/app_module/src/Plugin/app_module/MultiRouteAppModulePluginBase.php
+++ b/docroot/modules/custom/app_module/src/Plugin/app_module/MultiRouteAppModulePluginBase.php
@@ -76,4 +76,52 @@ abstract class MultiRouteAppModulePluginBase extends AppModulePluginBase {
     }
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  final public function alterPageAttachments(array &$attachments, $path, array $options = []) {
+    parent::alterPageAttachments($attachments, $path, $options);
+
+    /* @var \Drupal\app_module\Plugin\app_module\MultiRouteAppModuleBuilderBase */
+    $builder = $this->getBuilderForRoute($path);
+
+    if ($builder) {
+      $builder->alterPageAttachments($attachments, $options);
+    }
+
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * The default implementation is a NOOP.
+   */
+  final public function alterTokens(array &$replacements, array $context, $path, array $options = []) {
+    parent::alterTokens($replacements, $context, $path, $options);
+
+    /* @var \Drupal\app_module\Plugin\app_module\MultiRouteAppModuleBuilderBase */
+    $builder = $this->getBuilderForRoute($path);
+
+    if ($builder) {
+      $builder->alterTokens($replacements, $context, $options);
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * The default implementation is a NOOP.
+   */
+  public function getTokensForAltering($path, array $options = []) {
+    $builder = $this->getBuilderForRoute($path);
+
+    if ($builder) {
+      $tokensToAlter = $builder->getTokensForAltering($options);
+      return $tokensToAlter;
+    }
+    else {
+      return [];
+    }
+  }
+
 }

--- a/docroot/modules/custom/app_module/tests/modules/app_module_test/src/Plugin/app_module/TestAppModulePlugin.php
+++ b/docroot/modules/custom/app_module/tests/modules/app_module_test/src/Plugin/app_module/TestAppModulePlugin.php
@@ -46,4 +46,22 @@ class TestAppModulePlugin extends AppModulePluginBase {
     return $build;
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function alterPageAttachments(array &$attachments, $path, array $options = []) {
+    parent::alterPageAttachments($attachments, $path, $options);
+
+    $attachments['#attached']['html_head'][] = [
+      [
+        '#tag' => 'meta',
+        '#attributes' => [
+          'name' => 'testmeta',
+          'content' => 'test meta',
+        ],
+      ],
+      'testmeta',
+    ];
+  }
+
 }

--- a/docroot/modules/custom/app_module/tests/src/Functional/AppModuleRouteTest.php
+++ b/docroot/modules/custom/app_module/tests/src/Functional/AppModuleRouteTest.php
@@ -44,7 +44,13 @@ class AppModuleRouteTest extends AppModuleFieldBrowserTestBase {
     /* --------------------------------------
      * There is some issue where the path processor
      * is not firing. I don't know if it is minimal
-     * kernel or what. TODO: Test routing.
+     * kernel or what.
+     *
+     * There is an issue where a hook_page_attachments_alter is not firing
+     * as well. Probably similar issue.
+     *
+     * TODO: Test routing.
+     * TODO: Test meta tag additions.
      * --------------------------------------
      */
   }

--- a/docroot/modules/custom/app_module/tests/src/Unit/PathProcessorAppModuleTest.php
+++ b/docroot/modules/custom/app_module/tests/src/Unit/PathProcessorAppModuleTest.php
@@ -103,6 +103,8 @@ class PathProcessorAppModuleTest extends UnitTestCase {
     $this->assertEquals($path, $request_url);
     // There also should NOT be a param set for app_module_route.
     $this->assertTrue(!$request->query->has('app_module_route'));
+    $this->assertTrue(!$request->query->has('app_module_id'));
+    $this->assertTrue(!$request->query->has('app_module_data'));
     $stack->pop();
   }
 
@@ -141,6 +143,8 @@ class PathProcessorAppModuleTest extends UnitTestCase {
     // request.
     $this->assertEquals($path, $owner_alias);
     $this->assertEquals($request->query->get('app_module_route'), '/exact_route');
+    $this->assertEquals($request->query->get('app_module_id'), 'fake');
+    $this->assertEquals($request->query->get('app_module_data'), []);
     $stack->pop();
   }
 
@@ -179,6 +183,8 @@ class PathProcessorAppModuleTest extends UnitTestCase {
     // request.
     $this->assertEquals($path, $owner_alias);
     $this->assertEquals($request->query->get('app_module_route'), '/exact_route');
+    $this->assertEquals($request->query->get('app_module_id'), 'fake');
+    $this->assertEquals($request->query->get('app_module_data'), []);
     $stack->pop();
   }
 
@@ -217,6 +223,8 @@ class PathProcessorAppModuleTest extends UnitTestCase {
     // request.
     $this->assertEquals($path, $owner_alias);
     $this->assertEquals($request->query->get('app_module_route'), '/');
+    $this->assertEquals($request->query->get('app_module_id'), 'fake');
+    $this->assertEquals($request->query->get('app_module_data'), []);
     $stack->pop();
   }
 
@@ -253,6 +261,9 @@ class PathProcessorAppModuleTest extends UnitTestCase {
     // the redirect to the non-trailing slash url.
     $this->assertEquals($path, $request_url);
     $this->assertTrue(!$request->query->has('app_module_route'));
+    $this->assertTrue(!$request->query->has('app_module_id'));
+    $this->assertTrue(!$request->query->has('app_module_data'));
+
     $stack->pop();
   }
 
@@ -295,6 +306,8 @@ class PathProcessorAppModuleTest extends UnitTestCase {
     // request.
     $this->assertEquals($path, $owner_alias);
     $this->assertEquals($request->query->get('app_module_route'), '/route');
+    $this->assertEquals($request->query->get('app_module_id'), 'fake');
+    $this->assertEquals($request->query->get('app_module_data'), ['key1' => 'value1']);
     $this->assertEquals($request->query->get('some_id'), '123');
     $stack->pop();
   }
@@ -338,6 +351,8 @@ class PathProcessorAppModuleTest extends UnitTestCase {
     // request.
     $this->assertEquals($path, $owner_alias);
     $this->assertEquals($request->query->get('app_module_route'), '/route');
+    $this->assertEquals($request->query->get('app_module_id'), 'fake');
+    $this->assertEquals($request->query->get('app_module_data'), ['key1' => 'value1']);
     $this->assertEquals($request->query->get('some_id'), '123');
     $stack->pop();
   }


### PR DESCRIPTION
- Added in scaffolding for modules to participate in the
  hook_page_attachments_alter hook and hook_tokens_alter
- Added a method to identify what tokens an app module
  would use. Implemented hook_tokens_alter to filter
  out calls to app module based on available tokens.
- Added additional app_module parameters to the request
  query params in order to support these hook events,
  as hooks run outside of our FieldFormatter, which is
  what actually renders the app module.
- Updated tests for the path processor to validate our
  additional request parameters.
- NOTE: There is an issue with testing this scaffolding
  as our .module hooks are not being registered and
  thus are not firing during a Functional test.

Co-authored-by: Sarina Padilla <sarinapadilla@user.noreply.github.com>