### PR TITLE
Bugfix: Video Carousel mobile/tablet controls

### DIFF
--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/src/libraries/videoCarousel/video-carousel.js
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/src/libraries/videoCarousel/video-carousel.js
@@ -212,21 +212,22 @@ function appendCarouselControls($this) {
         $next = 'siguiente';
     }
 
-    var $carouselControls = '<div class="row yt-carousel-controls">' +
-                            '<div class="yt-carousel-thumbs columns small-10"></div>' +
-                            '<div class="yt-carousel-arrows columns small-2">' +
-                                '<button class="previous" type="button" value="' + $prev + '" alt="' + $prev + '"></button>' +
-                                '<button class="next" type="button" value="'+ $next +'" alt="'+ $next +'"></button>' +
-                                '<div class="yt-carousel-pager" />' +
-                                '</div>' +
-                            '</div>';
-    var $mobileControls = '<div class="row yt-carousel-m-controls">' +
-                            '<div class="yt-carousel-m-pager columns small-9"></div>' +
-                            '<div class="yt-carousel-m-arrows columns small-3">' +
-                                '<button class="m-previous" type="button" value="' + $prev + '" alt="' + $prev + '"></button>' +
-                                '<button class="m-next" type="button" value="'+ $next +'" alt="'+ $next +'"></button>' +
-                            '</div>' +
-                            '</div>';
+      var $carouselControls = '<div class="row yt-carousel-controls">' +
+    '<div class="yt-carousel-thumbs columns small-10"></div>' +
+    '<div class="yt-carousel-arrows columns small-2">' +
+    '<button class="previous" type="button" value="' + $prev + '" aria-label="' + $prev + '"></button>' +
+    '<button class="next" type="button" value="' + $next + '" aria-label="' + $next + '"></button>' +
+    '<div class="yt-carousel-pager"></div>' +
+    "</div>" +
+    "</div>";
+  var $mobileControls = '<div class="row yt-carousel-m-controls">' +
+    '<div class="yt-carousel-m-pager columns small-9"></div>' +
+    '<div class="yt-carousel-m-arrows columns small-3">' +
+    '<button class="m-previous" type="button" value="' + $prev + '" aria-label="' + $prev + '"></button>' +
+    '<button class="m-next" type="button" value="' + $next + '" aria-label="' + $next + '"></button>' +
+    "</div>" +
+    "</div>";
+    
     $this.append($carouselControls + $mobileControls);
 }
 


### PR DESCRIPTION
Closes #2928 .

Fix for injected markup which was causing mobile controls for video carousel to be hidden.

**Issue:** Playlist controls for video carousel (playlist of more than 3 videos) were not appearing at mobile and tablet breakpoints with the updates from release v1.2.0

Also changed alt attribute on buttons to aria-label for proper labeling for accessibility

ODE for testing:
http://ncigovcdode392.prod.acquia-sites.com/about-cancer/coping/feelings
http://ncigovcdode392.prod.acquia-sites.com/test/video-carousel-controls