### PR TITLE
Prune PDQ CIS revisions

### DIFF
--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/README.md
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/README.md
@@ -12,6 +12,9 @@ See [PDQ Content Design](../../../../../../../wiki/PDQ-Content-Design) in the pr
 ## Testing
 **NOTE:** General information about running tests and project structure can be found in the root [TESTING.md](../../../../../../../TESTING.md) file. Please refer to that before reading further.
 
+## Cleanup
+Use `drush pdq:drop-orphaned-summary-sections` to remove orphaned PDQ summary sections.
+
 ### Unit Tests
 
 ### Functional Tests

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/rest.resource.pdq_cis_api.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/rest.resource.pdq_cis_api.yml
@@ -11,6 +11,7 @@ granularity: resource
 configuration:
   methods:
     - GET
+    - PATCH
     - POST
   formats:
     - json

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/drush.services.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/drush.services.yml
@@ -1,0 +1,6 @@
+services:
+  pdq_cancer_information_summary.commands:
+    class: \Drupal\pdq_cancer_information_summary\Commands\OrphanCleanupCommands
+    arguments: ['@pdq_cancer_information_summary.orphan_cleanup']
+    tags:
+      - { name: drush.command }

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/pdq_cancer_information_summary.install
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/pdq_cancer_information_summary.install
@@ -24,7 +24,6 @@ function pdq_cancer_information_summary_install() {
 
   // Install permissions for this module.
   pdq_cancer_information_summary_install_permissions($siteHelper);
-
 }
 
 /**
@@ -40,9 +39,23 @@ function pdq_cancer_information_summary_install_permissions(CgovCoreTools $siteH
     ],
     'pdq_importer' => [
       'restful get pdq_cis_api',
+      'restful patch pdq_cis_api',
       'restful post pdq_cis_api',
     ],
   ];
 
+  $siteHelper->addRolePermissions($perms);
+}
+
+/**
+ * Add a new permission to the pdq_importer role.
+ */
+function pdq_cancer_information_summary_update_8001() {
+
+  // Get the helper service.
+  $siteHelper = \Drupal::service('cgov_core.tools');
+
+  // Install the new permission.
+  $perms = ['pdq_importer' => ['restful patch pdq_cis_api']];
   $siteHelper->addRolePermissions($perms);
 }

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/pdq_cancer_information_summary.services.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/pdq_cancer_information_summary.services.yml
@@ -1,0 +1,6 @@
+services:
+  pdq_cancer_information_summary.orphan_cleanup:
+    class: Drupal\pdq_cancer_information_summary\OrphanCleanup
+    arguments:
+      - '@entity_type.manager'
+      - '@database'

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/src/Commands/OrphanCleanupCommands.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/src/Commands/OrphanCleanupCommands.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Drupal\pdq_cancer_information_summary\Commands;
+
+use Drupal\pdq_cancer_information_summary\OrphanCleanup;
+use Drush\Commands\DrushCommands;
+
+/**
+ * Drush command for dropping orphaned PDQ summary sections.
+ *
+ * @package Drupal\cgov_cancer_information_summary\Commands
+ */
+class OrphanCleanupCommands extends DrushCommands {
+
+  /**
+   * Service for removing orphaned summary sections.
+   *
+   * @var \Drupal\pdq_cancer_information_summary\OrphanCleanup
+   */
+  protected $orphanCleanup;
+
+  /**
+   * OrphanCleanupCommands constructor.
+   */
+  public function __construct(OrphanCleanup $orphan_cleanup) {
+    $this->orphanCleanup = $orphan_cleanup;
+  }
+
+  /**
+   * Delete orphaned PDQ summary sections.
+   *
+   * @param array $options
+   *   An associative array of options whose values come from cli, aliases,
+   *   config, etc.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   * @option max_deletions
+   *   Restrict number of deletions to MAX_DELETIONS (default is 1000).
+   *   When all the revisions for a given entity are orphaned, the deletion
+   *   of the entity is counted as a single deletion. For revisions in
+   *   entities which also have revisions which are not orphans, each deleted
+   *   revision is counted separately.
+   * @usage drush pdq:drop-orphaned-summary-sections
+   *   Perform at most 1000 deletions of orphaned summary sections.
+   * @usage drush pdq:drop-orphaned-summary-sections --max_deletions=20
+   *   Perform at most 20 deletions of orphaned summary sections.
+   *
+   * @command pdq:drop-orphaned-summary-sections
+   */
+  public function cleanup(array $options = ['max_deletions' => self::REQ]) {
+    $max_deletions = $options['max_deletions'];
+    if (!is_numeric($max_deletions)) {
+      $max = 1000;
+    }
+    else {
+      $max = (int) $max_deletions;
+    }
+    $message = 'performing at most !n deletions';
+    $this->logger()->info(dt($message, ['!n' => $max]));
+    $dropped = $this->orphanCleanup->dropOrphanedSummarySections($max);
+    $pids = array_keys($dropped);
+    if (empty($pids)) {
+      $this->logger()->success(dt('No orphaned summary sections found.'));
+    }
+    else {
+      sort($pids, SORT_NUMERIC);
+      $total = 0;
+      foreach ($pids as $pid) {
+        $vids = $dropped[$pid];
+        sort($vids);
+        $message = 'Dropped orphaned revisions !vids for entity !pid';
+        $context = ['!pid' => $pid, '!vids' => implode(',', $vids)];
+        $this->logger()->notice(dt($message, $context));
+        $total += count($vids);
+      }
+      $message = 'Dropped !total revisions for !entities entities';
+      $context = ['!total' => $total, '!entities' => count($pids)];
+      $this->logger()->success(dt($message, $context));
+    }
+  }
+
+}

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/src/OrphanCleanup.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/src/OrphanCleanup.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Drupal\pdq_cancer_information_summary;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Database\Connection;
+
+/**
+ * Service for clearing out orphan summary sections.
+ *
+ * @package Drupal\pdq_cancer_information_summary
+ */
+class OrphanCleanup {
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * The database connection used to find orphaned summary sections.
+   *
+   * @var \Drupal\Core\Database\Connection
+   */
+  protected $connection;
+
+  /**
+   * Constructs an OrphanCleanup object.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   * @param \Drupal\Core\Database\Connection $connection
+   *   The database connection which will be used to find orphans.
+   */
+  public function __construct(
+    EntityTypeManagerInterface $entity_type_manager,
+    Connection $connection
+  ) {
+    $this->entityTypeManager = $entity_type_manager;
+    $this->connection = $connection;
+  }
+
+  /**
+   * Drop orphaned PDQ summary sections.
+   *
+   * Identify `paragraph` entities of type `pdq_summary_section` for which at
+   * least some of the revisions no longer have (or never had) a parent node.
+   * If all of such an entity's revisions are orphans, delete the entire
+   * entity. Otherwise, delete only revisions which are orphaned. Perform as
+   * many complete entity deletions as are requested by the caller, if that
+   * many are eligible for deletion, counting each entity as a single deletion,
+   * regardless of how many revisions the entity has. If there are fewer
+   * entities eligible for deletion than the number of deletions requested,
+   * perform the remaining number of deletions on individual orphaned revisions
+   * from `paragraph` entities which have some non-orphaned revisions (or as
+   * many such revisions as are eligible for deletion). It is not an error to
+   * perform fewer deletions than requested. If no maximum number of deletions
+   * is specified by the caller, delete all orphans found.
+   *
+   * @param int $max_deletions
+   *   Optional throttle on the number of deletions to be performed.
+   *
+   * @return array
+   *   Nested arrays of revision IDs indexed by the IDs of the entities in
+   *   which the orphaned revisions were found.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   */
+  public function dropOrphanedSummarySections($max_deletions = 0) {
+
+    // Find orphaned paragraph entities.
+    $storage = $this->entityTypeManager->getStorage('paragraph');
+    $query = $this->connection->select('paragraphs_item', 'p');
+    $query->fields('p', ['id']);
+    $query->condition('p.type', 'pdq_summary_section');
+    $query->distinct();
+    $query->leftJoin(
+      'node_revision__field_summary_sections',
+      's',
+      's.field_summary_sections_target_id = p.id'
+    );
+    $query->isNull('s.entity_id');
+    if ($max_deletions > 0) {
+      $query->range(0, $max_deletions);
+    }
+    $results = $query->execute();
+    $dropped = [];
+    foreach ($results as $result) {
+      $paragraph_id = $result->id;
+      $revision_ids = $this->connection
+        ->select('paragraphs_item_revision', 'r')
+        ->fields('r', ['revision_id'])
+        ->distinct()
+        ->condition('r.id', $paragraph_id)
+        ->execute()
+        ->fetchCol();
+      foreach ($revision_ids as $revision_id) {
+        $dropped[$paragraph_id][] = (int) $revision_id;
+      }
+      $entity = $storage->load($paragraph_id);
+      $entity->delete();
+    }
+
+    // If appropriate, find individual orphaned revisions.
+    if (empty($max_deletions) || count($dropped) < $max_deletions) {
+      $query = $this->connection->select('paragraphs_item_revision', 'r');
+      $query->fields('r', ['id', 'revision_id']);
+      $query->distinct();
+      $query->join('paragraphs_item', 'p', 'p.id = r.id');
+      $query->condition('p.type', 'pdq_summary_section');
+      $query->leftJoin(
+        'node_revision__field_summary_sections',
+        's',
+        's.field_summary_sections_target_revision_id = r.revision_id'
+      );
+      $query->isNull('s.entity_id');
+      if (!empty($max_deletions)) {
+        $remaining = $max_deletions - count($dropped);
+        $query->range(0, $remaining);
+      }
+      $results = $query->execute();
+      foreach ($results as $result) {
+        $entity = $storage->load($paragraph_id);
+        $storage->deleteRevision($result->revision_id);
+        $dropped[$result->id][] = (int) $result->revision_id;
+      }
+    }
+
+    return $dropped;
+  }
+
+}

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_core/README.md
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_core/README.md
@@ -83,3 +83,8 @@ deleted, the node is kept with the English summary.
 Each content type has its own set of APIs for retrieving (`GET`) and
 storing (`POST`) PDQ content. Consult the documentation for each content
 type's module for details.
