### PR TITLE
(#3104) Remove image deletion for image managers when an image is pub…

### DIFF
--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_image/cgov_image.module
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_image/cgov_image.module
@@ -9,6 +9,20 @@ use Drupal\crop\Entity\Crop;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 use Drupal\file\Entity\File;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\Access\AccessResult;
+
+/**
+ * Implements hook_ENTITY_TYPE_access().
+ *
+ */
+function cgov_image_media_access(EntityInterface $entity, $operation, AccountInterface $account) {
+  if ($entity->bundle() == 'cgov_image' || $entity->bundle() == 'cgov_contextual_image') {
+    if (in_array('image_manager', $account->getRoles()) && $entity->isPublished() && $operation == 'delete') {
+   	  return AccessResult::forbidden();
+	  }
+  }
+}
 
 /**
  * Implements hook_ENTITY_TYPE_view().


### PR DESCRIPTION
…lished

Closes : #3104 

Removed the permissions for the image manager to delete the image or contextual image if it was published.