### PR TITLE
Hotfix: Spanish menu items not getting current page designation

### DIFF
--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/libraries/mainNav/mobilemenu.js
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/libraries/mainNav/mobilemenu.js
@@ -258,9 +258,11 @@ const markCurrent = () => {
     const nodeArray = Array.from(list.querySelectorAll(`.lvl-${linkDepth}`));
     for (let i = 0; i < nodeArray.length; i++) {
       const node = nodeArray[i];
+      //strip from item url so it's apples to apples
       const nodeLink = node
         .querySelector(".nav-item-title > a")
-        .getAttribute("href");
+        .getAttribute("href")
+        .replace("/espanol", "");
 
       if (nodeLink.indexOf(`/${activeLinkSlugs[linkDepth]}`) >= 0) {
         if (nodeLink === activeLinkPath) {


### PR DESCRIPTION
Update the mobile menu to handle spanish links correctly, adding .current-page instead of .contains-current

<img width="696" alt="Screen Shot 2020-08-07 at 4 20 39 PM" src="https://user-images.githubusercontent.com/45469809/89685255-fb0a3e00-d8c9-11ea-9f88-a32caac962e3.png">