+
+## Cleanup
+Use `drush pdq:prune-summary-revisions` to remove older revisions of PDQ
+content, in order to free up space.
+

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_core/config/install/rest.resource.pdq_api.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_core/config/install/rest.resource.pdq_api.yml
@@ -13,6 +13,7 @@ configuration:
     - GET
     - POST
     - DELETE
+    - PATCH
   formats:
     - json
   authentication:

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_core/drush.services.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_core/drush.services.yml
@@ -1,0 +1,6 @@
+services:
+  pdq_core.commands:
+    class: \Drupal\pdq_core\Commands\RevisionPrunerCommands
+    arguments: ['@entity_type.manager', '@pdq_core.revision_pruner']
+    tags:
+      - { name: drush.command }

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_core/pdq_core.install
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_core/pdq_core.install
@@ -36,7 +36,6 @@ function pdq_core_install() {
 
   // Install permissions for this module.
   pdq_core_install_permissions($siteHelper);
-
 }
 
 /**
@@ -53,6 +52,7 @@ function pdq_core_install_permissions(CgovCoreTools $siteHelper) {
     'pdq_importer' => [
       'restful delete pdq_api',
       'restful get pdq_api',
+      'restful patch pdq_api',
       'restful post pdq_api',
       'use pdq_workflow transition create_new_draft',
       'use pdq_workflow transition publish',
@@ -60,5 +60,19 @@ function pdq_core_install_permissions(CgovCoreTools $siteHelper) {
     ],
   ];
 
+  $siteHelper->addRolePermissions($perms);
+}
+
+
+/**
+ * Add a new permission to the pdq_importer role.
+ */
+function pdq_core_update_8001() {
+
+  // Get the helper service.
+  $siteHelper = \Drupal::service('cgov_core.tools');
+
+  // Install the new permission.
+  $perms = ['pdq_importer' => ['restful patch pdq_api']];
   $siteHelper->addRolePermissions($perms);
 }

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_core/pdq_core.services.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_core/pdq_core.services.yml
@@ -1,4 +1,8 @@
 services:
