### PR TITLE
(#2620) Turn off floating delighter on Spanish  NCI-Connect pages

### DIFF
--- a/FrontendGlobals.json
+++ b/FrontendGlobals.json
@@ -3,6 +3,7 @@
     "en": "/policies/linking",
     "es": "/espanol/politicas/enlaces"
   },
+  "showFloatingDelighters": true,
   "environmentConfig": [],
   "ctsConfig": {
     "apiServer": "ctsproxy.cancer.gov",

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/libraries/floatingDelighter/README.md
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/libraries/floatingDelighter/README.md
@@ -10,11 +10,13 @@ Inject a floating delighter anchor element onto a page given a set of a rules fo
 
 New delighters should be defined in their own sub-directory in the delighters directory. Any custom css can be included through the new element file as well. A new element should consist of an exported object with the shape:
 
+```js
 {
     href: String,
     innerHTML: String,
     ?classList: String[]
 }
+```
 
 The href will be used to generate an anchor tag wrapping the innerHTML. The innerHTML should represent a string containing valid HTML that will be injected inside the anchor. The classList is an array of class names that will be added to the delighter container which will be inserted onto the page.
 
@@ -22,12 +24,13 @@ The href will be used to generate an anchor tag wrapping the innerHTML. The inne
 
 Adding a new rule is as simple as adding a new object to the rules array in rules.js. A new rule should have the shape:
 
+```js
 {
     rule: RegExp,
     delighter: Delighter,
     ?exclude: [ RegExp | { rule: RegExp, whitelist: String[] } ]
 }
-
+```
 
 ## Troubleshooting
 

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/libraries/floatingDelighter/rules.js
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/libraries/floatingDelighter/rules.js
@@ -1,3 +1,7 @@
+/**
+ * @file
+ */
+
 import {
     cts,
     socialMedia,
@@ -5,6 +9,8 @@ import {
 } from './delighters';
 
 /**
+ * Delighter configuration rules.
+ *
  * A rule is an object required to have a rule and delighter property. The third property exclude is optional. Exclude is an array of regular expressions and/or
  * objects containing a rule (regex) and whitelist (array) property.
  *
@@ -42,7 +48,8 @@ const rules = [
             /^\/rare-brain-spine-tumor\/about/i,
             /\/living\/finished-treatment/i,
             /\/living\/coping/i,
-            /\/living\/stories/i
+            /\/living\/stories/i,
+            /^\/rare-brain-spine-tumor\/espanol/i
         ]
     },
 ];


### PR DESCRIPTION
* Removes floating delighter for any path starting with /rare-brain-spine-tumor/espanol
* Enables delighters in default content.

Closes #2620 