### PR TITLE
CTS Metatags

### DIFF
--- a/docroot/modules/custom/app_module/src/Plugin/app_module/MultiRouteAppModuleBuilderBase.php
+++ b/docroot/modules/custom/app_module/src/Plugin/app_module/MultiRouteAppModuleBuilderBase.php
@@ -47,10 +47,9 @@ abstract class MultiRouteAppModuleBuilderBase implements MultiRouteAppModuleBuil
 
   /**
    * {@inheritdoc}
-   *
-   * The default implementation is a NOOP.
    */
   public function getTokensForAltering(array $options = []) {
+    return [];
   }
 
 }

--- a/docroot/modules/custom/cgov_cts/cgov_cts.services.yml
+++ b/docroot/modules/custom/cgov_cts/cgov_cts.services.yml
@@ -3,6 +3,14 @@ services:
   cgov_cts.app_route_default:
     class: Drupal\cgov_cts\MultiRouteBuilders\CTSDefaultBuilder
     arguments: []
+  cgov_cts.app_route_advanced_search:
+    class: Drupal\cgov_cts\MultiRouteBuilders\CTSAdvancedSearchBuilder
+    arguments: []
+  cgov_cts.app_route_results:
+    class: Drupal\cgov_cts\MultiRouteBuilders\CTSResultsBuilder
+    factory: Drupal\cgov_cts\MultiRouteBuilders\CTSResultsBuilder::create
+    arguments:
+      - '@service_container'
   cgov_cts.app_route_view_details:
     class: Drupal\cgov_cts\MultiRouteBuilders\CTSViewDetailsBuilder
     factory: Drupal\cgov_cts\MultiRouteBuilders\CTSViewDetailsBuilder::create

