### PR TITLE
DO NOT MERGE -- (#2718) Render main navigation via Edge Side Includes when Akamai mod…

### DIFF
--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.module
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.module
@@ -640,7 +640,9 @@ function cgov_core_entity_build_defaults_alter(array &$build, EntityInterface $e
 function cgov_core_theme($existing, $type, $theme, $path) {
   $result = [
     'main_nav_esi' => [
-      'render element' => 'elements',
+      'variables' => [
+        'the_nav' => 'I got nothing',
+      ],
     ],
   ];
   return $result;
@@ -657,36 +659,14 @@ function cgov_core_theme($existing, $type, $theme, $path) {
 /**
  * Implements hook_theme_suggestions_HOOK().
  */
-// function cgov_core_theme_suggestions_main_nav_esi(array $variables) {
-//   $suggestions = [];
-//   $main_nav_esi_id = $variables['elements']['#main_nav_esi_id'];
-//   $main_nav_esi_plugin_id = $variables['elements']['#main_nav_esi_plugin_id'];
-//   $app_route_id = $variables['elements']['#app_route_id'];
+function cgov_core_theme_suggestions_main_nav_esi(array $variables) {
 
-//   // Just main_nav_esi to start.
-//   $suggestions[] = 'main_nav_esi';
+  if(\count($variables) >= 0) {
+    $suggestions = [];
 
-//   // Do the plugin.
-//   $suggestions[] = 'main_nav_esi__' . $main_nav_esi_plugin_id;
+    // Just main_nav_esi to start.
+    $suggestions[] = 'main_nav_esi';
 
-//   // Plugin + route.
-//   $suggestions[] = 'main_nav_esi__' .
-//     $main_nav_esi_plugin_id . '__' .
-//     $app_route_id;
-
-//   // App Module ID.
-//   $suggestions[] = 'main_nav_esi__' . $main_nav_esi_id;
-
-//   // App Module ID + plugin.
-//   $suggestions[] = 'main_nav_esi__' .
-//     $main_nav_esi_id . '__' .
-//     $main_nav_esi_plugin_id;
-
-//   // App Module ID + plugin + path.
-//   $suggestions[] = 'main_nav_esi__' .
-//     $main_nav_esi_id . '__' .
-//     $main_nav_esi_plugin_id . '__' .
-//     $app_route_id;
-
-//   return $suggestions;
-// }
+    return $suggestions;
+    }
+}

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.module
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.module
@@ -342,6 +342,22 @@ function cgov_core_theme_suggestions_entity_embed_container(array $variables) {
 }
 
 /**
+ * Implements hook_theme_suggestions_HOOK_alter().
+ *
+ * If we're working with the block containing the main navigation,
+ * and ESI processing was turned on in MainNav::build, then we
+ * need to override the default template with one which knows how to
+ * render the ESI tag in place of the navigation block.
+ */
+function cgov_core_theme_suggestions_block_alter(array &$suggestions, array $variables) {
+  if ($variables['elements']['#plugin_id'] == 'cgov_main_nav' &&
+    isset($variables['elements']['content']['ESI']) &&
+    $variables['elements']['content']['ESI'] == 'ON') {
+      $suggestions = ['block__cgov_main_nav_esi'];
+  }
+}
+
+/**
  * Implements hook_language_switch_links_alter().
  *
  * The default language switcher shows all links to content, including the

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.module
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.module
@@ -633,3 +633,60 @@ function cgov_core_entity_build_defaults_alter(array &$build, EntityInterface $e
     ];
   }
 }
+
+/**
+ * Implements hook_theme().
+ */
+function cgov_core_theme($existing, $type, $theme, $path) {
+  $result = [
+    'main_nav_esi' => [
+      'render element' => 'elements',
+    ],
+  ];
+  return $result;
+}
+
+/**
+ * Implements template_preprocess_HOOK().
+ */
+// function template_preprocess_main_nav_esi(&$variables) {
+//   $variables['foo'] = $variables['elements']['foo'];
+//   $variables['the_nav'] = $variables['elements']['the_nav'];
+// }
+
+/**
+ * Implements hook_theme_suggestions_HOOK().
+ */
+// function cgov_core_theme_suggestions_main_nav_esi(array $variables) {
+//   $suggestions = [];
+//   $main_nav_esi_id = $variables['elements']['#main_nav_esi_id'];
+//   $main_nav_esi_plugin_id = $variables['elements']['#main_nav_esi_plugin_id'];
+//   $app_route_id = $variables['elements']['#app_route_id'];
+
+//   // Just main_nav_esi to start.
+//   $suggestions[] = 'main_nav_esi';
+
+//   // Do the plugin.
+//   $suggestions[] = 'main_nav_esi__' . $main_nav_esi_plugin_id;
+
+//   // Plugin + route.
+//   $suggestions[] = 'main_nav_esi__' .
+//     $main_nav_esi_plugin_id . '__' .
+//     $app_route_id;
+
+//   // App Module ID.
+//   $suggestions[] = 'main_nav_esi__' . $main_nav_esi_id;
+
+//   // App Module ID + plugin.
+//   $suggestions[] = 'main_nav_esi__' .
+//     $main_nav_esi_id . '__' .
+//     $main_nav_esi_plugin_id;
+
+//   // App Module ID + plugin + path.
+//   $suggestions[] = 'main_nav_esi__' .
+//     $main_nav_esi_id . '__' .
+//     $main_nav_esi_plugin_id . '__' .
+//     $app_route_id;
+
+//   return $suggestions;
+// }

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.routing.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.routing.yml
@@ -20,3 +20,17 @@ cgov_core.frontend_globals_form:
     _title: 'FrontendGlobalsForm'
   requirements:
     _permission: 'administer frontend globals'
+
+cgov_core.block.navigation_block:
+  path: '/block/{block_id}'
+  defaults:
+    _controller: '\Drupal\cgov_core\Controller\CgovBlockController::getBlock'
+    _title: 'navigation block route'
+  methods: [GET]
+  requirements:
+    _permission: 'access content'
+    block_id: '[a-zA-Z0-9_\-]+'
+  options:
+    parameters:
+      block_id:
+        type: string

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.services.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.services.yml
@@ -53,3 +53,6 @@ services:
     class: Drupal\cgov_core\CgovConfigOverrider
     tags:
       - {name: config.factory.override, priority: 5}
+  cgov_core.navigation_block:
+    class: Drupal\cgov_core\Services\NavigationBlockManager
+    arguments: ['@cgov_core.cgov_navigation_manager','@language_manager', '@logger.channel.cgov_core']

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Controller/CgovBlockController.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Controller/CgovBlockController.php
@@ -3,7 +3,6 @@
 namespace Drupal\cgov_core\Controller;
 
 use Drupal\Core\Controller\ControllerBase;
-use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -62,10 +61,14 @@ class CgovBlockController extends ControllerBase {
     $navTree = $this->blockMgr->getNavigationBlock($block_id);
 
     if (strlen($navTree) > 0) {
-      $response = new Response();
-      $response->setContent($navTree);
-      $response->headers->set('Content-Type', 'text/plain');
-      return $response;
+      $result = [
+        '#markup' => $navTree,
+      ];
+      return $result;
+      // $response = new Response();
+      // $response->setContent($navTree);
+      // $response->headers->set('Content-Type', 'text/plain');
+      // return $response;
     }
 
     throw new NotFoundHttpException();

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Controller/CgovBlockController.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Controller/CgovBlockController.php
@@ -62,7 +62,9 @@ class CgovBlockController extends ControllerBase {
 
     if (strlen($navTree) > 0) {
       $result = [
-        '#markup' => $navTree,
+        '#theme' => 'main_nav_esi',
+        '#the_nav' => $navTree,
+        '#foo' => 'bar',
       ];
       return $result;
       // $response = new Response();

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Controller/CgovBlockController.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Controller/CgovBlockController.php
@@ -63,7 +63,7 @@ class CgovBlockController extends ControllerBase {
     if (strlen($navTree) > 0) {
       $result = [
         '#theme' => 'main_nav_esi',
-        '#the_nav' => $navTree,
+        '#narkup' => $navTree,
         '#foo' => 'bar',
       ];
       return $result;

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Controller/CgovBlockController.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Controller/CgovBlockController.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Drupal\cgov_core\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+use Drupal\cgov_core\Services\NavigationBlockManager;
+
+/**
+ * Controller for rendering navigation blocks.
+ */
+class CgovBlockController extends ControllerBase {
+
+  /**
+   * Cgov Navigation Manager Service.
+   *
+   * @var \Drupal\cgov_core\Services\NavigationBlockManager
+   */
+  protected $blockMgr;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getModuleName() {
+    return 'cgov_core';
+  }
+
+  /**
+   * Constructs an LanguageBar object.
+   *
+   * @param \Drupal\cgov_core\Services\NavigationBlockManager $navBlockManager
+   *   Cgov navigation service.
+   */
+  public function __construct(NavigationBlockManager $navBlockManager) {
+    $this->blockMgr = $navBlockManager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('cgov_core.navigation_block')
+    );
+  }
+
+  /**
+   * Gets the markup for a named navigation block.
+   *
+   * @param string $block_id
+   *   The navigation block to render.
+   */
+  public function getBlock(string $block_id = NULL) {
+
+    if ($block_id == NULL) {
+      throw new NotFoundHttpException();
+    }
+
+    $navTree = $this->blockMgr->getNavigationBlock($block_id);
+
+    if (strlen($navTree) > 0) {
+      $response = new Response();
+      $response->setContent($navTree);
+      $response->headers->set('Content-Type', 'text/plain');
+      return $response;
+    }
+
+    throw new NotFoundHttpException();
+  }
+
+}

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/NavItem.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/NavItem.php
@@ -306,7 +306,7 @@ class NavItem {
    * Optional, pass an array of class properties
    * with boolean values to filter children against.
    *
-   * @return \Drupal\cgov_core\NavItemInterface[]
+   * @return \Drupal\cgov_core\NavItem[]
    *   Filtered array of direct descendents.
    */
   public function getChildren() {

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Services/CgovNavigationManager.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Services/CgovNavigationManager.php
@@ -332,7 +332,7 @@ class CgovNavigationManager {
    * @param string $testFieldName
    *   Name of field to check for root status.
    *
-   * @return \Drupal\cgov_core\NavItemInterface|null
+   * @return \Drupal\cgov_core\NavItem|null
    *   Nav Item representing nav root term.
    */
   public function getNavRoot(string $testFieldName) {
@@ -354,7 +354,7 @@ class CgovNavigationManager {
    * @param \Drupal\taxonomy\TermInterface $term
    *   Base Term to wrap.
    *
-   * @return \Drupal\cgov_core\NavItemInterface
+   * @return \Drupal\cgov_core\NavItem
    *   Nav Item wrapping given Term.
    */
   public function newNavItem(TermInterface $term) {

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Services/NavigationBlockManager.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Services/NavigationBlockManager.php
@@ -1,0 +1,245 @@
+<?php
+
+namespace Drupal\cgov_core\Services;
+
+use Drupal\Core\Language\LanguageManagerInterface;
+use Psr\Log\LoggerInterface;
+
+use Drupal\cgov_core\NavItem;
+
+/**
+ * For working with navigation blocks.
+ */
+class NavigationBlockManager implements NavigationBlockManagerInterface {
+
+  const MOBILE_NAV_MAX_DEPTH = 3;
+
+  /**
+   * Cgov Navigation Manager Service.
+   *
+   * @var \Drupal\cgov_core\Services\CgovNavigationManager
+   */
+  private $navMgr;
+
+  /**
+   * Language manager, so we know what languages we're dealing with.
+   *
+   * @var Drupal\Core\Language\LanguageManagerInterface
+   */
+  private $languageManager;
+
+  /**
+   * Logger.
+   *
+   * @var \Psr\Log\LoggerInterface
+   */
+  protected $logger;
+
+  /**
+   * Mapping of block names to the methods which render them.
+   *
+   * Keys are the block names, and the values are the methods.
+   *
+   * @var string[]
+   */
+  private $blockMap = [
+    'cgov_main_nav' => 'getCgovMainNav',
+  ];
+
+  /**
+   * Constructs a new NavigationBlockManager instance.
+   *
+   * @param \Drupal\cgov_core\Services\CgovNavigationManager $navigationManager
+   *   Cgov navigation service.
+   * @param \Drupal\Core\Language\LanguageManagerInterface $languageManager
+   *   Language manager instance so we know what language(s) we're working with.
+   * @param \Psr\Log\LoggerInterface $logger
+   *   Logger.
+   */
+  public function __construct(
+    CgovNavigationManager $navigationManager,
+    LanguageManagerInterface $languageManager,
+    LoggerInterface $logger
+  ) {
+    $this->navMgr = $navigationManager;
+    $this->languageManager = $languageManager;
+    $this->logger = $logger;
+  }
+
+  /**
+   * Draw a navigation block.
+   *
+   * @param string $block_name
+   *   The name of the block to render.
+   */
+  public function getNavigationBlock(string $block_name) {
+
+    if (\array_key_exists($block_name, $this->blockMap)) {
+      $method = $this->blockMap[$block_name];
+      return $this->$method();
+    }
+    else {
+      $message = "Unknown block name '${block_name}.";
+      $this->logger->error($message);
+      throw new \UnexpectedValueException($message);
+    }
+  }
+
+  /**
+   * Draws the CancerGov Main navigation.
+   *
+   * @return string|void
+   *   String containing the navigation HTML.
+   */
+  protected function getCgovMainNav() {
+
+    $navRoot = $this->navMgr->getNavRoot('field_main_nav_root');
+    if ($navRoot) {
+      $renderTree = $this->renderMainNav($navRoot);
+      return $renderTree;
+    }
+  }
+
+  /**
+   * Generate Main Navigation Markup.
+   *
+   * @param \Drupal\cgov_core\NavItem $navRoot
+   *   Root NavItem.
+   *
+   * @return string
+   *   Markup as string.
+   */
+  public function renderMainNav(NavItem $navRoot) {
+    $megaNavRootItems = $navRoot->getChildren();
+    $filteredMegaNavRootItems = [];
+    foreach ($megaNavRootItems as $child) {
+      if (!$child->hasDisplayRule('hide_in_main_nav')) {
+        $filteredMegaNavRootItems[] = $child;
+      }
+    }
+    usort($filteredMegaNavRootItems, [$this, "sortItemsByWeight"]);
+    $renderedMegaNavTrees = [];
+    for ($i = 0; $i < count($filteredMegaNavRootItems); $i++) {
+      $rootItem = $filteredMegaNavRootItems[$i];
+      $itemIndex = $i + 1;
+      $href = $rootItem->getHref();
+      $label = $rootItem->getLabel();
+      $containsCurrent = $rootItem->getIsInCurrentPath();
+      $isCurrent = $rootItem->isCurrentSiteSection();
+      $currentStatusClassname = "";
+      if ($containsCurrent) {
+        $currentStatusClassname = "contains-current";
+      }
+      if ($isCurrent) {
+        $currentStatusClassname = "current-page";
+      }
+      $children = $this->renderMobileNavLevel($rootItem, $containsCurrent, 2);
+      $megamenu = $rootItem->getMegamenuContent();
+      $hasChildrenClassname = strlen($children) > 0 ? 'has-children' : '';
+      $markup = "
+      <li class='nav-item lvl-1 $hasChildrenClassname $currentStatusClassname item-$itemIndex'>
+        <div class='nav-item-title'>
+          <a href='$href'>$label</a>
+        </div>
+        $children
+        <div class='sub-nav-mega' aria-expanded='true' aria-haspopup='true'>
+          $megamenu
+        </div>
+      </li>
+      ";
+      $renderedMegaNavTrees[] = $markup;
+    }
+    $megaNav = implode("", $renderedMegaNavTrees);
+    return $megaNav;
+  }
+
+  /**
+   * Generate Mobile navtree markup.
+   *
+   * @param \Drupal\cgov_core\NavItem $rootItem
+   *   Root NavItem for mobile tree.
+   * @param bool $isOpen
+   *   Is this path expanded in the tree?
+   * @param int $currentDepth
+   *   Used to add class attributes and prevent
+   *   excessively deep rendering.
+   *
+   * @return string
+   *   Constructed markup as string.
+   */
+  public function renderMobileNavLevel(NavItem $rootItem, bool $isOpen, int $currentDepth) {
+    $isNotLastLevel = self::MOBILE_NAV_MAX_DEPTH - $currentDepth > 0;
+    $mobileItemsToRender = $rootItem->getChildren();
+    $filteredMobileItemsToRender = [];
+    foreach ($mobileItemsToRender as $child) {
+      if (!$child->hasDisplayRule('hide_in_mobile_nav')) {
+        $filteredMobileItemsToRender[] = $child;
+      }
+    }
+    $hasItemsToRender = count($filteredMobileItemsToRender);
+    if (!$hasItemsToRender) {
+      return "";
+    }
+    usort($filteredMobileItemsToRender, [$this, "sortItemsByWeight"]);
+    $renderedMobileItems = [];
+    foreach ($filteredMobileItemsToRender as $mobileItem) {
+      $href = $mobileItem->getHref();
+      $label = $mobileItem->getLabel();
+      $containsCurrent = $mobileItem->getIsInCurrentPath();
+      $isCurrent = $mobileItem->isCurrentSiteSection();
+      $currentStatusClassname = "";
+      $hasChildrenClassname = "";
+      if ($containsCurrent) {
+        $currentStatusClassname = "contains-current";
+      }
+      if ($isCurrent) {
+        $currentStatusClassname = "current-page";
+      }
+      $children = "";
+      if ($isNotLastLevel) {
+        $children = $this->renderMobileNavLevel($mobileItem, $containsCurrent, $currentDepth + 1);
+        $hasChildrenClassname = strlen($children) > 0 ? 'has-children' : '';
+      }
+      $markup = "
+      <li class='lvl-$currentDepth $currentStatusClassname $isCurrent $hasChildrenClassname'>
+        <div class='nav-item-title'>
+          <a href='$href'>$label</a>
+        </div>
+        $children
+      </li>
+      ";
+      $renderedMobileItems[] = $markup;
+    }
+    $renderedMobileItemString = implode("", $renderedMobileItems);
+    $markup = "
+    <ul class='mobile-item'>
+      $renderedMobileItemString
+    </ul>
+    ";
+    return $markup;
+  }
+
+  /**
+   * Generic sorting function to sort by Term weight.
+   *
+   * It's equivalent to reverse sort, since higher weights should
+   * appear first.
+   *
+   * @param \Drupal\cgov_core\NavItem $firstItem
+   *   Nav item.
+   * @param \Drupal\cgov_core\NavItem $secondItem
+   *   Nav item.
+   *
+   * @return int
+   *   Sort result.
+   */
+  public function sortItemsByWeight(NavItem $firstItem, NavItem $secondItem) {
+    $firstWeight = $firstItem->getWeight();
+    $secondWeight = $secondItem->getWeight();
+    if ($firstWeight === $secondWeight) {
+      return 0;
+    }
+    return ($firstWeight < $secondWeight) ? -1 : 1;
+  }
+
+}

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Services/NavigationBlockManager.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Services/NavigationBlockManager.php
@@ -137,16 +137,20 @@ class NavigationBlockManager implements NavigationBlockManagerInterface {
       $megamenu = $rootItem->getMegamenuContent();
       $hasChildrenClassname = strlen($children) > 0 ? 'has-children' : '';
       $markup = "
-      <li class='nav-item lvl-1 $hasChildrenClassname $currentStatusClassname item-$itemIndex'>
-        <div class='nav-item-title'>
-          <a href='$href'>$label</a>
-        </div>
-        $children
-        <div class='sub-nav-mega' aria-expanded='true' aria-haspopup='true'>
-          $megamenu
-        </div>
-      </li>
-      ";
+      <nav id='mega-nav' role='navigation'>
+        <ul class='menu nav-menu'>
+          <li class='nav-item lvl-1 $hasChildrenClassname $currentStatusClassname item-$itemIndex'>
+            <div class='nav-item-title'>
+              <a href='$href'>$label</a>
+            </div>
+            $children
+            <div class='sub-nav-mega' aria-expanded='true' aria-haspopup='true'>
+              $megamenu
+            </div>
+          </li>
+        </ul>
+      </nav>
+          ";
       $renderedMegaNavTrees[] = $markup;
     }
     $megaNav = implode("", $renderedMegaNavTrees);

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Services/NavigationBlockManagerInterface.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Services/NavigationBlockManagerInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Drupal\cgov_core\Services;
+
+/**
+ * Defines the interface for a class which renders navigation blocks.
+ */
+interface NavigationBlockManagerInterface {
+
+  /**
+   * Draw a navigation block.
+   *
+   * @param string $block_name
+   *   The name of the block to render.
+   */
+  public function getNavigationBlock(string $block_name);
+
+}

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/templates/main-nav-esi.html.twig
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/templates/main-nav-esi.html.twig
@@ -1,2 +1,2 @@
 Hi There!
-{{page}}
+{{the_nav}}

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/templates/main-nav-esi.html.twig
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/templates/main-nav-esi.html.twig
@@ -1,2 +1,8 @@
 Hi There!
 {{the_nav}}
+!erehT iH
+{#
+<div>
+	{{kint()}}
+</div> #}
+

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/templates/main-nav-esi.html.twig
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/templates/main-nav-esi.html.twig
@@ -1,0 +1,2 @@
+Hi There!
+{{page}}

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/block/main_nav/block--cgov-main-nav-esi.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/block/main_nav/block--cgov-main-nav-esi.html.twig
@@ -4,11 +4,7 @@
   and cgov_core_theme_suggestions_block_alter() in cgov_core.
 
   Variables (provided by MainNav::build())
+  * lang_path - language-specific path.  Empty for English.
   * block_id - the block being rendered
-  * ?????
 #}
-<nav id="mega-nav" role="navigation">
-  <ul class="menu nav-menu">
-    <esi:include src="https://www-int-ac.cancer.gov/{{ content.lang_path }}block/{{ content.block_id }}" />
-  </ul>
-</nav>
+<esi:include src="https://www-int-ac.cancer.gov/{{ content.lang_path }}block/{{ content.block_id }}" />

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/block/main_nav/block--cgov-main-nav-esi.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/block/main_nav/block--cgov-main-nav-esi.html.twig
@@ -1,0 +1,14 @@
+{#
+  This template contains a placerholder for when the MainNav block will be
+  added to the page via Akamai's ESI capability.  Refer to MainNav::build()
+  and cgov_core_theme_suggestions_block_alter() in cgov_core.
+
+  Variables (provided by MainNav::build())
+  * block_id - the block being rendered
+  * ?????
+#}
+<nav id="mega-nav" role="navigation">
+  <ul class="menu nav-menu">
+    <esi:include src="https://www-int-ac.cancer.gov/{{ content.lang_path }}block/{{ content.block_id }}" />
+  </ul>
+</nav>

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/block/main_nav/block--cgov-main-nav.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/block/main_nav/block--cgov-main-nav.html.twig
@@ -1,5 +1,4 @@
-<nav id="mega-nav" role="navigation">
-  <ul class="menu nav-menu">
-    {{ content }}
-  </ul>
-</nav>
+{#
+  Main navigation block, as set in the content object.
+#}
+{{ content }}

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/layout/hhhtml--block--cgov-main-nav.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/layout/hhhtml--block--cgov-main-nav.html.twig
@@ -1,3 +1,0 @@
-top
-{{ foo }}
-bottom

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/layout/hhhtml--block--cgov-main-nav.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/layout/hhhtml--block--cgov-main-nav.html.twig
@@ -1,0 +1,3 @@
+top
+{{ foo }}
+bottom

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/layout/html--block--cgov-main-nav.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/layout/html--block--cgov-main-nav.html.twig
@@ -1,1 +1,0 @@
-{{ page.content }}

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/layout/html--block--cgov-main-nav.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/layout/html--block--cgov-main-nav.html.twig
@@ -1,0 +1,1 @@
+{{ page.content }}

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/layout/html--block--cgov-main-nav.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/layout/html--block--cgov-main-nav.html.twig
@@ -1,0 +1,10 @@
+top
+{{ page.content.system_main }}
+
+
+
+<div>
+{{kint(page.content.system_main)}}
+
+</div>
+bottom


### PR DESCRIPTION
…ule is active..

- Move rendering of main navigation block to cgov_core.navigation_block service.
- Update documentation referring to non-existant NavItemInterface interface.
- Render the ESI tag via a specialized variant of the template for the cgov_main_nav block.
- Create controller to render main navigation.