### PR TITLE
(#3121) Create new Adobe Launch module

### DIFF
--- a/docroot/modules/custom/cgov_adobe/cgov_adobe.info.yml
+++ b/docroot/modules/custom/cgov_adobe/cgov_adobe.info.yml
@@ -1,0 +1,7 @@
+name: 'Application Module'
+type: module
+package: 'Application Support'
+description: 'Support for embedding applications on nodes and other routable entities'
+core: 8.x
+# dependencies:
+#  - drupal:toolbar

--- a/docroot/modules/custom/cgov_adobe/cgov_adobe.links.menu.yml
+++ b/docroot/modules/custom/cgov_adobe/cgov_adobe.links.menu.yml
@@ -1,0 +1,5 @@
+cgov_adobe.settings_form:
+  title: 'Cgov Adobe'
+  description: 'Configure the integration with Adobe Launch and the web site.'
+  route_name: cgov_adobe.settings_form
+  parent: system.admin_config_system

--- a/docroot/modules/custom/cgov_adobe/cgov_adobe.module
+++ b/docroot/modules/custom/cgov_adobe/cgov_adobe.module
@@ -1,0 +1,164 @@
+<?php
+
+/**
+ * @file
+ * Contains cgov_adobe.module.
+ *
+ * This is heavily borrowed from drupal/adobe_dtm, which does not support
+ * D9, and has a lot of extra features we do not need. So we needed to
+ * implement tag management for our needs in order to get to D9.
+ *
+ * NOTE: We do not support async, and will only implement it when we have
+ * the need for it. (Since we can't really test async right now)
+ */
+
+use Drupal\Core\Routing\RouteMatchInterface;
+
+/**
+ * Implements hook_help().
+ */
+function cgov_adobe_help($route_name, RouteMatchInterface $route_match) {
+  $output = '';
+
+  switch ($route_name) {
+    // Main module help for the Cgov Adobe module.
+    case 'cgov_adobe.settings_form':
+    case 'help.page.cgov_adobe':
+      $output .= '<h3>' . t('About') . '</h3>';
+      $output .= '<p>' . t("This Adobe module allows the use of Adobe Systems' Launch to insert new tags into platform sites.") . '</p>';
+      break;
+  }
+
+  return $output;
+}
+
+/**
+ * Implements hook_module_implements_alter().
+ */
+function cgov_adobe_module_implements_alter(&$implementations, $hook) {
+  // This makes sure our page bottom attachment is the last to fire, and
+  // thus the last elements before the closing </body> tag.
+  $hooks = ['page_attachments', 'page_bottom'];
+
+  if (in_array($hook, $hooks)) {
+    $group = $implementations['cgov_adobe'];
+    unset($implementations['cgov_adobe']);
+    $implementations['cgov_adobe'] = $group;
+  }
+}
+
+/**
+ * Implements hook_page_attachments().
+ */
+function cgov_adobe_page_attachments(&$attachments) {
+  $cgov_adobe_attachments = &drupal_static('cgov_adobe_attachments');
+
+  if (is_null($cgov_adobe_attachments)) {
+    if ($embed_code = _cgov_adobe_embed_code_tag_array()) {
+      // Add embed code.
+      $attachments['#attached']['html_head'][] = $embed_code;
+    }
+  }
+  // Add cache tags to any pages so that when the config is updated,
+  // then the Drupal cache will clear. This is added to all pages
+  // when this module is enabled as we can change the paths that
+  // are allowed or disallowed.
+  $attachments['#cache']['tags'][] = 'config:cgov_adobe.settings';
+}
+
+/**
+ * Implements hook_page_bottom().
+ */
+function cgov_adobe_page_bottom(array &$page_bottom) {
+  // If we would add a script tag to the head, then add to
+  // the bottom as well.
+  if (_cgov_adobe_embed_code_tag_array()) {
+    $page_bottom['cgov_adobe'] = [
+      '#type'       => 'html_tag',
+      '#tag'        => 'script',
+      '#value'      => '_satellite.pageBottom();',
+      '#attributes' => [
+        'id'         => 'cgov-adobe-bottom',
+        'type' => 'text/javascript',
+      ],
+    ];
+  }
+}
+
+/**
+ * Determines whether Launch tags should be added or not, based on path settings.
+ *
+ * @return bool
+ *   TRUE if script should be add to the current path, otherwise FALSE.
+ */
+function _cgov_adobe_path_check() {
+  static $result;
+
+  if (!isset($result)) {
+    $config = \Drupal::config('cgov_adobe.settings');
+    $exclude_paths = $config->get('exclude_paths');
+
+    if (empty($exclude_paths)) {
+      $result = TRUE;
+    }
+    else {
+      $exclude_patterns = implode("\n", $exclude_paths);
+      $request = \Drupal::request();
+      $alias_manager = \Drupal::service('path.alias_manager');
+      $current_path = \Drupal::service('path.current');
+      $path_matcher = \Drupal::service('path.matcher');
+
+      // Compare the lowercase path alias (if any) and internal path.
+      $path = $current_path->getPath($request);
+      $path_alias = mb_strtolower($alias_manager->getAliasByPath($path));
+
+      // Since we are excluding paths, note the negation of matchPath below.
+      $result = !(
+        // Match alias.
+        $path_matcher->matchPath($path_alias, $exclude_patterns) ||
+        // Match actual route.
+        (($path != $path_alias) && $path_matcher->matchPath($path, $exclude_patterns))
+      );
+    }
+  }
+
+  return $result;
+}
+
+
+/**
+ * Returns tag array with embed code.
+ *
+ * @return array|bool
+ *   The tag array or FALSE if failed.
+ */
+function _cgov_adobe_embed_code_tag_array() {
+  $config = \Drupal::config('cgov_adobe.settings');
+  $enabled = $config->get('enabled');
+  $build_url = $config->get('launch_property_build_url');
+
+  // If cgov_adobe is disabled or the path check returns FALSE, return.
+  if (!$enabled || !_cgov_adobe_path_check()) {
+    return FALSE;
+  }
+
+  // Retrieve script URL based on specific connection type function.
+  $script = empty($build_url) ? FALSE : $build_url;
+
+  $tag = [
+    '#type'       => 'html_tag',
+    '#tag'        => 'script',
+    '#attributes' => [
+      'id'         => 'cgov-adobe-url',
+      'type'  => 'text/javascript',
+      'src'   => $script,
+    ],
+  ];
+
+  $attachment = [
+    $tag,
+    'cgov_adobe_tag',
+  ];
+
+  return $attachment;
+}

--- a/docroot/modules/custom/cgov_adobe/cgov_adobe.permissions.yml
+++ b/docroot/modules/custom/cgov_adobe/cgov_adobe.permissions.yml
@@ -1,0 +1,3 @@
+administer cgov adobe:
+  title: 'Administer Cgov Adobe Tag Management'
+  description: 'Configure the integration with Adobe Launch and the web site.'

--- a/docroot/modules/custom/cgov_adobe/cgov_adobe.routing.yml
+++ b/docroot/modules/custom/cgov_adobe/cgov_adobe.routing.yml
@@ -1,0 +1,7 @@
+cgov_adobe.settings_form:
+  path: '/admin/config/system/cgov-adobe'
+  defaults:
+    _title: 'Cgov Adobe Tag Management'
+    _form: '\Drupal\cgov_adobe\Form\CgovAdobeSettingsForm'
+  requirements:
+    _permission: 'administer cgov adobe'

--- a/docroot/modules/custom/cgov_adobe/config/install/cgov_adobe.settings.yml
+++ b/docroot/modules/custom/cgov_adobe/config/install/cgov_adobe.settings.yml
@@ -1,6 +1,5 @@
 enabled: true
-datalayer_enabled: false
-paths:
+exclude_paths:
   - '/admin*'
   - '/batch*'
   - '/node/add*'
@@ -9,10 +8,4 @@ paths:
   - '/node/*/revisions*'
   - '/user/*/edit*'
   - '/user/*/cancel*'
-paths_negate: '1'
-connection_type: launch
 launch_property_build_url: //assets.adobedtm.com/6a4249cd0a2c/663bb44c2e69/launch-9ed25e181790.min.js
-dtm_property_embed_code_id: ''
-dtm_property_embed_code_hash: ''
-dtm_environment: production
-launch_property_async: false

--- a/docroot/modules/custom/cgov_adobe/config/schema/cgov_adobe.schema.yml
+++ b/docroot/modules/custom/cgov_adobe/config/schema/cgov_adobe.schema.yml
@@ -1,0 +1,15 @@
+cgov_adobe.settings:
+  type: config_object
+  mapping:
+    enabled:
+      type: boolean
+      label: 'Adobe Tag Management enabled'
+    launch_property_build_url:
+      type: string
+      label: 'Launch property build URL'
+    exclude_paths:
+      type: sequence
+      label: 'Exclude Paths'
+      sequence:
+        type: string
+        label: 'Exclude Path'

--- a/docroot/modules/custom/cgov_adobe/src/Form/CgovAdobeSettingsForm.php
+++ b/docroot/modules/custom/cgov_adobe/src/Form/CgovAdobeSettingsForm.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Drupal\cgov_adobe\Form;
+
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Class for the Cgov Adobe settings.
+ */
+class CgovAdobeSettingsForm extends ConfigFormBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'cgov_adobe_settings';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return ['cgov_adobe.settings'];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $config = $this->config('cgov_adobe.settings');
+
+    $form['settings'] = [
+      '#type'       => 'vertical_tabs',
+      '#attributes' => ['class' => ['cgov-adobe-settings']],
+    ];
+
+    // General section.
+    $form['general'] = [
+      '#type'  => 'details',
+      '#title' => $this->t('General'),
+      '#group' => 'settings',
+    ];
+
+    $form['general']['enabled'] = [
+      '#type'          => 'checkbox',
+      '#title'         => $this->t('Enable Adobe Launch Tags'),
+      '#description'   => $this->t('Will enable the Adobe Tag Management script, using Launch.'),
+      '#default_value' => $config->get('enabled'),
+    ];
+
+    $form['general']['launch_property_build_url'] = [
+      '#type'          => 'textfield',
+      '#title'         => $this->t('Build URL'),
+      '#description'   => $this->t('Launch property build URL.'),
+      '#default_value' => $config->get('launch_property_build_url'),
+      '#size'          => 80,
+      '#maxlength'     => 250,
+      '#states'        => [
+        'required' => [
+          ':input[name="enabled"]' => ['value' => TRUE],
+        ],
+      ],
+    ];
+
+    $form['general']['exclude_paths'] = [
+      '#type'          => 'textarea',
+      '#title'         => $this->t('Excluded paths'),
+      '#description'   => $this->t("Enter one path per line. ENSURE CASE IS CORRECT!! The '*' character is a wildcard. An example path is %node-edit-wildcard for every node edit page, %admin-wildcard targets administration pages.", [
+        '%node-edit-wildcard' => '/node/*/edit',
+        '%admin-wildcard'     => '/admin/*',
+      ]),
+      '#default_value' => $this->implodeListOfItems($config->get('exclude_paths')),
+      '#rows'          => 10,
+    ];
+
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateForm(array &$form, FormStateInterface $form_state) {
+    // Clean text values.
+    $launch_property_build_url = trim($form_state->getValue('launch_property_build_url'));
+    $form_state->setValue('launch_property_build_url', $launch_property_build_url);
+    $exclude_paths = $this->splitAndCleanText($form_state->getValue('exclude_paths'));
+    $form_state->setValue('exclude_paths', $exclude_paths);
+
+    parent::validateForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $this->config('cgov_adobe.settings')
+      ->set('enabled', $form_state->getValue('enabled'))
+      ->set('launch_property_build_url', $form_state->getValue('launch_property_build_url'))
+      ->set('exclude_paths', $form_state->getValue('exclude_paths'))
+      ->save();
+
+    parent::submitForm($form, $form_state);
+  }
+
+  /**
+   * Splits new lines and cleans a string representing a list of items.
+   *
+   * @param string $text
+   *   The string to clean.
+   *
+   * @return array
+   *   The clean text array.
+   */
+  protected function splitAndCleanText($text) {
+    $text = explode("\n", $text);
+    $text = array_map('trim', $text);
+    $text = array_filter($text, 'trim');
+    return $text;
+  }
+
+  /**
+   * Implodes a given list of items into a string.
+   *
+   * @param array $items
+   *   The array with list of items.
+   *
+   * @return string
+   *   The imploded list of items as a string.
+   */
+  protected function implodeListOfItems(array $items) {
+    return implode("\n", $items);
+  }
+
+}

