### PR TITLE
(#2625) Add translations as a theme option.

### DIFF
--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/site-banner.content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/site-banner.content.yml
@@ -12,7 +12,7 @@
       value: |
         <div class="contentid-911584 slot-item only-SI nci-logo-pages large-12 columns">
           <a href="/"><img
-              src="https://www.cancer.gov/publishedcontent/images/images/design-elements/logos/nci-logo-full.__v1.svg"
+              src="/profiles/custom/cgov_site/themes/custom/cgov/static/images/design-elements/logos/nci-logo-full.svg"
               alt="National Cancer Institute" width="60%"></a>
           </div>
   field_raw_html__ES:
@@ -20,6 +20,6 @@
       value: |
         <div class="contentid-911584 slot-item only-SI nci-logo-pages large-12 columns">
           <a href="/"><img
-              src="https://www.cancer.gov/publishedcontent/images/images/design-elements/logos/nci-logo-full.__v1.svg"
+              src="/profiles/custom/cgov_site/themes/custom/cgov/static/images/design-elements/logos/nci-logo-full-es.svg"
               alt="National Cancer Institute" width="60%"></a>
           </div>

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/cgov_common.theme
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/cgov_common.theme
@@ -74,6 +74,11 @@ function cgov_common_theme_suggestions_field_alter(array &$suggestions, array $v
 function cgov_common_preprocess_html(&$variables) {
   $colorTheme = theme_get_setting('color_theme');
   $variables['attributes']['class'][] = $colorTheme . '-theme';
+
+  $hasTranslations = theme_get_setting('has_translations');
+  if ($hasTranslations){
+    $variables['attributes']['class'][] = 'has-translated-content';
+  }
 }
 
 /**

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/config/install/cgov_common.settings.yml
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/config/install/cgov_common.settings.yml
@@ -1,0 +1,11 @@
+features:
+  node_user_picture: false
+  comment_user_picture: true
+  comment_user_verification: true
+  favicon: 1
+logo:
+  use_default: 1
+favicon:
+  use_default: 1
+color_theme:
+has_translations: 1

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/config/schema/cgov_common.schema.yml
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/config/schema/cgov_common.schema.yml
@@ -1,0 +1,37 @@
+cgov_common.settings:
+  type: theme_settings
+  label: 'CGov Common settings'
+  mapping:
+    features:
+      type: config_object
+      mapping:
+        node_user_picture:
+          type: boolean
+          label: 'User pictures in posts'
+        comment_user_picture:
+          type: boolean
+          label: 'User pictures in comments'
+        comment_user_verification:
+          type: boolean
+          label: 'User verification status in comments'
+        favicon:
+          type: integer
+          label: 'Shortcut icon'
+    logo:
+      type: config_object
+      mapping:
+        use_default:
+          type: integer
+          label: 'Use the logo supplied by the theme'
+    favicon:
+      type: config_object
+      mapping:
+        use_default:
+          type: integer
+          label: 'Use the logo supplied by the theme'
+    color_theme:
+      type: string
+      label: 'Theme'
+    has_translations:
+      type: integer
+      label: 'Has Translations'

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/variants/blue/entrypoints/Blue.scss
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/variants/blue/entrypoints/Blue.scss
@@ -252,7 +252,7 @@ a.arrow-link:focus
       h3 {
         color: $default-link-color;
       }
-      
+
     }
   }
 }
@@ -280,9 +280,8 @@ h6 {
   background: $page-margin-background;
 }
 
-// language bar
-.columns.utility,
-.language-bar {
+// hidden elements
+.columns.utility {
   display: none;
 }
 
@@ -306,6 +305,16 @@ h6 {
 // overcoming foundation class that hides utility bar for mobile
 .utility-background.micro-a {
   display: block !important;
+}
+
+// language bar
+// Override colors from _language_bar.scss
+.language-bar {
+  background: #fff;
+}
+
+.sitewide-language a {
+  color: $denim;
 }
 
 // menu bar

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/variants/green/entrypoints/Green.scss
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/variants/green/entrypoints/Green.scss
@@ -279,9 +279,8 @@ h6 {
   background: $page-margin-background;
 }
 
-// language bar
-.columns.utility,
-.language-bar {
+// hidden elements
+.columns.utility {
   display: none;
 }
 
@@ -305,6 +304,16 @@ h6 {
 // overcoming foundation class that hides utility bar for mobile
 .utility-background.micro-a {
   display: block !important;
+}
+
+// language bar
+// Override colors from _language_bar.scss
+.language-bar {
+  background: #fff;
+}
+
+.sitewide-language a {
+  color: $ocean;
 }
 
 // menu bar
@@ -448,9 +457,9 @@ figure a.article-image-enlarge:hover {
   background-color: $content-view-button-hover-background;
 }
 
-// #2209: CR to update secondary feature styling 
+// #2209: CR to update secondary feature styling
 .feature-secondary {
-  .card { 
+  .card {
     background: $cloud;
   }
 

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/variants/purple/entrypoints/Purple.scss
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/variants/purple/entrypoints/Purple.scss
@@ -42,7 +42,7 @@ $bronze: #c78005;
 .contentzone h4 a,
 .contentzone h5 a,
 .contentzone h6 a,
-.main-content .feature-card a, 
+.main-content .feature-card a,
 ul.breadcrumbs>* a,
 .pullquote,
 .desktop #blog-archive-accordion .ui-accordion-header .toggle,
@@ -141,7 +141,6 @@ a.arrow-link:focus,
 }
 
 // hidden elements
-.language-bar,
 #microsite-a .utility {
   display: none;
 }
@@ -162,6 +161,15 @@ a.arrow-link:focus,
     padding-left: 5px;
     color: $asphalt;
   }
+}
+
+// language bar
+// Override colors from _language_bar.scss
+.language-bar {
+  background: #fff;
+}
+.sitewide-language a {
+  color: $ultra-violet;
 }
 
 // menu bar
@@ -469,7 +477,7 @@ form button[type="submit"]:hover {
   .section-nav .contains-current>div a {
     color: $iris;
   }
-  
+
   .section-nav .level-0.contains-current>div a {
     color: #fff;
   }

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/theme-settings.php
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/theme-settings.php
@@ -40,4 +40,18 @@ function cgov_common_form_system_theme_settings_alter(&$form) {
       // Add new theme names here. Value(key) should match folder name in /src/variants
     ],
   );
+  /* ------------ 'Has Translations' button ----------- */
+  $form['translations'] = array(
+    '#type' => 'details',
+    '#title' => ('Translations'),
+    '#collapsible' => TRUE,
+    '#collapsed' => FALSE,
+    '#open' => TRUE,
+  );
+  $form['translations']['has_translations'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Has Translations'),
+    '#description' => t('Does the site include translated content?'),
+    '#default_value' => theme_get_setting('has_translations'),
+  );
 }

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/src/styles/_language_bar.scss
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/src/styles/_language_bar.scss
@@ -3,6 +3,12 @@
   background-color: #fff;
   padding: 0 0 0.2em;
   min-height: 28px;
+  /* Default to hiding the language bar. */
+  display: none;
+}
+/* Make language bar visible when the has-translated-content class is present. */
+.has-translated-content .language-bar {
+  display: block;
 }
 .sitewide-language {
     padding-right: 0;


### PR DESCRIPTION
- Add has_translations as a theme setting.
- Modify CSS to control language bar visibility based
on has_translations setting.

Closes #2625 
Closes #2640