--- a/docroot/modules/custom/cgov_cts/src/MultiRouteBuilders/CTSAdvancedSearchBuilder.php
+++ b/docroot/modules/custom/cgov_cts/src/MultiRouteBuilders/CTSAdvancedSearchBuilder.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Drupal\cgov_cts\MultiRouteBuilders;
+
+/**
+ * Advanced search route builder for CTS.
+ *
+ * Loads the React app; sets up the page-specific metadata.
+ */
+class CTSAdvancedSearchBuilder extends CTSBuilderBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function id() {
+    return 'advanced_search';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function alterTokens(array &$replacements, array $context, array $options = []) {
+    foreach ($replacements as $key => $value) {
+      switch ($key) {
+        case '[node:url]':
+          $replacements[$key] = $value . '/advanced';
+          break;
+
+        case '[current-page:url]':
+          $replacements[$key] = $value . '/advanced';
+          break;
+
+        default:
+          break;
+      }
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * Return an array of tokens to alter.
+   */
+  public function getTokensForAltering(array $options = []) {
+    $tokensToAlter = [
+      '[node:url]',
+      '[current-page:url]',
+    ];
+
+    return $tokensToAlter;
+  }
+
+}

--- a/docroot/modules/custom/cgov_cts/src/MultiRouteBuilders/CTSAdvancedSearchBuilder.php
+++ b/docroot/modules/custom/cgov_cts/src/MultiRouteBuilders/CTSAdvancedSearchBuilder.php
@@ -22,6 +22,18 @@ class CTSAdvancedSearchBuilder extends CTSBuilderBase {
   public function alterTokens(array &$replacements, array $context, array $options = []) {
     foreach ($replacements as $key => $value) {
       switch ($key) {
+        case '[cgov_tokens:cgov-title]':
+          $replacements[$key] = 'Find NCI-Supported Clinical Trials - Advanced Search';
+          break;
+
+        case '[node:field_page_description:value]':
+          $replacements[$key] = 'Use our advanced search to find an NCI-supported clinical trial—and learn how to locate other research studies—that may be right for you or a loved one.';
+          break;
+
+        case '[node:field_browser_title:value]':
+          $replacements[$key] = 'Find NCI-Supported Clinical Trials - Advanced Search';
+          break;
+
         case '[node:url]':
           $replacements[$key] = $value . '/advanced';
           break;
@@ -43,6 +55,9 @@ class CTSAdvancedSearchBuilder extends CTSBuilderBase {
    */
   public function getTokensForAltering(array $options = []) {
     $tokensToAlter = [
+      '[cgov_tokens:cgov-title]',
+      '[node:field_page_description:value]',
+      '[node:field_browser_title:value]',
       '[node:url]',
       '[current-page:url]',
     ];

--- a/docroot/modules/custom/cgov_cts/src/MultiRouteBuilders/CTSBuilderBase.php
+++ b/docroot/modules/custom/cgov_cts/src/MultiRouteBuilders/CTSBuilderBase.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Drupal\cgov_cts\MultiRouteBuilders;
+
+use Drupal\app_module\Plugin\app_module\MultiRouteAppModuleBuilderBase;
+use Drupal\Core\Cache\CacheableMetadata;
+
+/**
+ * Route builder base for CTS.
+ */
+class CTSBuilderBase extends MultiRouteAppModuleBuilderBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function id() {
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build(array $options) {
+    $build = [
+      '#markup' => '<noscript>You need to enable JavaScript to run this app.</noscript>',
+    ];
+
+    return $build;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheInfo(array $options) {
+    $meta = new CacheableMetadata();
+    $meta
+      ->setCacheTags(['cgov_cts_app']);
+
+    return $meta;
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * On the base builder, alter the dcterms_coverage meta tag
+   * to include nciclinicaltrials for analytics.
+   */
+  public function alterPageAttachments(array &$attachments, array $options = []) {
+    foreach ($attachments['#attached']['html_head'] as $delta => $tag) {
+      if (isset($tag[1]) && $tag[1] == 'dcterms_coverage') {
+        $attachments['#attached']['html_head'][$delta][0]['#attributes']['content'] = 'nciglobal,ncienterprise,nciclinicaltrials';
+      }
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * Return an array of tokens to alter. On the base builder,
+   * do not return any tokens.
+   */
+  public function getTokensForAltering(array $options = []) {
+    return [];
+  }
+
+}

--- a/docroot/modules/custom/cgov_cts/src/MultiRouteBuilders/CTSDefaultBuilder.php
+++ b/docroot/modules/custom/cgov_cts/src/MultiRouteBuilders/CTSDefaultBuilder.php
@@ -38,4 +38,22 @@ class CTSDefaultBuilder extends MultiRouteAppModuleBuilderBase {
     return $meta;
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function alterTokens(array &$replacements, array $context, array $options = []) {
+    $this->initializeTrial();
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * The default implementation is a NOOP.
+   */
+  public function getTokensForAltering(array $options = []) {
+    $tokensToAlter = [];
+
+    return $tokensToAlter;
+  }
+
 }

--- a/docroot/modules/custom/cgov_cts/src/MultiRouteBuilders/CTSDefaultBuilder.php
+++ b/docroot/modules/custom/cgov_cts/src/MultiRouteBuilders/CTSDefaultBuilder.php
@@ -2,58 +2,18 @@
 
 namespace Drupal\cgov_cts\MultiRouteBuilders;
 
-use Drupal\app_module\Plugin\app_module\MultiRouteAppModuleBuilderBase;
-use Drupal\Core\Cache\CacheableMetadata;
-
 /**
- * Default route builder for CTS - should just load React app.
+ * Default route builder for CTS.
+ *
+ * Loads the React app.
  */
-class CTSDefaultBuilder extends MultiRouteAppModuleBuilderBase {
+class CTSDefaultBuilder extends CTSBuilderBase {
 
   /**
    * {@inheritdoc}
    */
   public function id() {
     return 'default';
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function build(array $options) {
-    $build = [
-      '#markup' => "<div>TODO - Add App Wrapper Here</div>",
-    ];
-
-    return $build;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function getCacheInfo(array $options) {
-    $meta = new CacheableMetadata();
-    $meta
-      ->setCacheTags(['cgov_cts_app']);
-    return $meta;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function alterTokens(array &$replacements, array $context, array $options = []) {
-    $this->initializeTrial();
-  }
-
-  /**
-   * {@inheritdoc}
-   *
-   * The default implementation is a NOOP.
-   */
-  public function getTokensForAltering(array $options = []) {
-    $tokensToAlter = [];
-
-    return $tokensToAlter;
   }
 
 }

--- a/docroot/modules/custom/cgov_cts/src/MultiRouteBuilders/CTSResultsBuilder.php
+++ b/docroot/modules/custom/cgov_cts/src/MultiRouteBuilders/CTSResultsBuilder.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Drupal\cgov_cts\MultiRouteBuilders;
+
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Results route builder for CTS.
+ *
+ * Loads the React app; sets up the page-specific metadata.
+ */
+class CTSResultsBuilder extends CTSBuilderBase {
+
+  /**
+   * Symfony\Component\HttpFoundation\RequestStack definition.
+   *
+   * @var \Symfony\Component\HttpFoundation\RequestStack
+   */
+  protected $requestStack;
+
+  /**
+   * Constructs a CTSResultsBuilder object.
+   *
+   * @param \Symfony\Component\HttpFoundation\RequestStack $request_stack
+   *   The request object.
+   */
+  public function __construct(RequestStack $request_stack) {
+    $this->requestStack = $request_stack;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    $requestStack = $container->get('request_stack');
+
+    return new static($requestStack);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function id() {
+    return 'results';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function alterPageAttachments(array &$attachments, array $options = []) {
+    parent::alterPageAttachments($attachments, $options);
+
+    foreach ($attachments['#attached']['html_head'] as $delta => $tag) {
+      if (isset($tag[1]) && $tag[1] == 'robots') {
+        $attachments['#attached']['html_head'][$delta][0]['#attributes']['content'] = 'noindex, nofollow';
+      }
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function alterTokens(array &$replacements, array $context, array $options = []) {
+    $uri = $this->requestStack->getCurrentRequest()->getRequestUri();
+
+    foreach ($replacements as $key => $value) {
+      switch ($key) {
+        case '[cgov_tokens:cgov-title]':
+          $replacements[$key] = 'Clinical Trials Search Results';
+          break;
+
+        case '[node:field_page_description:value]':
+          $replacements[$key] = 'Find an NCI-supported clinical trial - Search results';
+          break;
+
+        case '[node:field_browser_title:value]':
+          $replacements[$key] = 'Clinical Trials Search Results';
+          break;
+
+        case '[node:url]':
+          $url = str_replace('/about-cancer/treatment/clinical-trials/search', $uri, $value);
+          $replacements[$key] = $url;
+          break;
+
+        case '[current-page:url]':
+          $url = str_replace('/about-cancer/treatment/clinical-trials/search', $uri, $value);
+          $replacements[$key] = $url;
+          break;
+
+        default:
+          break;
+      }
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * Return an array of tokens to alter.
+   */
+  public function getTokensForAltering(array $options = []) {
+    $tokensToAlter = [
+      '[cgov_tokens:cgov-title]',
+      '[node:field_page_description:value]',
+      '[node:field_browser_title:value]',
+      '[node:url]',
+      '[current-page:url]',
+    ];
+
+    return $tokensToAlter;
+  }
+
+}

--- a/docroot/modules/custom/cgov_cts/src/MultiRouteBuilders/CTSViewDetailsBuilder.php
+++ b/docroot/modules/custom/cgov_cts/src/MultiRouteBuilders/CTSViewDetailsBuilder.php
@@ -137,6 +137,24 @@ class CTSViewDetailsBuilder extends MultiRouteAppModuleBuilderBase {
   }
 
   /**
+   * {@inheritdoc}
+   */
+  public function alterTokens(array &$replacements, array $context, array $options = []) {
+    $this->initializeTrial();
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * The default implementation is a NOOP.
+   */
+  public function getTokensForAltering(array $options = []) {
+    $tokensToAlter = [];
+
+    return $tokensToAlter;
+  }
+
+  /**
    * Set up Inclusion Criteria variable.
    */
   protected function setupInclusionCriteria($trial) {

--- a/docroot/modules/custom/cgov_cts/src/Plugin/app_module/ClinicalTrialsSearchAppModulePlugin.php
+++ b/docroot/modules/custom/cgov_cts/src/Plugin/app_module/ClinicalTrialsSearchAppModulePlugin.php
@@ -26,7 +26,21 @@ class ClinicalTrialsSearchAppModulePlugin extends MultiRouteAppModulePluginBase 
   private $defaultBuilder;
 
   /**
-   * Gets the default route builder.
+   * Gets the advanced search route builder.
+   *
+   * @var \Drupal\app_module\Plugin\app_module\MultiRouteAppModuleBuilderInterface
+   */
+  private $advancedSearchBuilder;
+
+  /**
+   * Gets the results route builder.
+   *
+   * @var \Drupal\app_module\Plugin\app_module\MultiRouteAppModuleBuilderInterface
+   */
+  private $resultsBuilder;
+
+  /**
+   * Gets the view details route builder.
    *
    * @var \Drupal\app_module\Plugin\app_module\MultiRouteAppModuleBuilderInterface
    */
@@ -43,19 +57,27 @@ class ClinicalTrialsSearchAppModulePlugin extends MultiRouteAppModulePluginBase 
    *   The plugin implementation definition.
    * @param \Drupal\app_module\Plugin\app_module\MultiRouteAppModuleBuilderInterface $default_builder
    *   The default route builder.
+   * @param \Drupal\app_module\Plugin\app_module\MultiRouteAppModuleBuilderInterface $advanced_search_builder
+   *   The advanced search route builder.
+   * @param \Drupal\app_module\Plugin\app_module\MultiRouteAppModuleBuilderInterface $results_builder
+   *   The results route builder.
    * @param \Drupal\app_module\Plugin\app_module\MultiRouteAppModuleBuilderInterface $view_details_builder
-   *   The chicken route builder.
+   *   The view details route builder.
    */
   public function __construct(
     array $configuration,
     $plugin_id,
     $plugin_definition,
     MultiRouteAppModuleBuilderInterface $default_builder,
+    MultiRouteAppModuleBuilderInterface $advanced_search_builder,
+    MultiRouteAppModuleBuilderInterface $results_builder,
     MultiRouteAppModuleBuilderInterface $view_details_builder
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->definition = $plugin_definition + $configuration;
     $this->defaultBuilder = $default_builder;
+    $this->advancedSearchBuilder = $advanced_search_builder;
+    $this->resultsBuilder = $results_builder;
     $this->viewDetailsBuilder = $view_details_builder;
   }
 
@@ -68,6 +90,8 @@ class ClinicalTrialsSearchAppModulePlugin extends MultiRouteAppModulePluginBase 
       $plugin_id,
       $plugin_definition,
       $container->get('cgov_cts.app_route_default'),
+      $container->get('cgov_cts.app_route_advanced_search'),
+      $container->get('cgov_cts.app_route_results'),
       $container->get('cgov_cts.app_route_view_details')
     );
   }
@@ -91,7 +115,17 @@ class ClinicalTrialsSearchAppModulePlugin extends MultiRouteAppModulePluginBase 
      */
     switch ($path_components[0]) {
       case "advanced":
+        return [
+          'app_module_route' => '/' . $path_components[0],
+          'params' => [],
+        ];
+
       case "r":
+        return [
+          'app_module_route' => '/' . $path_components[0],
+          'params' => [],
+        ];
+
       case "v":
         return [
           'app_module_route' => '/' . $path_components[0],
@@ -108,6 +142,12 @@ class ClinicalTrialsSearchAppModulePlugin extends MultiRouteAppModulePluginBase 
   protected function getBuilderForRoute($path) {
 
     switch ($path) {
+      case '/advanced':
+        return $this->advancedSearchBuilder;
+
+      case '/r':
+        return $this->resultsBuilder;
+
       case '/v':
         return $this->viewDetailsBuilder;
 

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/app_module/cts/app-module--cgov-cts-app--cgov-cts-app-module-plugin--advanced-search.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/app_module/cts/app-module--cgov-cts-app--cgov-cts-app-module-plugin--advanced-search.html.twig
@@ -20,5 +20,4 @@
 <div id="modal-root"></div>
 <div id="NCI-CTS-root" data-isRehydrating="true">
   {{ content['#markup']|raw }}
-  {{ content }}
 </div>

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/app_module/cts/app-module--cgov-cts-app--cgov-cts-app-module-plugin--default.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/app_module/cts/app-module--cgov-cts-app--cgov-cts-app-module-plugin--default.html.twig
@@ -20,5 +20,4 @@
 <div id="modal-root"></div>
 <div id="NCI-CTS-root" data-isRehydrating="true">
   {{ content['#markup']|raw }}
-  {{ content }}
 </div>

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/app_module/cts/app-module--cgov-cts-app--cgov-cts-app-module-plugin--results.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/app_module/cts/app-module--cgov-cts-app--cgov-cts-app-module-plugin--results.html.twig
@@ -20,5 +20,4 @@
 <div id="modal-root"></div>
 <div id="NCI-CTS-root" data-isRehydrating="true">
   {{ content['#markup']|raw }}
-  {{ content }}
 </div>


### PR DESCRIPTION
(#2580) Update CTS Advanced Search metatags
* Update metatag overwrites for CTS Advanced Search
* Closes #2580

(#2573) Update CTS page metadata
* Create builder base class for CTS pages
* Update default & create advanced/results builders for CTS pages
* Set build arrays, alter page attachments, and overwrite metatag tokens
* Update CTS App Module Plugin with all CTS page builders
* Update services file with all CTS page builders
* Create/update twig templates for CTS pages
* Closes #2573