--- a/docroot/modules/custom/cgov_adobe/tests/src/Functional/CgovAdobeRenderTest.php
+++ b/docroot/modules/custom/cgov_adobe/tests/src/Functional/CgovAdobeRenderTest.php
@@ -1,0 +1,279 @@
+<?php
+
+namespace Drupal\Tests\cgov_adobe\Functional;
+
+use Drupal\Component\Render\FormattableMarkup;
+use Drupal\Core\Url;
+use Drupal\Tests\BrowserTestBase;
+
+/**
+ * Test the ability for cgov_adobe to render launch tags.
+ *
+ * @group cgov_adobe
+ */
+class CgovAdobeRenderTest extends BrowserTestBase {
+
+  /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  public static $modules = [
+    'language',
+    'path',
+    'block',
+    'node',
+    'field_ui',
+    'cgov_adobe',
+  ];
+
+  /**
+   * The installation profile to use with this test.
+   *
+   * @var string
+   */
+  protected $profile = 'minimal';
+
+  /**
+   * The theme to use with this test.
+   *
+   * @var string
+   */
+  protected $defaultTheme = 'classy';
+
+  /**
+   * The content type name.
+   *
+   * @var string
+   */
+  protected $contentTypeName;
+
+  /**
+   * The administrator account.
+   *
+   * @var \Drupal\Core\Session\AccountInterface
+   */
+  protected $administratorAccount;
+
+  /**
+   * {@inheritdoc}
+   *
+   * Once installed, a content type with the desired field is created.
+   */
+  protected function setUp() {
+    // Install Drupal.
+    parent::setUp();
+
+    $this->drupalPlaceBlock('system_menu_block:tools', ['region' => 'primary_menu']);
+    $this->drupalPlaceBlock('local_tasks_block', ['region' => 'secondary_menu']);
+    $this->drupalPlaceBlock('local_actions_block', ['region' => 'content']);
+    $this->drupalPlaceBlock('page_title_block', ['region' => 'content']);
+
+    // Create and login a user that creates the content type.
+    $permissions = [
+      'administer content types',
+      'administer node fields',
+      'administer node form display',
+      'administer node display',
+      'administer cgov adobe',
+      'access administration pages',
+      'administer url aliases',
+      'administer site configuration',
+    ];
+    $this->administratorAccount = $this->drupalCreateUser($permissions);
+    $this->drupalLogin($this->administratorAccount);
+
+    // Prepare a new content type where the field will be added.
+    $this->contentTypeName = strtolower($this->randomMachineName(10));
+    $this->drupalGet('admin/structure/types/add');
+    $edit = [
+      'name' => $this->contentTypeName,
+      'type' => $this->contentTypeName,
+    ];
+    $this->drupalPostForm(NULL, $edit, 'Save and manage fields');
+    $this->assertText((string) new FormattableMarkup('The content type @name has been added.', ['@name' => $this->contentTypeName]));
+
+    // Reset the permission cache.
+    $create_permission = 'create ' . $this->contentTypeName . ' content';
+    $this->checkPermissions([$create_permission], TRUE);
+    $edit_permission = 'edit any ' . $this->contentTypeName . ' content';
+    $this->checkPermissions([$edit_permission], TRUE);
+
+    // Now that we have a new content type, create a user that has privileges
+    // on the content type.
+    $this->authorAccount = $this->drupalCreateUser([
+      $create_permission,
+      $edit_permission,
+      'create url aliases',
+    ]);
+
+  }
+
+  /**
+   * Tests the Cgov Adobe module.
+   */
+  public function testCgovAdobe() {
+    /*
+     * Setup Data.
+     */
+
+    // Login with Author user for content creation.
+    $this->drupalLogin($this->authorAccount);
+
+    $nodedetails = [];
+    for ($i = 0; $i < 4; $i++) {
+      $title_base = $this->randomMachineName(20);
+      $alias_base = $this->randomMachineName(10);
+      $detail = [
+        'title' => $title_base . '-' . $i,
+        'alias' => '/' . $alias_base . '-' . $i,
+      ];
+      $nodedetails[$i] = $detail;
+
+      $this->drupalGet('node/add/' . $this->contentTypeName);
+      // Details to be submitted for content creation.
+      $edit = [
+        'title[0][value]' => $detail['title'],
+        'path[0][alias]' => $detail['alias'],
+      ];
+      // Submit the content creation form.
+      $this->drupalPostForm(NULL, $edit, 'Save');
+    }
+    $this->drupalGet('node/add/' . $this->contentTypeName);
+
+    /* Set Adobe Config */
+    $this->drupalLogin($this->administratorAccount);
+
+    // Setup Adobe Config.
+    $this->drupalPostForm(
+      Url::fromRoute('cgov_adobe.settings_form'),
+      [
+        'enabled' => 1,
+        'launch_property_build_url' => '//example.org/launch.js',
+        'exclude_paths' => "/node/2\n" . strtolower($nodedetails[2]['alias']),
+      ],
+      'Save configuration'
+    );
+
+    /*
+     * Test Scenarios
+     */
+    $this->doTestConfig($nodedetails);
+    $this->doTestPathFilters($nodedetails);
+    $this->doTestEnables($nodedetails);
+    $this->doTestNoPaths($nodedetails);
+  }
+
+  /**
+   * Tests the inital config object.
+   */
+  private function doTestConfig($nodedetails) {
+    $initialConfig = $this->config('cgov_adobe.settings');
+    $this->assertEquals($initialConfig->get('enabled'), TRUE, 'Enabled saved correctly in initial config');
+    $this->assertEquals($initialConfig->get('launch_property_build_url'), '//example.org/launch.js', 'Property URL saved correctly in initial config');
+    $this->assertEquals(
+      $initialConfig->get('exclude_paths'),
+      [
+        '/node/2',
+        strtolower($nodedetails[2]['alias']),
+      ],
+      'Exclude Paths saved correctly in initial config'
+    );
+  }
+
+  /**
+   * Tests the path filters.
+   */
+  private function doTestPathFilters($nodedetails) {
+    $assert = $this->assertSession();
+
+    // Tags are loaded on an allowed path.
+    $this->drupalGet('/node/1');
+    $script_file_el = $assert->elementExists('css', 'script#cgov-adobe-url');
+    $actual_script_src = $script_file_el->getAttribute('src');
+    $this->assertEquals('//example.org/launch.js', $actual_script_src);
+    $assert->elementExists('css', 'script#cgov-adobe-bottom');
+
+    // Tags are loaded on an allowed path.
+    $this->drupalGet($nodedetails[0]['alias']);
+    $script_file_el = $assert->elementExists('css', 'script#cgov-adobe-url');
+    $actual_script_src = $script_file_el->getAttribute('src');
+    $this->assertEquals('//example.org/launch.js', $actual_script_src);
+    $assert->elementExists('css', 'script#cgov-adobe-bottom');
+
+    // Excluded the route based on excluded route.
+    $this->drupalGet('/node/2');
+    $assert->elementNotExists('css', 'script#cgov-adobe-url');
+    $assert->elementNotExists('css', 'script#cgov-adobe-bottom');
+
+    // Excluded the alias based on excluded route.
+    $this->drupalGet($nodedetails[1]['alias']);
+    $assert->elementNotExists('css', 'script#cgov-adobe-url');
+    $assert->elementNotExists('css', 'script#cgov-adobe-bottom');
+
+    // Exclude the alias based on excluded alias.
+    $this->drupalGet($nodedetails[2]['alias']);
+    $assert->elementNotExists('css', 'script#cgov-adobe-url');
+    $assert->elementNotExists('css', 'script#cgov-adobe-bottom');
+
+    // Exclude the route based on the path alias.
+    $this->drupalGet('/node/3');
+    $assert->elementNotExists('css', 'script#cgov-adobe-url');
+    $assert->elementNotExists('css', 'script#cgov-adobe-bottom');
+  }
+
+  /**
+   * Tests the enables setting.
+   *
+   * This also happens to test the cache tag clearing on save of the config.
+   * During testing it was noticed that we had to clear the cache because
+   * the save of the config was not changing the rendered pages.
+   */
+  private function doTestEnables($nodedetails) {
+    $assert = $this->assertSession();
+    $this->drupalLogin($this->administratorAccount);
+
+    // Setup Adobe Config.
+    $this->drupalPostForm(
+      Url::fromRoute('cgov_adobe.settings_form'),
+      [
+        'enabled' => 0,
+        'launch_property_build_url' => '//example.org/launch.js',
+        'exclude_paths' => "/node/2\n" . strtolower($nodedetails[2]['alias']),
+      ],
+      'Save configuration'
+    );
+
+    // The settings are disabled, so no nodes should have the tags.
+    $this->drupalGet('/node/1');
+    $assert->elementNotExists('css', 'script#cgov-adobe-url');
+    $assert->elementNotExists('css', 'script#cgov-adobe-bottom');
+  }
+
+  /**
+   * Tests the enables setting.
+   */
+  private function doTestNoPaths($nodedetails) {
+    $assert = $this->assertSession();
+    $this->drupalLogin($this->administratorAccount);
+
+    // Setup Adobe Config.
+    $this->drupalPostForm(
+      Url::fromRoute('cgov_adobe.settings_form'),
+      [
+        'enabled' => 1,
+        'launch_property_build_url' => '//example.org/launch.js',
+        'exclude_paths' => "",
+      ],
+      'Save configuration'
+    );
+
+    // Exclude the route based on the path alias.
+    $this->drupalGet('/node/3');
+    $script_file_el = $assert->elementExists('css', 'script#cgov-adobe-url');
+    $actual_script_src = $script_file_el->getAttribute('src');
+    $this->assertEquals('//example.org/launch.js', $actual_script_src);
+    $assert->elementExists('css', 'script#cgov-adobe-bottom');
+  }
+
+}

