### PR TITLE
(#2989) Require HTTPS to access the site.

### DIFF
--- a/docroot/.htaccess
+++ b/docroot/.htaccess
@@ -115,19 +115,17 @@ AddEncoding gzip svgz
   # uncomment the following line:
   # RewriteBase /
 
+  # Redirect HTTP to HTTPS, but only on Acquia servers.
+  RewriteCond %{ENV:AH_SITE_ENVIRONMENT}  ^(.)+$
+  RewriteCond %{HTTP:X-Forwarded-Proto} !https
+  RewriteRule ^(.*)$ https://%{HTTP_HOST}%{REQUEST_URI} [L,R=301]
+
   # Return Status 403 (Forbidden) on non-ODE server access in the
   # Acquia cloud.
   RewriteCond %{ENV:AH_SITE_ENVIRONMENT} ^(.)+$
   RewriteCond %{HTTP_HOST} ^(.)+\.acquia-sites\.com$ [NC]
   RewriteCond %{ENV:AH_SITE_ENVIRONMENT} !^ode[0-9]+$ [NC]
   RewriteRule .* - [R=403]
-
-  # Redirect HTTP to HTTPS, but only on Acquia servers,and only
-  # for cancer.gov domains (non-HTTPS allowed for ODEs).
-  RewriteCond %{ENV:AH_SITE_ENVIRONMENT}  ^(.)+$
-  RewriteCond %{HTTP_HOST} ^(.)+\.cancer\.gov [nc]
-  RewriteCond %{HTTP:X-Forwarded-Proto} !https
-  RewriteRule ^(.*)$ https://%{HTTP_HOST}%{REQUEST_URI} [L,R=301]
 
   # Redirect common PHP files to their new locations.
   RewriteCond %{REQUEST_URI} ^(.*)?/(install.php) [OR]

--- a/patches/drupal-scaffold/htaccess.acsf.patch
+++ b/patches/drupal-scaffold/htaccess.acsf.patch
@@ -2,7 +2,7 @@ diff --git docroot/.htaccess docroot/.htaccess
 index 044ff1f3..971f754b 100644
 --- docroot/.htaccess
 +++ docroot/.htaccess
-@@ -159,6 +159,8 @@ AddEncoding gzip svgz
+@@ -157,6 +157,8 @@ AddEncoding gzip svgz
    # Copy and adapt this rule to directly execute PHP files in contributed or
    # custom modules or to run another PHP application in the same directory.
    RewriteCond %{REQUEST_URI} !/core/modules/statistics/statistics.php$

--- a/patches/drupal-scaffold/htaccess.hsts.patch
+++ b/patches/drupal-scaffold/htaccess.hsts.patch
@@ -2,7 +2,7 @@ diff --git docroot/.htaccess docroot/.htaccess
 index 55ba88ad..383dfb5a 100644
 --- docroot/.htaccess
 +++ docroot/.htaccess
-@@ -198,4 +198,6 @@ AddEncoding gzip svgz
+@@ -196,4 +196,6 @@ AddEncoding gzip svgz
    Header always set X-Content-Type-Options nosniff
    # Disable Proxy header, since it's an attack vector.
    RequestHeader unset Proxy

--- a/patches/drupal-scaffold/htaccess.https.patch
+++ b/patches/drupal-scaffold/htaccess.https.patch
@@ -2,23 +2,21 @@ diff --git docroot/.htaccess docroot/.htaccess
 index b2a1a29..0247fb0 100644
 --- docroot/.htaccess
 +++ docroot/.htaccess
-@@ -122,6 +122,20 @@ AddEncoding gzip svgz
+@@ -122,6 +122,18 @@ AddEncoding gzip svgz
    # uncomment the following line:
    # RewriteBase /
 
++  # Redirect HTTP to HTTPS, but only on Acquia servers.
++  RewriteCond %{ENV:AH_SITE_ENVIRONMENT}  ^(.)+$
++  RewriteCond %{HTTP:X-Forwarded-Proto} !https
++  RewriteRule ^(.*)$ https://%{HTTP_HOST}%{REQUEST_URI} [L,R=301]
++
 +  # Return Status 403 (Forbidden) on non-ODE server access in the
 +  # Acquia cloud.
 +  RewriteCond %{ENV:AH_SITE_ENVIRONMENT} ^(.)+$
 +  RewriteCond %{HTTP_HOST} ^(.)+\.acquia-sites\.com$ [NC]
 +  RewriteCond %{ENV:AH_SITE_ENVIRONMENT} !^ode[0-9]+$ [NC]
 +  RewriteRule .* - [R=403]
-+
-+  # Redirect HTTP to HTTPS, but only on Acquia servers,and only
-+  # for cancer.gov domains (non-HTTPS allowed for ODEs).
-+  RewriteCond %{ENV:AH_SITE_ENVIRONMENT}  ^(.)+$
-+  RewriteCond %{HTTP_HOST} ^(.)+\.cancer\.gov [nc]
-+  RewriteCond %{HTTP:X-Forwarded-Proto} !https
-+  RewriteRule ^(.*)$ https://%{HTTP_HOST}%{REQUEST_URI} [L,R=301]
 +
    # Redirect common PHP files to their new locations.
    RewriteCond %{REQUEST_URI} ^(.*)?/(install.php) [OR]


### PR DESCRIPTION
- Remove 403 for non HTTPS access attempt, simply redirect to HTTPS. This will enforce HTTPS in all environments, regardless of domain.
- Update line numbers for file offsets occuring after .htaccess.https.patch.

Close #2989 