### PR TITLE
(#3122) Updated the migrate_file module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -70,7 +70,7 @@
         "drupal/linkit": "^5.0",
         "drupal/memcache": "^2.1",
         "drupal/metatag": "^1.12",
-        "drupal/migrate_file": "^1.1",
+        "drupal/migrate_file": "^2.0",
         "drupal/migrate_plus": "^5.1",
         "drupal/migrate_tools": "^4.1",
         "drupal/moderation_sidebar": "^1.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "08d187afb0e09b08d4b51420a8449b39",
+    "content-hash": "f1c5f294badf0070b4d3c14c4ca945cd",
     "packages": [
         {
             "name": "acquia/acsf-tools",
@@ -6353,29 +6353,26 @@
         },
         {
             "name": "drupal/migrate_file",
-            "version": "1.1.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/migrate_file.git",
-                "reference": "8.x-1.1"
+                "reference": "2.0.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/migrate_file-8.x-1.1.zip",
-                "reference": "8.x-1.1",
-                "shasum": "4a24edc577541b5aa67682a4f89c8dfd7c0788d5"
+                "url": "https://ftp.drupal.org/files/projects/migrate_file-2.0.0.zip",
+                "reference": "2.0.0",
+                "shasum": "84bc9aea018baa263cd24d0a6194a30b79f60801"
             },
             "require": {
-                "drupal/core": "*"
+                "drupal/core": "^8 || ^9"
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
                 "drupal": {
-                    "version": "8.x-1.1",
-                    "datestamp": "1539064380",
+                    "version": "2.0.0",
+                    "datestamp": "1605920047",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"


### PR DESCRIPTION
This is a tricky one. The migration stuff in the profile needs to be removed as it is now outdated and would most likely fail since content types have changed, and the original sites no longer exist to pull images and files from. HOWEVER, loading the site sections for ODE content IS migrate and the cgov_migrate code. So this all still references migrate_file, and we need to bump the version, however we have no real way to test. So as long as browser tests still work and nothing else breaks, we are going to do this update untested otherwise.

Closes #3122 