### PR TITLE
(#2743) Fix typo in purge patch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -253,7 +253,7 @@
             },
             "drupal/purge": {
                 "2921309: Port purge_drush commands to Drush 9": "https://git.drupalcode.org/project/purge/commit/6f84e4ec96044408b5a54ec9e0d0201e7c9f063d.diff",
-                "3094343 : Garbled purge tag IDs": "https://www.drupal.org/files/issues/2020-04-01/issue-3094343.patch"
+                "3094343 : Garbled purge tag IDs": "https://www.drupal.org/files/issues/2020-04-06/purge-3094343.patch"
             },
             "drupal/memcache": {
                 "2997537 : Undefined method error on Statistics page": "https://www.drupal.org/files/issues/2018-09-05/memcache_undefined-2997537-3.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5f4e8c671a7164980a817716416739aa",
+    "content-hash": "067d8c52bddd01452cea3907116ebc6a",
     "packages": [
         {
             "name": "acquia/acsf-tools",
@@ -6111,7 +6111,7 @@
                 },
                 "patches_applied": {
                     "2921309: Port purge_drush commands to Drush 9": "https://git.drupalcode.org/project/purge/commit/6f84e4ec96044408b5a54ec9e0d0201e7c9f063d.diff",
-                    "3094343 : Garbled purge tag IDs": "https://www.drupal.org/files/issues/2020-04-01/issue-3094343.patch"
+                    "3094343 : Garbled purge tag IDs": "https://www.drupal.org/files/issues/2020-04-06/purge-3094343.patch"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",


### PR DESCRIPTION
Fix mismatch in variable name (`$values` -> `$vals`).

Fixes issue #2731 
Fixes issue #2743 