### PR TITLE
(#2810, #2814, #2784) Multiple URL Management Updates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,12 +3,10 @@
     "description": "Project template for Drupal 8 projects with composer",
     "type": "project",
     "license": "GPL-2.0-or-later",
-    "authors": [
-        {
-            "name": "",
-            "role": ""
-        }
-    ],
+    "authors": [{
+        "name": "",
+        "role": ""
+    }],
     "repositories": {
         "0": {
             "type": "composer",
@@ -74,7 +72,7 @@
         "drupal/panels": "^4.3",
         "drupal/paragraphs": "^1.6",
         "drupal/paragraphs_asymmetric_translation_widgets": "^1.0",
-        "drupal/pathauto": "^1.3",
+        "drupal/pathauto": "^1.6",
         "drupal/redirect": "1.x-dev",
         "drupal/role_delegation": "^1.0",
         "drupal/seckit": "^1.1",
@@ -234,9 +232,6 @@
             "drupal/page_manager": {
                 "2820218 : Page manager does not respect existing route defaults for title callbacks": "https://www.drupal.org/files/issues/2018-03-21/2820218-50.patch",
                 "2876880 : page_variant entity type does not exist when installing or enabling": "https://www.drupal.org/files/issues/2876880-page-varient-cache-2.patch"
-            },
-            "drupal/pathauto": {
-                "3003373 : Wrong verbose messenger method": "https://www.drupal.org/files/issues/2018-09-30/3003373-2.patch"
             },
             "drupal/simplesamlphp_auth": {
                 "2907182: Admin UI Pages not Accessible via Permission": "https://www.drupal.org/files/issues/simplesamlphp_auth-admin_ui_pages-2907182-30.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ac60108b5416799e9049f2c352a3c7ea",
+    "content-hash": "1b9f76d24176f36ef6ce788d4c91e76b",
     "packages": [
         {
             "name": "acquia/acsf-tools",
@@ -5983,38 +5983,32 @@
         },
         {
             "name": "drupal/pathauto",
-            "version": "1.3.0",
+            "version": "1.6.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/pathauto.git",
-                "reference": "8.x-1.3"
+                "reference": "8.x-1.6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/pathauto-8.x-1.3.zip",
-                "reference": "8.x-1.3",
-                "shasum": "115d5998d7636a03e26c7ce34261b65809d53965"
+                "url": "https://ftp.drupal.org/files/projects/pathauto-8.x-1.6.zip",
+                "reference": "8.x-1.6",
+                "shasum": "eb976ae110d73c06fafb1b657adb967dd2cb8246"
             },
             "require": {
-                "drupal/core": "^8.5",
+                "drupal/core": "^8.6",
                 "drupal/ctools": "*",
                 "drupal/token": "*"
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
                 "drupal": {
-                    "version": "8.x-1.3",
-                    "datestamp": "1554239887",
+                    "version": "8.x-1.6",
+                    "datestamp": "1575467285",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
                     }
-                },
-                "patches_applied": {
-                    "3003373 : Wrong verbose messenger method": "https://www.drupal.org/files/issues/2018-09-30/3003373-2.patch"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -7349,12 +7343,12 @@
             "version": "0.9.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/njh/easyrdf.git",
+                "url": "https://github.com/easyrdf/easyrdf.git",
                 "reference": "acd09dfe0555fbcfa254291e433c45fdd4652566"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/njh/easyrdf/zipball/acd09dfe0555fbcfa254291e433c45fdd4652566",
+                "url": "https://api.github.com/repos/easyrdf/easyrdf/zipball/acd09dfe0555fbcfa254291e433c45fdd4652566",
                 "reference": "acd09dfe0555fbcfa254291e433c45fdd4652566",
                 "shasum": ""
             },
@@ -15792,17 +15786,6 @@
         {
             "name": "webflo/drupal-core-require-dev",
             "version": "8.7.13",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/webflo/drupal-core-require-dev.git",
-                "reference": "56eb5356cd7fd44a35856b5018265c5ff42fb521"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/webflo/drupal-core-require-dev/zipball/56eb5356cd7fd44a35856b5018265c5ff42fb521",
-                "reference": "56eb5356cd7fd44a35856b5018265c5ff42fb521",
-                "shasum": ""
-            },
             "require": {
                 "behat/mink": "1.7.x-dev",
                 "behat/mink-goutte-driver": "^1.2",
@@ -16276,17 +16259,6 @@
         {
             "name": "acquia/blt-require-dev",
             "version": "10.0.0-beta1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/acquia/blt-require-dev.git",
-                "reference": "85dfeac6a0b76de7a128b645ef31503c75ec9a40"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/acquia/blt-require-dev/zipball/85dfeac6a0b76de7a128b645ef31503c75ec9a40",
-                "reference": "85dfeac6a0b76de7a128b645ef31503c75ec9a40",
-                "shasum": ""
-            },
             "require": {
                 "behat/behat": ">=3.1 <3.4",
                 "bex/behat-screenshot": "^1.2",

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.install
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.install
@@ -136,6 +136,7 @@ function _cgov_core_install_permissions(CgovCoreTools $siteHelper) {
       'RSS publishing',
       'View plugins',
       'Field list report',
+      'regenerate urls',
     ],
   ];
 
@@ -235,4 +236,22 @@ function cgov_core_update_8003() {
     $installer = \Drupal::service('module_installer');
     $installer->install(['cgov_mail']);
   }
+}
+
+/**
+ * Update for Issue #2784.
+ *
+ * Adds regenerate urls to site admin role.
+ */
+function cgov_core_update_8004() {
+  // Get the helper service.
+  $siteHelper = \Drupal::service('cgov_core.tools');
+
+  $perms = [
+    'site_admin' => [
+      'regenerate urls',
+    ],
+  ];
+
+  $siteHelper->addRolePermissions($perms);
 }

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.links.menu.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.links.menu.yml
@@ -14,3 +14,10 @@ cgov_core.frontend_globals_form:
       class:
         - some-class
         - anotherclass
+cgov_core.regenerate_urls:
+  title: 'Regenerate Urls'
+  description: 'Regenerate Urls after a site section move'
+  parent: system.admin_config_search
+  route_name: pathauto.bulk.update.form
+  weight: 100
+  menu_name: system

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.permissions.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.permissions.yml
@@ -2,3 +2,7 @@ administer frontend globals:
   title: 'Administer Frontend Globals'
   description: 'Access to change frontend globals config'
   restrict access: true
+regenerate urls:
+  title: 'Regenerate Urls'
+  description: 'Access to get to pathautos Bulk generate screen'
+  restrict access: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.services.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.services.yml
@@ -53,3 +53,7 @@ services:
     class: Drupal\cgov_core\CgovConfigOverrider
     tags:
       - {name: config.factory.override, priority: 5}
+  cgov_core.route_subscriber:
+    class: Drupal\cgov_core\Routing\RouteSubscriber
+    tags:
+      - { name: event_subscriber }

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Routing/RouteSubscriber.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Routing/RouteSubscriber.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Drupal\cgov_core\Routing;
+
+use Drupal\Core\Routing\RouteSubscriberBase;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * Listens to the dynamic route events.
+ */
+class RouteSubscriber extends RouteSubscriberBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function alterRoutes(RouteCollection $collection) {
+    // Allow Site Admins to access the bulk update form for URLs. This
+    // is useful when a site section URL is changed and all the nodes
+    // and media under that URL need to be rebuilt.
+    // Why add a permission? The default permission 'administer url aliases'
+    // allows for dangerous activities we want to avoid. (e.g. bulk delete)
+    if ($route = $collection->get('pathauto.bulk.update.form')) {
+      $new_perm = 'regenerate urls';
+      $permission = $route->getRequirement('_permission');
+      $route->setRequirement(
+        '_permission',
+        ($permission ? $permission . '+' . $new_perm : $new_perm)
+      );
+    }
+  }
+
+}

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_site_section/cgov_site_section.tokens.inc
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_site_section/cgov_site_section.tokens.inc
@@ -54,17 +54,31 @@ function cgov_site_section_tokens($type, $tokens, array $data, array $options, B
         elseif (!empty($data['media'])) {
           $entity = $data['media'];
         }
+        else {
+          \Drupal::logger('cgov_site_section')
+            ->notice('Could not identify entity from data');
+          break;
+        }
 
         if (!empty($entity->get('field_site_section')->first())) {
           try {
             $tid = $entity->get('field_site_section')->first()->getValue()['target_id'];
-            $term = Term::load($tid);;
+            $term = Term::load($tid);
+            if (!$term) {
+              \Drupal::logger('cgov_site_section')
+                ->notice('Could not load the term for tid: ' . $tid . " for entity " . $entity->id());
+              break;
+            }
             $replacements[$original] = $term->get('computed_path')->value;
           }
           catch (Exception $e) {
             \Drupal::logger('cgov_site_section')
-              ->notice('Could not retrieve computed path for tid: ' . $tid);
+              ->notice('Error loading and getting the computed path for tid: ' . $tid . " for entity " . $entity->id());
           }
+        }
+        else {
+          \Drupal::logger('cgov_site_section')
+            ->notice('Entity has no site section, entity: ' . $entity->id());
         }
         break;
 


### PR DESCRIPTION
* (#2810) Update pathauto package to 1.6
   - This is to support the 8.9 upgrade
* (#2814) Fixed Error in URL Generation
   - There were a few conditions where is a term were deleted from the system and still had associated entities it would break all URL generation. Added guards and logging.
* (#2784) Expose Pathauto Bulk Generate
   - Allow site admins to rebuild aliases when they change site sections.

Closes #2810
Closes #2814
Closes #2784 