### PR TITLE
(#2791) Update Adobe DTM config

### DIFF
--- a/docroot/profiles/custom/cgov_site/config/install/adobe_dtm.settings.yml
+++ b/docroot/profiles/custom/cgov_site/config/install/adobe_dtm.settings.yml
@@ -10,9 +10,9 @@ paths:
   - '/user/*/edit*'
   - '/user/*/cancel*'
 paths_negate: '1'
-connection_type: dtm
-launch_property_build_url: ''
-dtm_property_embed_code_id: f1bfa9f7170c81b1a9a9ecdcc6c5215ee0b03c84
-dtm_property_embed_code_hash: 8c356a9a11116b0b8550a4349b05bc801933186c
+connection_type: launch
+launch_property_build_url: //assets.adobedtm.com/6a4249cd0a2c/663bb44c2e69/launch-9ed25e181790.min.js
+dtm_property_embed_code_id: ''
+dtm_property_embed_code_hash: ''
 dtm_environment: production
 launch_property_async: false


### PR DESCRIPTION
- Updated Adobe DTM config to point to Extension Development Property

This is needed going forward now that Cancer.gov is using the new Event-Driven Data Layer analytics. 