### PR TITLE
Disable legacy glossary and sitewide search app modules

### DIFF
--- a/docroot/modules/custom/cgov_glossary/cgov_glossary.install
+++ b/docroot/modules/custom/cgov_glossary/cgov_glossary.install
@@ -1,0 +1,15 @@
+<?php
+
+use Drupal\app_module\Entity\AppModule;
+
+function cgov_glossary_uninstall() {
+
+  $storage = \Drupal::service('app_module.app_path_storage');
+  $paths = $storage->load(['app_module_id' => 'cgov_glossary_app']);
+  if($paths) {
+    $storage->delete(['app_module_id' => 'cgov_glossary_app']);
+  }
+
+  $app_module = AppModule::load('cgov_glossary_app');
+  $app_module->delete();
+}

--- a/docroot/modules/custom/cgov_sitewide_search/cgov_sitewide_search.install
+++ b/docroot/modules/custom/cgov_sitewide_search/cgov_sitewide_search.install
@@ -1,0 +1,15 @@
+<?php
+
+use Drupal\app_module\Entity\AppModule;
+
+function cgov_sitewide_search_uninstall() {
+
+  $storage = \Drupal::service('app_module.app_path_storage');
+  $paths = $storage->load(['app_module_id' => 'cgov_sitewide_search_app']);
+  if($paths) {
+    $storage->delete(['app_module_id' => 'cgov_sitewide_search_app']);
+  }
+
+  $app_module = AppModule::load('cgov_sitewide_search_app');
+  $app_module->delete();
+}

--- a/docroot/profiles/custom/cgov_site/cgov_site.info.yml
+++ b/docroot/profiles/custom/cgov_site/cgov_site.info.yml
@@ -78,7 +78,6 @@ install:
   - cgov_list
   - cgov_promo
   - cgov_cts
-  - cgov_glossary
   - cgov_r4r
   - cgov_sitewide_search
   - cgov_application_page

--- a/docroot/profiles/custom/cgov_site/cgov_site.info.yml
+++ b/docroot/profiles/custom/cgov_site/cgov_site.info.yml
@@ -79,7 +79,6 @@ install:
   - cgov_promo
   - cgov_cts
   - cgov_r4r
-  - cgov_sitewide_search
   - cgov_application_page
   - cgov_article
   - cgov_blog

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_application_page/cgov_application_page.install
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_application_page/cgov_application_page.install
@@ -92,3 +92,23 @@ function cgov_application_page_update_8006() {
     $installer->install(['cgov_js_app_module']);
   }
 }
+
+/**
+ * Disable the drupal-based Glossary module.
+ */
+function cgov_application_page_update_8007() {
+  if (\Drupal::moduleHandler()->moduleExists('cgov_glossary')) {
+    $installer = \Drupal::service('module_installer');
+    $installer->uninstall(['cgov_glossary'], FALSE);
+  }
+}
+
+/**
+ * Disable the drupal-based Sitewide Search module.
+ */
+function cgov_application_page_update_8008() {
+  if (\Drupal::moduleHandler()->moduleExists('cgov_sitewide_search')) {
+    $installer = \Drupal::service('module_installer');
+    $installer->uninstall(['cgov_sitewide_search'], FALSE);
+  }
+}


### PR DESCRIPTION
Two-fer.

#3022 Disables the legacy Glossary App module.
#3021 Disables the legacy Site Wide Search App module.

Closes #3022 
Closes #3021 
