### PR TITLE
(#2466)  Add the cgov_mail module.

### DIFF
--- a/docroot/profiles/custom/cgov_site/cgov_site.info.yml
+++ b/docroot/profiles/custom/cgov_site/cgov_site.info.yml
@@ -97,6 +97,7 @@ install:
   - cgov_cancer_research
   - cgov_redirect_manager
   - cgov_schema_org
+  - cgov_mail
 themes:
   - cgov_common
   - cgov_admin

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_mail/cgov_mail.features.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_mail/cgov_mail.features.yml
@@ -1,0 +1,12 @@
+excluded:
+  - user.role.authenticated
+  - user.role.content_author
+  - user.role.content_editor
+  - user.role.advanced_editor
+  - user.role.layout_manager
+  - user.role.site_admin
+  - user.role.admin_ui
+  - user.role.content_previewer
+  - user.role.blog_manager
+  - user.role.image_manager
+  - user.role.pdq_importer

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_mail/cgov_mail.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_mail/cgov_mail.info.yml
@@ -1,0 +1,6 @@
+name: 'Cgov Mail'
+type: module
+description: 'Mail backend and configuration for Cancer.gov'
+core: 8.x
+package: 'CGov Digital Platform'
+configure: cgov_mail.email_settings.form

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_mail/cgov_mail.menu.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_mail/cgov_mail.menu.yml
@@ -1,0 +1,6 @@
+cgov_mail.settings_form:
+  title: 'SettingsForm'
+  route_name: cgov_mail.email_settings
+  description: 'The Cgov mail settings configuration.'
+  parent: system.admin_config_system
+  weight: 99

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_mail/cgov_mail.module
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_mail/cgov_mail.module
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * @file
+ * Contains cgov_mail logic.
+ */
+
+use Drupal\Component\Utility\Html;
+
+/**
+ * Implements hook_mail().
+ */
+function cgov_mail_mail($key, &$message, $params) {
+  switch ($key) {
+    case 'send_contact_form':
+      $message['from'] = $params['from'];
+      $message['subject'] = $params['subject'];
+      $message['body'][] = Html::escape($params['message']);
+      break;
+  }
+}
+
+/**
+ * Implements hook_metatags_attachments_alter().
+ */
+function cgov_mail_metatags_attachments_alter(array &$metatag_attachments) {
+  // Add no-index to the metatags for our custom thank you page.
+  $current_path = \Drupal::service('path.current')->getPath();
+  if ($current_path == '/form/thank-you') {
+
+    // Set the title.
+    foreach ($metatag_attachments['#attached']['html_head'] as $id => $attachment) {
+      if ($attachment[1] == 'title') {
+        $metatag_attachments['#attached']['html_head'][$id][0]['#attributes']['content'] = 'Thank You - National Cancer Institute';
+      }
+    }
+
+    $metatag_attachments['#attached']['html_head'][] = [
+      [
+        '#tag' => 'meta',
+        '#attributes' => [
+          'name' => 'robots',
+          'content' => 'noindex',
+        ],
+      ],
+      'noindex',
+    ];
+
+  }
+}
+
+/**
+ * Update for v1.1.14.
+ *
+ * Install cgov_mail as a CGov Module.
+ */
+function cgov_mail_update_8001() {
+  if (!\Drupal::moduleHandler()->moduleExists('cgov_mail')) {
+    $installer = \Drupal::service('module_installer');
+    $installer->install(['cgov_mail']);
+  }
+}

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_mail/cgov_mail.routing.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_mail/cgov_mail.routing.yml
@@ -1,0 +1,27 @@
+cgov_mail.email_settings:
+  path: '/admin/config/cgov_mail/settings'
+  defaults:
+    _form: '\Drupal\cgov_mail\Form\MailSettingsForm'
+    _title: 'Cancer.gov mail form configuration.'
+  requirements:
+    _permission: 'administer site configuration'
+  options:
+    _admin_route: TRUE
+
+####
+# Form API endpoints
+cgov_mail_api.post:
+  path: '/FormEmailer'
+  defaults: { _controller: '\Drupal\cgov_mail\Controller\MailAPIController::handleForm' }
+  methods:  [POST]
+  requirements:
+    ## Public API
+    _access: 'TRUE'
+
+cgov_mail_api.thank_you:
+  path: '/form/thank-you'
+  defaults:
+    _controller: '\Drupal\cgov_mail\Controller\MailAPIController::handleThankYouRedirect'
+    _title: 'Contact Us - Thank You'
+  requirements:
+    _permission: 'access content'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_mail/config/install/cgov_mail.settings.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_mail/config/install/cgov_mail.settings.yml
@@ -1,0 +1,4 @@
+contact_form_recipient: 'example@example.com'
+es_contact_form_recipient: 'example@example.com'
+enable-lower-tier-routing: true
+re-captcha: 're-captcha-123'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_mail/config/schema/cgov_mail.schema.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_mail/config/schema/cgov_mail.schema.yml
@@ -1,0 +1,16 @@
+cgov_mail.settings:
+  type: config_object
+  label: 'Email Settings'
+  mapping:
+    contact_form_recipient:
+      type: text
+      label: 'Email form recipient, only takes effect on prod.'
+    es_contact_form_recipient:
+      type: text
+      label: 'Email form recipient, only takes effect on prod.'
+    re-captcha:
+      type: text
+      label: 'Re-captcha key'
+    enable-lower-tier-routing:
+      type: boolean
+      label: 'Whether or not rerouting mail to log is enabled for lower tiers.'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_mail/src/Controller/MailAPIController.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_mail/src/Controller/MailAPIController.php
@@ -1,0 +1,312 @@
+<?php
+
+namespace Drupal\cgov_mail\Controller;
+
+/**
+ * @file
+ * Contains \Drupal\cgov_mail\Controller\MailAPIController.
+ */
+
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\Mail\MailManagerInterface;
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Drupal\Component\Utility\EmailValidatorInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\Messenger\MessengerTrait;
+
+/**
+ * Controller routines for C.gov email form routes.
+ */
+class MailAPIController extends ControllerBase {
+
+  use StringTranslationTrait;
+  use MessengerTrait;
+
+  protected $emailValidator;
+
+  protected $mailManager;
+
+  protected $cgovMailConfig;
+
+  protected $account;
+
+  protected $mailPlugin;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(EmailValidatorInterface $email_validator,
+                              MailManagerInterface $mail_manager,
+                              ConfigFactoryInterface $config_factory,
+                              AccountInterface $account) {
+    $this->emailValidator = $email_validator;
+    $this->mailManager = $mail_manager;
+    $this->cgovMailConfig = $config_factory->get('cgov_mail.settings');
+    $this->mailPlugin = $config_factory->getEditable('system.mail');
+    $this->account = $account;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('email.validator'),
+      $container->get('plugin.manager.mail'),
+      $container->get('config.factory'),
+      $container->get('current_user')
+    );
+  }
+
+  /**
+   * Callback for `/FormEmailer` API method.
+   *
+   * @param \Symfony\Component\HttpFoundation\Request $request
+   *   The request.
+   *
+   * @return \Symfony\Component\HttpFoundation\RedirectResponse
+   *   The response.
+   */
+  public function handleForm(Request $request) {
+    // Grab the referring URL in the event the
+    // data fails validation, or the MailManager fails to send.
+    $previousUrl = $request->server->get('HTTP_REFERER');
+
+    // Initialize variables.
+    $from = $to = $subject = $body = $redirect = $requiredFields = $splitFields = '';
+    $errorList = [];
+    $error_p = FALSE;
+
+    $data = $request->request->all();
+    foreach ($data as $key => $value) {
+      switch ($key) {
+        case 'submit.x':
+          // Ignore.
+          break;
+
+        case 'submit.y':
+          // Ignore.
+          break;
+
+        case '__from':
+          $from = $value;
+          if (!$this->emailValidator->isValid($from)) {
+            $errorList[] = "Error: from email '" . $from . "' is invalid. Please go back and enter a valid email address.";
+            $error_p = TRUE;
+          }
+          break;
+
+        case '__subject':
+          $subject = $value;
+          break;
+
+        case '__recipient';
+          $to = $this->cgovMailConfig->get($value);
+          // Set an error if a configured address was not found.
+          if (($to === NULL) || ($to === '')) {
+            $errorList[] = "Error: recipient '" . $value . "'' is not configured.";
+            $error_p = TRUE;
+          }
+          break;
+
+        case '__redirectto':
+          $redirect = $value;
+          break;
+
+        case '__requiredfields':
+          $requiredFields = str_replace(' ', '', trim($value));
+          break;
+
+        case '__splitFields':
+          $splitFields = ',' . str_replace(' ', '', $value) . ',';
+          break;
+
+        // Recaptcha fields.
+        case "g-recaptcha-response":
+          $recaptchaResponseField = $value;
+          break;
+
+        default:
+          if ($this->startsWith($key, '__linebreak')) {
+            $body .= "\r\n";
+          }
+          else {
+            // Only send "real" fields.
+            if (!$this->startsWith($key, '__')) {
+              $pos = strrpos($splitFields, $key);
+              if ($pos === FALSE) {
+                $temp_body = str_replace('_', ' ', $key);
+                $body .= $temp_body . ": " . $value . "\r\n";
+              }
+              else {
+                $temp_key = str_replace('_', ' ', $key);
+                $temp_value = str_replace(",", "\r\n\t\t", $value);
+                $body .= $temp_key . ": \r\n\t\t" . urldecode($temp_value) . "\r\n";
+              }
+            }
+          }
+          break;
+      }
+    }
+
+    // Check required fields.
+    if ($requiredFields !== '') {
+      $fields = explode(',', $requiredFields);
+      foreach ($fields as $field) {
+        if (($data[$field] === NULL) || trim($data[$field]) === '') {
+          $errorList[] = 'Required field missing: ' . $field;
+          $error_p = TRUE;
+        }
+      }
+    }
+
+    // Validate reCAPTCHA.
+    // Google reCAPTCHA API secret key.
+    $captcha_key = $this->cgovMailConfig->get('re-captcha');
+    $ch = curl_init();
+    curl_setopt($ch, CURLOPT_URL, "https://www.google.com/recaptcha/api/siteverify");
+    curl_setopt($ch, CURLOPT_POST, 1);
+    curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query([
+      'secret' => $captcha_key,
+      'response' => $recaptchaResponseField,
+    ]));
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
+    $response = curl_exec($ch);
+    curl_close($ch);
+    $responseData = json_decode($response, TRUE);
+
+    if (!$responseData['success'] === TRUE) {
+      if ($responseData['error-codes'] === NULL) {
+        $errorList[] = 'reCAPTCHA check not completed!';
+      }
+      else {
+        foreach ($responseData['error-codes'] as $code) {
+          $errorList[] = $code;
+        }
+      }
+      $error_p = TRUE;
+    }
+    // If there was an error with the captcha return an error.
+    if ($error_p) {
+      foreach ($errorList as $error) {
+        $this->messenger()
+          ->addError('NOTICE: There was a problem sending your message
+           and it was not sent. ERROR: ' . $error);
+      }
+      return new RedirectResponse($previousUrl);
+    }
+    else {
+      // Send the message.
+      $result = $this->sendMail($from, $to, $subject, $body);
+      if ($result !== TRUE && $result['result'] !== TRUE) {
+        $this->messenger()
+          ->addError($this->t('There was a problem sending your message and it was not sent.'));
+        return new RedirectResponse($previousUrl);
+      }
+      else {
+        // Redirect the user to the supplied uri.
+        $response = new RedirectResponse($redirect);
+      }
+    }
+    return $response;
+  }
+
+  /**
+   * Sends the mail using the MailManager service.
+   *
+   * @param string $from
+   *   From address.
+   * @param string $to
+   *   The email recipient.
+   * @param string $subject
+   *   The email subject.
+   * @param string $body
+   *   The body of the email.
+   *
+   * @return array
+   *   The email success result.
+   */
+  private function sendMail($from, $to, $subject, $body) {
+    $params['from'] = $from;
+    $params['subject'] = $subject;
+    $params['message'] = $body;
+    $module = 'cgov_mail';
+    $key = 'send_contact_form';
+    $langcode = $this->account->getPreferredLangcode();
+    $send = TRUE;
+
+    // If re-routing is disabled for lower tiers,
+    // don't use the mail manager (CgovMailLogger), use PHP Mail.
+    $enabled = $this->cgovMailConfig->get('enable-lower-tier-routing');
+    if (!$enabled) {
+      $message["headers"] = [
+        "content-type" => "text/html",
+        "MIME-Version" => "1.0",
+        "reply-to" => $from,
+        "from" => $from,
+      ];
+
+      $message['from'] = $from;
+      $message['to'] = $to;
+      $message['subject'] = $subject;
+      $message['body'] = $body;
+
+      // Create an instance of a the default php mail plugin.
+      $this->mailPlugin->set('interface.default', 'php_mail')
+        ->save();
+      $plugin_id = 'php_mail';
+      $mailer = $this->mailManager->createInstance($plugin_id);
+      $result = $mailer->mail($message);
+    }
+    else {
+      $result = $this->mailManager->mail($module, $key, $to, $langcode, $params, NULL, $send);
+    }
+    return $result;
+  }
+
+  /**
+   * Helper function to determine if a string starts with another.
+   *
+   * @param string $haystack
+   *   The string to search within.
+   * @param string $needle
+   *   The string to search for.
+   *
+   * @return bool
+   *   Return true if found.
+   */
+  private function startsWith($haystack, $needle) {
+    $length = strlen($needle);
+    return (substr($haystack, 0, $length) === $needle);
+  }
+
+  /**
+   * Returns a thank you page.
+   *
+   * @return array
+   *   A simple renderable array.
+   */
+  public function handleThankYouRedirect() {
+    $element = [
+      '#markup' => '
+<div class="error-page">
+<div class="error-content">
+<div class="error-content-english">
+<h1>Thank You</h1>
+<p><span>We received your submission</span>.</p>
+</div>
+<div class="error-content-spanish">
+<h1>Gracias</h1>
+<p>Hemos recibido su mensaje.</p>
+</div>
+</div>
+</div>',
+    ];
+    return $element;
+  }
+
+}

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_mail/src/Form/MailSettingsForm.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_mail/src/Form/MailSettingsForm.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Drupal\cgov_mail\Form;
+
+/**
+ * @file
+ * Contains Drupal\cgov_mail\Form\SettingsForm.
+ */
+
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Class SettingsForm.
+ *
+ * @package Drupal\cgov_mail\Form
+ */
+class MailSettingsForm extends ConfigFormBase {
+  /**
+   * Config settings.
+   *
+   * @var string
+   */
+  const CGOV_MAIL_SETTINGS = 'cgov_mail.settings';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return [
+      static::CGOV_MAIL_SETTINGS,
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'cgov_settings_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $config = $this->config(static::CGOV_MAIL_SETTINGS);
+    $form['contact_form_recipient'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Contact Form Recipient'),
+      '#default_value' => $config->get('contact_form_recipient'),
+    ];
+    $form['es_contact_form_recipient'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Spanish Contact Form Recipient'),
+      '#default_value' => $config->get('es_contact_form_recipient'),
+    ];
+    $form['re-captcha'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Re-captcha Key'),
+      '#default_value' => $config->get('re-captcha'),
+    ];
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    parent::submitForm($form, $form_state);
+
+    $this->config(static::CGOV_MAIL_SETTINGS)
+      ->set('contact_form_recipient', $form_state->getValue('contact_form_recipient'))
+      ->set('re-captcha', $form_state->getValue('re-captcha'))
+      ->save();
+  }
+
+}

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_mail/src/Plugin/Mail/CgovMailLogger.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_mail/src/Plugin/Mail/CgovMailLogger.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Drupal\cgov_mail\Plugin\Mail;
+
+use Drupal\Component\Utility\Unicode;
+use Drupal\Core\Mail\MailFormatHelper;
+use Drupal\Core\Mail\MailInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Site\Settings;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Defines a mail backend that captures sent messages to the logger.
+ *
+ * To enable, save the following variable in settings.php (or otherwise)
+ *
+ * @code
+ * $config['system.mail']['interface']['default'] = 'cgov_mail_logger';
+ * @endcode
+ *
+ * @Mail(
+ *   id = "cgov_mail_logger",
+ *   label = @Translation("Cancer.gov Mail logger"),
+ *   description = @Translation("Does not send the message, but sends it to the
+ *   logger. Used for lower tiers")
+ * )
+ */
+class CgovMailLogger implements MailInterface, ContainerFactoryPluginInterface {
+
+  /**
+   * The logger.
+   *
+   * @var \Psr\Log\LoggerInterface
+   */
+  protected $logger;
+
+  /**
+   * Constructs a new LoggerMail object.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Psr\Log\LoggerInterface $logger
+   *   The logger.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, LoggerInterface $logger) {
+    $this->logger = $logger;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static($configuration, $plugin_id, $plugin_definition, $container->get('logger.factory')
+      ->get('mail'));
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function format(array $message) {
+    // Join the body array into one string.
+    $message['body'] = implode("\n\n", $message['body']);
+
+    // Convert any HTML to plain-text.
+    $message['body'] = MailFormatHelper::htmlToText($message['body']);
+    // Wrap the mail body for sending.
+    $message['body'] = MailFormatHelper::wrapMail($message['body']);
+
+    return $message;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function mail(array $message) {
+    $this->logger->info('Mail sent to @to with subject %subject: <pre>@mail</pre>', [
+      '@to' => $message['to'],
+      '%subject' => $message['subject'],
+      '@mail' => $this->formatMessage($message),
+    ]);
+    return TRUE;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function formatMessage($message) {
+    $mimeheaders = [];
+    $message['headers']['To'] = $message['to'];
+    foreach ($message['headers'] as $name => $value) {
+      $mimeheaders[] = $name . ': ' . Unicode::mimeHeaderEncode($value);
+    }
+    $line_endings = Settings::get('mail_line_endings', PHP_EOL);
+    $output = implode($line_endings, $mimeheaders) . $line_endings;
+
+    // 'Subject:' is a mail header and should not be translated.
+    $output .= 'Subject: ' . $message['subject'] . $line_endings;
+
+    // Blank line to separate headers from body.
+    $output .= $line_endings;
+    $output .= preg_replace('@\\r?\\n@', $line_endings, $message['body']);
+    return $output;
+  }
+
+}

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/email-form.content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/email-form.content.yml
@@ -1,0 +1,344 @@
+## About us contact
+- entity: "taxonomy_term"
+  vid: "cgov_site_sections"
+  tid: 902900
+  name: "Contact Us"
+  field_pretty_url:
+    value: "contact"
+  field_navigation_label:
+    value: "Contact"
+  field_section_nav_root:
+    value: true
+  field_levels_to_display:
+    value: 5
+  computed_path: "/contact"
+  parent:
+    - "#process":
+        callback: "reference"
+        args:
+          - "taxonomy_term"
+          - vid: "cgov_site_sections"
+            name: "Cancer Treatment"
+          - computed_path: "/about-cancer/treatment"
+
+###
+- entity: "block_content"
+  type: "raw_html_block"
+  info: "Contact Us Email Form - English"
+  info__ES:
+    value: "Contact Us Email Form - Spanish"
+  langcode: en
+  status: 1
+  field_raw_html:
+    - format: "raw_html"
+      value: |
+        <!-- function validateEmail() -->
+        <script language="javascript" type="text/javascript">  function validateEmail() {
+            var email = "not valid email";
+            var saywhat = '';
+            var theresponse = '';
+            if (document.contactNCI.__from.value === '') {
+                saywhat += "Please enter a valid email address (ex. xxxxx@xxxxx.com).\n";
+            } else {
+                theresponse = '';
+                theresponse += CheckEmail(document.contactNCI.__from.value);
+                if (theresponse !== '') {
+                    saywhat += theresponse;
+                } else {
+                    email = document.contactNCI.__from.value;
+                }
+            }
+            if (document.contactNCI.__email_confirm.value === '') {
+                saywhat += "Please enter a valid confirmation email address.\n";
+            }
+            if (email !== document.contactNCI.__email_confirm.value) {
+                saywhat += "Please make sure both email addresses match.\n";
+            }
+            if (document.contactNCI.Message.value === '') {
+                saywhat += "Please enter a message.\n";
+            }
+            if (email === document.contactNCI.__email_confirm.value && document.contactNCI.Message.value !== '') {
+                if (document.contactNCI.__subject.value.indexOf('Cancer.gov Inquiry - ') === -1) {
+                    document.contactNCI.__subject.value = 'Cancer.gov Inquiry - ' + document.contactNCI.__subject.value;
+                }
+            }
+            if (saywhat !== '') {
+                alert(saywhat);
+                return false;
+            }
+            return true;
+        }
+
+        function CheckEmail(strng) {
+            var error = '';
+            var emailFilter = /^.+@.+\..{2,3}$/;
+            if (!(emailFilter.test(strng))) {
+                error = "Please enter a valid email address.\n";
+            } else {
+                var illegalChars = /[\(\)\,\;\:\\\"\[\]]/;
+                if (strng.match(illegalChars)) {
+                    error = "The email address contains illegal characters.\n";
+                }
+            }
+            return error;
+        } </script> <!-- end function validateEmail() -->
+        <div class="callout-box-right"> OMB NO: 0925-0208<br> EXPIRATION DATE: 11/30/2021<br> <a href="#omb-control">Burden
+            Statement</a></div>  <p>Please use this form to contact NCI. Your answers will help us give you the most useful
+            information. Personal information will be kept confidential and used only to respond to your question.</p> <p>NOTE:
+            Information provided by the NCI’s Cancer Information Service is not a substitute for personal medical advice.
+            <strong>Do not send or attach photos or medical reports.</strong> If you need medical advice, please consult with
+            your health care provider.</p>
+        <div class="callout-box"><p> Would you rather speak with one of our Cancer Information Specialists?<br> <b>1-800-4-CANCER
+            (1-800-422-6237)</b><br> 9 a.m. to 9 p.m. ET, M-F </p></div>
+        <form action="/FormEmailer" id="Form1" method="post" name="contactNCI" class="email-us-form"
+              onsubmit="return(validateEmail());"><input name="__recipient" id="Hidden1" type="hidden"
+                                                         value="contact_form_recipient"> <input name="__redirectto" id="Hidden2"
+                                                                                               type="hidden"
+                                                                                               value="/form/thank-you">
+            <input name="__splitFields" type="hidden" value="describe_yourself,your_question_is_about">
+            <div class="row">
+                <div class="medium-4 columns"><label for="a__from" class="inline">E-mail address:*</label></div>
+                <div class="medium-8 columns"><input id="a__from" name="__from" type="text" maxlength="60"></div>
+            </div>
+            <div class="row">
+                <div class="medium-4 columns"><label for="a__email_confirm" class="inline">Enter e-mail address again to
+                    confirm:*</label></div>
+                <div class="medium-8 columns"><input id="a__email_confirm" name="__email_confirm" type="text" maxlength="60">
+                </div>
+            </div>
+            <div class="row">
+                <div class="medium-4 columns"><label for="a__zipcode" class="inline">Zip code (if U.S. resident):</label></div>
+                <div class="medium-8 columns"><input id="a__zipcode" name="your_zipcode" type="text" maxlength="5"></div>
+            </div>
+            <div class="row">
+                <div class="medium-4 columns"><label for="a__country" class="inline">Country (if outside the U.S.):</label>
+                </div>
+                <div class="medium-8 columns"><input id="a__country" name="your_country" type="text" maxlength="100"></div>
+            </div>
+            <div class="row">
+                <div class="medium-4 columns"><label for="a__subject" class="inline">Enter the subject of your e-mail:</label>
+                </div>
+                <div class="medium-8 columns"><input id="a__subject" name="__subject" type="text" maxlength="50"></div>
+            </div>
+            <div class="row">
+                <div class="medium-4 columns"><label for="message" class="inline"> Message<br> (please limit your message to
+                    2,000 characters):* </label></div>
+                <div class="medium-8 columns"><textarea id="message" name="Message" rows="10"></textarea>
+                    <p>Should your message require a response, you may expect one within 5 business days.</p></div>
+            </div>
+            <div class="row">
+                <div class="medium-8 columns right">    <!-- Recaptcha set up -->
+                    <script src='https://www.google.com/recaptcha/api.js' async defer></script>
+                    <div class='g-recaptcha' data-sitekey='6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI'></div>
+                </div>
+            </div>
+            <div class="row vertical-space">
+                <div class="medium-8 right columns">
+                    <button type="submit" class="submit button">Submit</button>
+                    <button type="reset" class="reset button">Clear</button>
+                </div>
+            </div>
+        </form> <p>* Required field</p> <p><a href="/policies/privacy-security#email">Privacy Policy on E-mail Messages Sent to
+            the NCI Web Site</a></p>
+        <div class="callout-box" id="omb-control" tabindex="0"><p>Public reporting burden for this collection of information is
+            estimated to average 10 minutes per response, including the time for reviewing instructions, searching existing data
+            sources, gathering and maintaining the data needed, and completing and reviewing the collection of information. An
+            agency may not conduct or sponsor, and a person is not required to respond to, a collection of information unless it
+            displays a currently valid OMB control number. Send comments regarding this burden estimate or any other aspect of
+            this collection of information, including suggestions for reducing this burden, to: NIH, Project Clearance Branch,
+            6705 Rockledge Drive, MSC 7974, Bethesda, MD 20892-7974, ATTN: PRA (0925-0208). Do not return the completed form to
+            this address.</p></div>
+  field_raw_html__ES:
+    - format: "raw_html"
+      value: |
+        <!-- function validateEmail() -->
+        <script language="javascript" type="text/javascript">  function validateEmail() {
+            var email = "not valid email";
+            var saywhat = '';
+            var theresponse = '';
+            if (document.contactNCI.__from.value === '') {
+                saywhat += "Por favor escriba una dirección de correo electrónica válida: (p.ej. xxxxx@xxxxx.com).\n";
+            } else {
+                theresponse = '';
+                theresponse += CheckEmail(document.contactNCI.__from.value);
+                if (theresponse !== '') {
+                    saywhat += theresponse;
+                } else {
+                    email = document.contactNCI.__from.value;
+                }
+            }
+            if (document.contactNCI.__email_confirm.value === '') {
+                saywhat += "Por favor escriba un correo electrónico de confirmación válido.\n";
+            }
+            if (email !== document.contactNCI.__email_confirm.value) {
+                saywhat += "Por favor asegúrese de que ambas direcciones de correo electrónico sean las mismas.\n";
+            }
+            if (document.contactNCI.Message.value === '') {
+                saywhat += "Por favor escriba un mensaje.\n";
+            }
+            if (email === document.contactNCI.__email_confirm.value && document.contactNCI.Message.value !== '') {
+                if (document.contactNCI.__subject.value.indexOf('Cancer.gov Inquiry - ') === -1) {
+                    document.contactNCI.__subject.value = 'Cancer.gov Inquiry - ' + document.contactNCI.__subject.value;
+                }
+            }
+            if (saywhat !== '') {
+                alert(saywhat);
+                return false;
+            }
+            return true;
+        }
+
+        function CheckEmail(strng) {
+            var error = '';
+            var emailFilter = /^.+@.+\..{2,3}$/;
+            if (!(emailFilter.test(strng))) {
+                error = "Por favor escriba una dirección de correo electrónica válida.\n";
+            } else {
+                var illegalChars = /[\(\)\,\;\:\\\"\[\]]/;
+                if (strng.match(illegalChars)) {
+                    error = "Por favor escriba una dirección de correo electrónica válida.\n";
+                }
+            }
+            return error;
+        } </script>
+        <div class="callout-box-right"> OMB NO: 0925-0208<br> FECHA DE VENCIMIENTO: 30 de noviembre de 2021<br> <a
+                href="#omb-control">Declaración de tiempo estimado</a></div>  <p>Para comunicarse con el Instituto Nacional del
+            C&aacute;ncer (NCI), s&iacute;rvase llenar este formulario. Sus respuestas nos ayudar&aacute;n a darle la informaci&oacute;n
+            m&aacute;s &uacute;til posible. La informaci&oacute;n personal ser&aacute; considerada confidencial y se utilizar&aacute;
+            solamente para responder a sus preguntas.</p> <p>NOTA: La información que se suministra a través del Servicio de
+            Información sobre el Cáncer del NCI no sustituye las recomendaciones de su médico personal. <strong>Por favor no
+                envíe ni añada fotos o reportes médicos.</strong> Si necesita consejos médicos, por favor consulte a su
+            proveedor de atención médica.</p>
+        <div class="callout-box"> &iquest;Preferir&iacute;a hablar con uno de nuestros especialistas en informaci&oacute;n sobre
+            el c&aacute;ncer?<br> <b>1-800-4-CANCER (1-800-422-6237)</b><br> 9 a.m. a 9 p.m. hora del Este de EE. UU., lunes a
+            viernes
+        </div>  <!-- end function validateEmail() -->
+        <form action="/FormEmailer" id="Form1" method="post" name="contactNCI" class="email-us-form"
+              onsubmit="return(validateEmail());"><input name="__recipient" id="Hidden1" type="hidden"
+                                                         value="es_contact_form_recipient"> <input name="__redirectto"
+                                                                                                  id="Hidden2" type="hidden"
+                                                                                                  value="/form/thank-you">
+            <input name="__splitFields" type="hidden" value="describe_yourself,your_question_is_about">
+            <div class="row">
+                <div class="medium-4 columns"><label for="a__from" class="inline">Direcci&oacute;n de correo electr&oacute;nico:*</label>
+                </div>
+                <div class="medium-8 columns"><input id="a__from" name="__from" type="text" maxlength="60"></div>
+            </div>
+            <div class="row">
+                <div class="medium-4 columns"><label for="a__email_confirm" class="inline">Repita su direcci&oacute;n de correo
+                    electr&oacute;nico para confirmarla:*</label></div>
+                <div class="medium-8 columns"><input id="a__email_confirm" name="__email_confirm" type="text" maxlength="60">
+                </div>
+            </div>
+            <div class="row">
+                <div class="medium-4 columns"><label for="a__zipcode" class="inline">C&oacute;digo postal (si reside en Estados
+                    Unidos):</label></div>
+                <div class="medium-8 columns"><input id="a__zipcode" name="your_zipcode" type="text" maxlength="5"></div>
+            </div>
+            <div class="row">
+                <div class="medium-4 columns"><label for="a__country" class="inline">Pa&iacute;s (si reside fuera de Estados
+                    Unidos):</label></div>
+                <div class="medium-8 columns"><input id="a__country" name="your_country" type="text" maxlength="30"></div>
+            </div>
+            <div class="row">
+                <div class="medium-4 columns"><label for="a__subject" class="inline">Tema de su correo
+                    electr&oacute;nico:</label></div>
+                <div class="medium-8 columns"><input id="a__subject" name="__subject" type="text" maxlength="50"></div>
+            </div>
+            <div class="row">
+                <div class="medium-4 columns"><label for="message" class="inline"> Mensaje<br> (por favor limite su mensaje a
+                    2000 caracteres):* </label></div>
+                <div class="medium-8 columns"><textarea id="message" name="Message" rows="10"></textarea>
+                    <p>Si su mensaje requiere de una respuesta, espere recibirla en cinco d&iacute;as laborales.</p></div>
+            </div>
+            <div class="row">
+                <div class="medium-8 columns right">    <!-- Recaptcha set up -->
+                    <script src='https://www.google.com/recaptcha/api.js' async defer></script>
+                    <div class='g-recaptcha' data-sitekey='6LePCSkTAAAAAP_Eqe83x8ohu-Tb9Chk3TBhFhY7'></div>
+                </div>
+            </div>
+            <div class="row vertical-space">
+                <div class="medium-8 right columns">
+                    <button type="submit" class="submit button">Enviar</button>
+                    <button type="reset" class="reset button">Borrar</button>
+                </div>
+            </div>
+        </form>  <p>* Campo obligatorio</p> <p><a href="/espanol/global/politicas/confidencialidad">Pol&iacute;tica de
+            confidencialidad sobre correos electr&oacute;nicos enviados al sitio web del Instituto Nacional del
+            C&aacute;ncer</a></p>
+        <div class="callout-box" id="omb-control" tabindex="0"><p>Se calcula que la carga p&uacute;blica para suministrar esta
+            informaci&oacute;n es en promedio de 10 minutos por respuesta, e incluye el tiempo para leer las instrucciones,
+            revisar las fuentes de informaci&oacute;n existentes, recopilar y mantener los datos necesarios, y concluir y
+            revisar la informaci&oacute;n recogida. Ninguna agencia puede realizar ni patrocinar la recolecci&oacute;n de
+            informaci&oacute;n, y no se requiere que ninguna persona responda a tal recolecci&oacute;n de informaci&oacute;n, a
+            menos que &eacute;sta tenga un n&uacute;mero de control OMB v&aacute;lido vigente. Env&iacute;e sus comentarios
+            acerca de esta carga estimada o sobre cualquier otro aspecto de esta recolecci&oacute;n de informaci&oacute;n y sus
+            sugerencias para reducir el tiempo invertido en esta tarea a: NIH, Project Clearance Branch, 6705 Rockledge Drive,
+            MSC 7974, Bethesda, MD 20892-7974, ATTN: PRA (0925-0208). No env&iacute;e el formulario completo a esta direcci&oacute;n.</p>
+        </div>
+######
+- entity: "node"
+  type: "cgov_article"
+  title: "Contact Us E-mail Form"
+  title__ES:
+    value: "Contact Us E-mail Form - Spanish"
+  langcode: en
+  status: 1
+  moderation_state:
+    value: 'published'
+  field_site_section:
+    - '#process':
+        callback: 'reference'
+        args:
+          - 'taxonomy_term'
+          - vid: 'cgov_site_sections'
+            computed_path: '/contact'
+  field_pretty_url:
+    value: 'email-us'
+  field_site_section__ES:
+    - '#process':
+        callback: 'reference'
+        args:
+          - 'taxonomy_term'
+          - vid: 'cgov_site_sections'
+            computed_path: '/espanol/contactenos'
+  field_pretty_url__ES:
+    value: 'correo-electronico'
+  field_article_body:
+    - entity: 'paragraph'
+      type: "body_section"
+      field_body_section_content:
+        - value: |
+          format: "full_html"
+  field_article_body__ES:
+    - entity: 'paragraph'
+      type: "body_section"
+      field_body_section_content:
+        - format: "full_html"
+          value: |
+
+  field_browser_title:
+    value: "Contact Us"
+  field_browser_title__ES:
+    value: "Contact Us - Spanish"
+  field_feature_card_description:
+    value: "Contact US "
+  field_feature_card_description__ES:
+    value: "Contact Us - Spanish"
+  field_card_title:
+    value: "Contact Us"
+  field_card_title__ES:
+    value: "Contact Us - Spanish"
+  field_date_display_mode:
+    - value: "reviewed"
+  field_list_description:
+  field_page_description:
+    value: "Contact us e-mail page."
+  field_page_description__ES:
+    value: "Información y consejos para controlar la anemia, un efecto secundario del tratamiento del cáncer."
+  field_date_posted:
+    value: "2020-02-01"
+  field_date_reviewed:
+    value: "2020-02-01"
+  field_date_updated:
+    value: "2020-02-01"

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/src/styles/_errorPage.scss
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/src/styles/_errorPage.scss
@@ -81,3 +81,50 @@
     }
   }
 }
+
+.error-page .error-content div {
+  padding: 0 0 10px;
+  -webkit-box-flex: 1;
+  -ms-flex: 1;
+  flex: 1
+}
+
+.error-page .error-content h1 {
+  font-size: 30px;
+  line-height: 35px;
+  margin-top: 1.4em
+}
+
+.error-page .error-content .error-content-english h1 {
+  color: #62539d
+}
+
+.error-page .error-content .error-content-spanish h1 {
+  color: #14819b
+}
+
+@media screen and (max-width: 767px) {
+  .error-page .error-content-spanish h1 {
+    margin-top: 0
+  }
+  .error-content div {
+    padding-bottom: 0
+  }
+  .error-searchbar {
+    display: block
+  }
+}
+
+@media screen and (min-width: 768px) {
+  .error-page .error-content {
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex
+  }
+  .error-page .error-content .error-content-english {
+    padding-right: 40px
+  }
+  .error-page .error-content .error-content-spanish {
+    padding-left: 40px
+  }
+}

--- a/docroot/sites/settings/cgov_core.settings.php
+++ b/docroot/sites/settings/cgov_core.settings.php
@@ -7,16 +7,16 @@
  * @see https://docs.acquia.com/site-factory/tiers/paas/workflow/hooks
  */
 
- /*
- * Set the translation path to allow for easy management of third-party
- * translation files. The installer ignores the path for the initial install,
- * but it will honor the use source. (It is here as configs will not be set
- * before the installation starts.)
- *
- * There is a known issue where the installer will not honor the override for the
- * path because it is hardcoded in the installer code.
- * https://www.drupal.org/project/drupal/issues/2689305
- */
+/*
+* Set the translation path to allow for easy management of third-party
+* translation files. The installer ignores the path for the initial install,
+* but it will honor the use source. (It is here as configs will not be set
+* before the installation starts.)
+*
+* There is a known issue where the installer will not honor the override for the
+* path because it is hardcoded in the installer code.
+* https://www.drupal.org/project/drupal/issues/2689305
+*/
 $config['locale.settings']['translation']['use_source'] = 'local';
 $config['locale.settings']['translation']['path'] = DRUPAL_ROOT . '/translations';
 
@@ -32,13 +32,44 @@ if ($is_acsf_env && $acsf_db_name) {
   $domains = gardens_data_get_sites_from_file($GLOBALS['gardens_site_settings']['conf']['acsf_db_name']);
   // Full disclosure, I don't know if the preferred_domain is always set.
   $domain = array_keys($domains)[0];
-  foreach($domains as $site_name => $site_info) {
+  foreach ($domains as $site_name => $site_info) {
     if (!empty($site_info['flags']['preferred_domain'])) {
       $domain = $site_name;
     }
   }
   $config['simple_sitemap.settings']['base_url'] = 'https://' . $domain;
-} else {
+}
+else {
   // NOTE: you can override this in your local.settings.php.
   $config['simple_sitemap.settings']['base_url'] = 'https://www.cancer.gov';
 }
+
+// If this is a local environment or non-production (01live) environment
+// route e-mails to the logger.
+if (file_exists('/var/www/site-php') && isset($_ENV['AH_SITE_ENVIRONMENT'])) {
+  // Alter '01dev,' '01test', and '01live' to match
+  // your website's environment names.
+  $env = $_ENV['AH_SITE_ENVIRONMENT'];
+  if (preg_match('/^ode\d*$/', $env)) {
+    $env = 'ode';
+  }
+  switch ($env) {
+    case '01live':
+      break;
+
+    case '01dev':
+    case 'dev':
+    case '01test':
+    case 'test':
+    case 'ode':
+    default:
+      $config['system.mail']['interface']['default'] = 'cgov_mail_logger';
+      break;
+  }
+}
+else {
+  $config['system.mail']['interface']['default'] = 'cgov_mail_logger';
+}
+// Outlook doesn't adhere to standards, so accommodating and using
+// CRLF line-endings.
+$settings['mail_line_endings'] = "\r\n";


### PR DESCRIPTION
* Adds and enables the cgov_mail module.
* Adds email-form.content.yml to cgov_yaml_content module.
* Creates a controller to handle e-mail forms.
* Enables the re-rerouting of e-mails to log on lower tiers.

Closes #2466


## Environment with email rerouting
**ODE:** http://ncigovcdode319.prod.acquia-sites.com
**Form:** http://ncigovcdode319.prod.acquia-sites.com/contact/email-us
**DB Log:** http://ncigovcdode319.prod.acquia-sites.com/admin/reports/dblog
**Configuration:** http://ncigovcdode319.prod.acquia-sites.com/admin/config/cgov_mail/settings

## Environment without email rerouting
**ODE:** http://ncigovcdode320.prod.acquia-sites.com
**Form:** http://ncigovcdode320.prod.acquia-sites.com/contact/email-us
**Configuration:** http://ncigovcdode320.prod.acquia-sites.com//admin/config/cgov_mail/settings

## Testing Notes

- On the ODE's e-mails have been received 30min+ after being sent. Please wait an appropriate amount of time before determining the e-mail hasn't sent.

- E-mails sent to our companies address are often either routed to Spam or blocked at the network level. For less headache when testing, route to a gmail or non-company email address. 

## General Notes:
   - The existing form redirects to "/PublishedContent/ErrorMessages/Thankyou.html" upon completion. This has been changed to the URL "/form/thank-you". This can be modified as needed.
       -  The thank you page itself is generated as part of the module and not managed in the CMS.

   - YAML content has been added to create the raw HTML email form content block, as well as the pages it lives on. However as the cgov_yaml_content module doesn't handle entity embeds, when testing, the content block must be manually inserted on the page.

   -  By default when testing, e-mails on the non-production tier will be routed to the environments database logs '/admin/reports/dblog'

   -  To enable email sending on lower tiers, email rerouting must be specifically disabled by a developer. The email address to send the contact form data to must be specified on the cgov_email configuration page. http://cgov.devbox/admin/config/cgov_mail/settings

   -  By default re-captcha (once the key in cgov_email configuration is set) is in developer mode and the google re-captcha service will always return a yes response. In production tiers the site and secret keys need to be updated as appropriate.
       -  Note: This may include adding additional acsf domains/sub-domains to googles re-captcha configuration.





## Dev Notes:


- By default lower tiers are set to use the cgov_mail_logger backend which routes email traffic to the db log. This is configured in a settings.php file. To enable testing and troubleshooting, the cgov mail logger has a flag/option to disable rerouting and use the default PHPMail backend.  

   - On the production tier, the mail backend is always left untouched as the default (PHPMail).

- On the local docker installation sendmail is not installed by default and must currently be manually added: apt-get update apt-get install sendmail /etc/init.d/sendmail start


- Within the ODE settings at times it may be helpful to specifically configure the sendmail options. Click the gear icon and paste something along the lines of :
 ` /usr/sbin/sendmail -t -i -f name@example.com`

Getting the current state of rerouting: 
`drush cget cgov_mail.settings enable-lower-tier-routing`

Disbale email re-rerouting: 
`drush cset cgov_mail.settings enable-lower-tier-routing 0`

- NOTE:  On local environments, blockage by the company of outgoing e-mails has been shown to occur at the network level sporadically. 


