### PR TITLE
(#3120) Update admin_toolbar module to version 3.0.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
         "drupal/acquia_purge": "^1.0@beta",
         "drupal/acsf": "^2.67",
         "drupal/address": "~1.0",
-        "drupal/admin_toolbar": "^1.25",
+        "drupal/admin_toolbar": "^3.0",
         "drupal/adobe_dtm": "dev-8.x-1.x",
         "drupal/akamai": "3.x-dev@dev",
         "drupal/config_perms": "^2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8b726d7afe78238f7e0afeb1d1796440",
+    "content-hash": "e0c1251ad66c9e1d8565b41162ddea66",
     "packages": [
         {
             "name": "acquia/acsf-tools",
@@ -4117,26 +4117,29 @@
         },
         {
             "name": "drupal/admin_toolbar",
-            "version": "1.27.0",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/admin_toolbar.git",
-                "reference": "8.x-1.27"
+                "reference": "3.0.2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/admin_toolbar-8.x-1.27.zip",
-                "reference": "8.x-1.27",
-                "shasum": "fed1fbbdf8f805b1da63d73e7e2c54750f354d61"
+                "url": "https://ftp.drupal.org/files/projects/admin_toolbar-3.0.2.zip",
+                "reference": "3.0.2",
+                "shasum": "a3b7a8030695d0c1d49ec57786321e2dd142184a"
             },
             "require": {
-                "drupal/core": "^8"
+                "drupal/core": "^8.8.0 || ^9.0"
+            },
+            "require-dev": {
+                "drupal/admin_toolbar_tools": "*"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-1.27",
-                    "datestamp": "1558553350",
+                    "version": "3.0.2",
+                    "datestamp": "1629907124",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -4145,7 +4148,7 @@
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
             "license": [
-                "GPL-2.0+"
+                "GPL-2.0-or-later"
             ],
             "authors": [
                 {
@@ -4189,7 +4192,7 @@
                 "Toolbar"
             ],
             "support": {
-                "source": "http://cgit.drupalcode.org/admin_toolbar",
+                "source": "https://git.drupalcode.org/project/admin_toolbar",
                 "issues": "https://www.drupal.org/project/issues/admin_toolbar"
             }
         },


### PR DESCRIPTION
On the host machine:
```
composer require drupal/admin_toolbar:^3.0
composer update drupal/admin_toolbar --with-dependencies
```
In the docker container:
```
drush updatedb -y
drush cache:rebuild
blt custom:paratest:run
drush pm:list | grep admin_toolbar
```

Reviewed the admin toolbar and didn't see anything suspicious. I'm not a heavy CMS user, though, so others might pick up on changes I've missed.

Closes #3120