### PR TITLE
(#3089) CgovCoreTools is incorrectly referencing the Exception class

### DIFF
--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/CgovCoreTools.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/CgovCoreTools.php
@@ -487,7 +487,7 @@ class CgovCoreTools {
    */
   public function filterAccessForDependantEntity(ContentEntityInterface $entity, $field_name) {
     if (!$entity->hasField($field_name)) {
-      throw new Exception($field_name . " does not exist on entity");
+      throw new \Exception($field_name . " does not exist on entity");
     }
 
     $dependant = $entity->get($field_name)->entity;


### PR DESCRIPTION


http://ncigovcdode425.prod.acquia-sites.com

Closes: #3089 

Fixed - The CgovCoreTools is incorrectly referencing the exception class.