### PR TITLE
(#3126) Update twig_field_value module to 2.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -87,7 +87,7 @@
         "drupal/simplesamlphp_auth": "3.0",
         "drupal/token": "^1.6",
         "drupal/token_filter": "^1.1",
-        "drupal/twig_field_value": "^1.2",
+        "drupal/twig_field_value": "^2.0",
         "drupal/twig_tweak": "^2.1",
         "drupal/viewsreference": "^2.0-beta2",
         "drupal/yaml_content": "^1.0-alpha7",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8b726d7afe78238f7e0afeb1d1796440",
+    "content-hash": "984e42a5ee9eb2cd39f5ac6a029038e0",
     "packages": [
         {
             "name": "acquia/acsf-tools",
@@ -7558,26 +7558,26 @@
         },
         {
             "name": "drupal/twig_field_value",
-            "version": "1.2.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/twig_field_value.git",
-                "reference": "8.x-1.2"
+                "reference": "2.0.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/twig_field_value-8.x-1.2.zip",
-                "reference": "8.x-1.2",
-                "shasum": "dd5bfb64bc455ca262b3bdc6b489fdb08b2b8538"
+                "url": "https://ftp.drupal.org/files/projects/twig_field_value-2.0.0.zip",
+                "reference": "2.0.0",
+                "shasum": "d2d0db6249493542bf9d568970f67d10ce143f90"
             },
             "require": {
-                "drupal/core": "~8.0"
+                "drupal/core": "^8 || ^9"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-1.2",
-                    "datestamp": "1549817580",
+                    "version": "2.0.0",
+                    "datestamp": "1587069998",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"


### PR DESCRIPTION
On the host machine:
```
composer require drupal/twig_field_value:^2.0
composer update drupal/twig_field_value --with-dependencies
```
In the docker container (rebuilding the front end since twig controls rendering templates for the front end):
```
drush updatedb
drush cache:rebuild
blt --no-interaction cgov:rebuild-feq
blt tests:phpunit:run
```
Looking at the front-end pages, I don't see any anomalies in the display.

Closes #3126.