### PR TITLE
(#2746) Add missing 'use' statement for BltException class.

### DIFF
--- a/blt/src/Commands/UsersCommand.php
+++ b/blt/src/Commands/UsersCommand.php
@@ -3,6 +3,7 @@
 namespace Acquia\Blt\Custom\Commands;
 
 use Acquia\Blt\Robo\BltTasks;
+use Acquia\Blt\Robo\Exceptions\BltException;
 use Symfony\Component\Yaml\Yaml;
 
 /**


### PR DESCRIPTION
Closes #2746 