+  pdq_core.revision_pruner:
+    class: Drupal\pdq_core\RevisionPruner
+    arguments:
+      - '@entity_type.manager'
   pdq_core.config_overrider:
     class: Drupal\pdq_core\PDQConfigOverrider
     tags:

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_core/src/Commands/RevisionPrunerCommands.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_core/src/Commands/RevisionPrunerCommands.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Drupal\pdq_core\Commands;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\pdq_core\RevisionPruner;
+use Drush\Commands\DrushCommands;
+use Drush\Utils\StringUtils;
+
+/**
+ * Drush command for pruning older node revisions.
+ *
+ * @package Drupal\cgov_core\Commands
+ */
+class RevisionPrunerCommands extends DrushCommands {
+
+  /**
+   * Storage manager for entities.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * Service for paring back the number of older revisions retained.
+   *
+   * @var \Drupal\pdq_core\RevisionPruner
+   */
+  protected $revisionPruner;
+
+  /**
+   * RevisionPrunerCommands constructor.
+   */
+  public function __construct(EntityTypeManagerInterface $manager, RevisionPruner $pruner) {
+    $this->entityTypeManager = $manager;
+    $this->revisionPruner = $pruner;
+  }
+
+  /**
+   * Delete older revisions of PDQ content nodes.
+   *
+   * @param string $ids
+   *   A comma-delimited list of IDs of nodes to be pruned.
+   * @param array $options
+   *   An associative array of options whose values come from cli, aliases,
+   *   config, etc.
+   * @option bundle
+   *   Prune all nodes of specified bundle. Ignored when ids are specified.
+   *   Only pdq_cancer_information_summary and pdq_drug_information_summary
+   *   nodes are supported.
+   * @option keep
+   *   Number of per-language revisions to preserve for each node
+   *   (default is 3).
+   * @usage drush pdq:prune-node-revisions --bundle=pdq_cancer_information_summary
+   *   Prune older revisions for all nodes of type
+   *   pdq_cancer_information_summary.
+   * @usage drush pdq:prune-node-revisions 960,1187
+   *   Prune older revisions for nodes 960 and 1187.
+   *
+   * @command pdq:prune-node-revisions
+   * @aliases rprune
+   * @throws \Exception
+   */
+  public function prune($ids = '', array $options = ['bundle' => self::REQ, 'keep' => self::REQ]) {
+    $keep = $options['keep'];
+    if (!is_numeric($keep)) {
+      $keep = 3;
+    }
+    else {
+      $keep = (int) $keep;
+    }
+    $message = 'keeping at most !revs revisions per language for each node';
+    $this->logger()->info(dt($message, ['!revs' => $keep]));
+    $nids = StringUtils::csvToArray($ids);
+    if (empty($nids)) {
+      $bundle = $options['bundle'];
+      if (!empty($bundle)) {
+        $supported = [
+          'pdq_cancer_information_summary',
+          'pdq_drug_information_summary',
+        ];
+        if (!in_array($bundle, $supported)) {
+          $message = 'bundle !b not supported';
+          $this->logger()->error(dt($message, ['!b' => $bundle]));
+          return;
+        }
+        $storage = $this->entityTypeManager->getStorage('node');
+        $query = $storage->getQuery();
+        $query->condition('type', $bundle);
+        $nids = $query->execute();
+      }
+    }
+    if (empty($nids)) {
+      $this->logger()->success(dt('No nodes to be pruned.'));
+    }
+    else {
+      $total = 0;
+      $message = 'Dropped !dropped revisions for node !nid';
+      foreach ($nids as $nid) {
+        $dropped = $this->revisionPruner->dropOldRevisions($nid, $keep);
+        $context = ['!dropped' => count($dropped), '!nid' => $nid];
+        $this->logger()->notice(dt($message, $context));
+        $total += count($dropped);
+      }
+      $message = 'Pruned !revisions revisions from !nodes nodes';
+      $context = ['!revisions' => $total, '!nodes' => count($nids)];
+      $this->logger()->success(dt($message, $context));
+    }
+  }
+
+}

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_core/src/RevisionPruner.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_core/src/RevisionPruner.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Drupal\pdq_core;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+
+/**
+ * Service for removing unwanted older revisions of PDQ content.
+ *
+ * @package Drupal\pdq_core
+ */
+class RevisionPruner {
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * Constructs a RevisionPruner object.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager) {
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * Discard older revisions of a specified node.
+   *
+   * Identify the most recent published revisions for each language found in
+   * the node and retain those revisions, deleting the others. The number of
+   * per-language revisions to preserve defaults to 3 but can be overridden
+   * by the optional second parameter.
+   *
+   * @param int $nid
+   *   Unique identifier for the node whose revisions are to be pruned.
+   * @param int $keep
+   *   Number of revisions to preserve for each language in the node.
+   *
+   * @return array
+   *   List of IDs for deleted revisions.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   */
+  public function dropOldRevisions($nid, $keep = 3) {
+    $storage = $this->entityTypeManager->getStorage('node');
+    $node = $storage->load($nid);
+    $vids = $storage->revisionIds($node);
+    sort($vids, SORT_NUMERIC);
+    $vids = array_reverse($vids);
+    $languages = array_keys($node->getTranslationLanguages());
+    $kept = [];
+    $dropped = [];
+    foreach ($languages as $langcode) {
+      $kept[$langcode] = 0;
+    }
+    foreach ($vids as $vid) {
+      $wanted = FALSE;
+      $revision = $storage->loadRevision($vid);
+      foreach ($languages as $langcode) {
+        if ($kept[$langcode] < $keep) {
+          if ($revision->hasTranslation($langcode)) {
+            $translation = $revision->getTranslation($langcode);
+            if ($translation->isRevisionTranslationAffected()) {
+              if ($translation->isPublished()) {
+                $wanted = TRUE;
+                $kept[$langcode]++;
+              }
+            }
+          }
+        }
+      }
+      if (!$wanted) {
+        $storage->deleteRevision($vid);
+        $dropped[] = (int) $vid;
+      }
+    }
+    return $dropped;
+  }
+
+}

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_core/tests/src/Kernel/CleanupTest.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_core/tests/src/Kernel/CleanupTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Drupal\Tests\pdq_core\Kernel;
+
+use CgovPlatform\Tests\CgovSchemaExclusions;
+use Drupal\KernelTests\Core\Entity\EntityKernelTestBase;
+use Drupal\language\Entity\ConfigurableLanguage;
+use Drupal\node\Entity\NodeType;
+use Drupal\node\Entity\Node;
+
+/**
+ * Verify that the PDQ content cleanup works as advertised (issue #2815).
+ *
+ * @group cgov
+ * @group cgov_site
+ */
+class CleanupTest extends EntityKernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static $modules = ['node', 'language', 'block_content', 'pdq_core'];
+
+  /**
+   * Use our own profile instead of one from the standard distribution.
+   *
+   * @var string
+   */
+  protected $profile = 'cgov_site';
+
+  /**
+   * {@inheritdoc}
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  protected function setUp() {
+    static::$configSchemaCheckerExclusions =
+      CgovSchemaExclusions::$configSchemaCheckerExclusions;
+    parent::setUp();
+    $type = NodeType::create(['type' => 'test', 'name' => 'test']);
+    $type->save();
+    $this->installSchema('node', 'node_access');
+    $this->installEntitySchema('block_content');
+    ConfigurableLanguage::createFromLangcode('es')->save();
+  }
+
+  /**
+   * Test pruning of older revisions.
+   */
+  public function testPruneOldRevisions() {
+    $admin = $this->drupalCreateUser([], 'Zeus', TRUE);
+    $this->setCurrentUser($admin);
+    $uid = \Drupal::currentUser()->id();
+    $node = Node::create([
+      'title' => 'Sam and Janet Evening',
+      'type' => 'test',
+      'uid' => $uid,
+      'language' => 'en',
+    ]);
+    $node->save();
+    $nid = $node->id();
+    $drop = [$node->getRevisionId()];
+    $node = $node->addTranslation('es');
+    $node->setTitle('No necesitamos insignias apestosas');
+    $node->setNewRevision(TRUE);
+    $node->save();
+    $drop[] = $node->getRevisionId();
+    $languages = ['en', 'es'];
+    $storage = $this->entityTypeManager->getStorage('node');
+    $pub_revisions_to_create = 10;
+    $pub_revisions_to_keep = 3;
+    $keep = [];
+    for ($i = 0; $i < $pub_revisions_to_create; ++$i) {
+      foreach ($languages as $langcode) {
+        $node = $node->getTranslation($langcode);
+        $node->setPublished(FALSE);
+        $node->setNewRevision(TRUE);
+        $node->save();
+        $drop[] = $node->getRevisionId();
+        $node->setPublished(TRUE);
+        $node->setNewRevision(TRUE);
+        $node->save();
+        if ($i < $pub_revisions_to_create - $pub_revisions_to_keep) {
+          $drop[] = $node->getRevisionId();
+        }
+        else {
+          $keep[] = $node->getRevisionId();
+        }
+      }
+    }
+    $pruner = \Drupal::service('pdq_core.revision_pruner');
+    $dropped = $pruner->dropOldRevisions($nid, $pub_revisions_to_keep);
+    $this->assertCount(count($drop), $dropped);
+    foreach ($dropped as $vid) {
+      $this->assertContains($vid, $drop);
+    }
+    $kept = $storage->revisionIds($node);
+    $this->assertCount(count($keep), $kept);
+    foreach ($kept as $vid) {
+      $this->assertContains($vid, $keep);
+    }
+  }
+
+}

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_drug_information_summary/src/Plugin/rest/resource/PDQResource.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_drug_information_summary/src/Plugin/rest/resource/PDQResource.php
@@ -110,7 +110,7 @@ class PDQResource extends ResourceBase {
 
     // Make sure the client gave us something to look for.
     if (!$id) {
-      throw new BadRequestHttpException($this->t('No ID was provided'));
+      throw new BadRequestHttpException('No ID was provided');
     }
 
     // We got a node ID, so return the corresponding node's values.
@@ -207,6 +207,12 @@ class PDQResource extends ResourceBase {
     // nodes published in a separate pass after they've all been
     // stored, in order to minimize the window of time during which
     // older versions exist alongside newer.
+    // There is a long-standing bug in Drupal core, which fails to
+    // set the correct revision creation time and user for new
+    // revisions, so we do it here.
+    // See https://github.com/NCIOCPL/cgov-digital-platform/issues/2630.
+    $node->setRevisionCreationTime(\time());
+    $node->setRevisionUserId($this->currentUser->id());
     $node->moderation_state->value = 'draft';
     $node->save();
     $verb = empty($nid) ? 'Created' : 'Updated';


### PR DESCRIPTION
Addresses some of the issues raised by #2815 but not necessarily all of them (so not using the magic "closes" phrase for that ticket in this comment). Also takes care of #2630.

Adds:
* new service to identify and remove older PDQ content node revisions
* new service to drop orphaned summary section paragraph entities/revisions
* new `drush` commands to use the new services
* new REST API endpoints
* new phpunit tests
* correct revision timestamp and user

Closes #2630