--- a/docroot/profiles/custom/cgov_site/cgov_site.info.yml
+++ b/docroot/profiles/custom/cgov_site/cgov_site.info.yml
@@ -58,7 +58,6 @@ install:
   - paragraphs_asymmetric_translation_widgets
   - ctools
   - entity_browser
-  - adobe_dtm
   - metatag
   - metatag_dc
   - metatag_dc_advanced
@@ -69,6 +68,7 @@ install:
   # from CGOV
   - app_module
   - cgov_js_app_module
+  - cgov_adobe
   - cgov_core
   - cgov_vocab_manager
   - cgov_site_section

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.info.yml
@@ -4,7 +4,6 @@ package: 'CGov Digital Platform'
 description: 'CGov Core Components (used by the CGov Site install profile)'
 core: 8.x
 dependencies:
-  - adobe_dtm
   - block
   - block_content
   - ckeditor

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.install
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.install
@@ -111,8 +111,8 @@ function _cgov_core_install_permissions(CgovCoreTools $siteHelper) {
       'select account cancellation method',
       'access user profiles',
       'administer account settings',
-      // Set DTM tag after site provisioning.
-      'administer adobe dynamic tag management',
+      // Set Launch tag after site provisioning.
+      'administer cgov adobe',
       // Set microsite theme colors after provisioning.
       'administer themes',
       'administer frontend globals',
@@ -254,4 +254,46 @@ function cgov_core_update_8004() {
   ];
 
   $siteHelper->addRolePermissions($perms);
+}
+
+/**
+ * Update for Cgov Adobe. (Issue #3121)
+ */
+function cgov_core_update_8005() {
+
+  // Enable cgov adobe
+  if (!\Drupal::moduleHandler()->moduleExists('cgov_adobe')) {
+    $installer = \Drupal::service('module_installer');
+    $installer->install(['cgov_adobe']);
+  }
+  // add role 'administer cgov adobe'
+  $siteHelper = \Drupal::service('cgov_core.tools');
+
+  $perms = [
+    'site_admin' => [
+      'administer cgov adobe',
+    ],
+  ];
+  $siteHelper->addRolePermissions($perms);
+
+  // If adobe dtm does not exist, then we should bail.
+  if (!\Drupal::moduleHandler()->moduleExists('adobe_dtm')) {
+    return;
+  }
+
+  /* Copy launch tag from adobe_dtm settings to cgov_adobe settings. */
+  $launch_url = \Drupal::config('adobe_dtm.settings')->get('launch_property_build_url');
+
+  if ($launch_url) {
+  /* remove role 'administer adobe dynamic tag management', */
+  \Drupal::configFactory()->getEditable('cgov_adobe.settings')
+    ->set('launch_property_build_url', $launch_url)
+    ->save(TRUE);
+  }
+
+  // Uninstall Adobe DTM
+  if (\Drupal::moduleHandler()->moduleExists('adobe_dtm')) {
+    $installer = \Drupal::service('module_installer');
+    $installer->uninstall(['adobe_dtm'], FALSE);
+  }
 }


### PR DESCRIPTION
ODE: ncigovcdode432.prod.acquia-sites.com

- This is to remove adobe_dtm, which does not support Drupal 9.
- This borrows from some of the logic, what is necessary for our requirements.
- We addeed a config:cgov_adobe.settings cache tag to the build array, so updating the analytics config will invalidate all pages and the Drupal cache. I.E. No longer a need to drush cr and the like when the config is updated. This did not exist previously.
- This also enables cgov_adobe, copies the launch URL from the adobe_dtm config, and disables adobe_dtm.  
- THIS DOES REQUIRE AN SUBSEQUENT RELEASE TO REMOVE THE adobe_dtm MODULE FROM COMPOSER!

Closes #3121
 