### PR TITLE
(#3124) Update simplesamlphp_auth to 3.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -84,7 +84,7 @@
         "drupal/seckit": "^2.0",
         "drupal/shield": "^1.2",
         "drupal/simple_sitemap": "^3.2",
-        "drupal/simplesamlphp_auth": "3.0",
+        "drupal/simplesamlphp_auth": "3.2",
         "drupal/token": "^1.6",
         "drupal/token_filter": "^1.1",
         "drupal/twig_field_value": "^2.0",
@@ -232,9 +232,6 @@
             "drupal/page_manager": {
                 "2820218 : Page manager does not respect existing route defaults for title callbacks": "https://www.drupal.org/files/issues/2018-03-21/2820218-50.patch",
                 "2876880 : page_variant entity type does not exist when installing or enabling": "https://www.drupal.org/files/issues/2876880-page-varient-cache-2.patch"
-            },
-            "drupal/simplesamlphp_auth": {
-                "2907182: Admin UI Pages not Accessible via Permission": "https://www.drupal.org/files/issues/simplesamlphp_auth-admin_ui_pages-2907182-30.patch"
             },
             "drupal/token_filter": {
                 "3036541: Missing token_filter schema file": "https://www.drupal.org/files/issues/2019-03-04/3036541-2-token_filter_schema.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f1c5f294badf0070b4d3c14c4ca945cd",
+    "content-hash": "a5be16e5e00f6c29bcfbb30f1967efc3",
     "packages": [
         {
             "name": "acquia/acsf-tools",
@@ -5623,17 +5623,17 @@
         },
         {
             "name": "drupal/externalauth",
-            "version": "1.3.0",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/externalauth.git",
-                "reference": "8.x-1.3"
+                "reference": "8.x-1.4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/externalauth-8.x-1.3.zip",
-                "reference": "8.x-1.3",
-                "shasum": "b1b38e6718fe66bd38fc894dab1f9d7a7d60f10b"
+                "url": "https://ftp.drupal.org/files/projects/externalauth-8.x-1.4.zip",
+                "reference": "8.x-1.4",
+                "shasum": "caea7d2d5a890adad9e6b5beaa2cf139727266d6"
             },
             "require": {
                 "drupal/core": "^8 || ^9"
@@ -5641,8 +5641,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-1.3",
-                    "datestamp": "1587629529",
+                    "version": "8.x-1.4",
+                    "datestamp": "1624457496",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -7285,38 +7285,32 @@
         },
         {
             "name": "drupal/simplesamlphp_auth",
-            "version": "3.0.0",
+            "version": "3.2.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/simplesamlphp_auth.git",
-                "reference": "8.x-3.0"
+                "reference": "8.x-3.2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/simplesamlphp_auth-8.x-3.0.zip",
-                "reference": "8.x-3.0",
-                "shasum": "2ee230173df2128edb5d72953222d229dabf27e7"
+                "url": "https://ftp.drupal.org/files/projects/simplesamlphp_auth-8.x-3.2.zip",
+                "reference": "8.x-3.2",
+                "shasum": "a5a2b10fc873eb8669929ad1a6d9599e47a2ca99"
             },
             "require": {
-                "drupal/core": "*",
-                "drupal/externalauth": "*",
-                "simplesamlphp/simplesamlphp": "~1.15"
+                "drupal/core": "^8.7|^9.0",
+                "drupal/externalauth": "^1.1",
+                "simplesamlphp/simplesamlphp": "^1.18.2"
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-3.x": "3.x-dev"
-                },
                 "drupal": {
-                    "version": "8.x-3.0",
-                    "datestamp": "1565118485",
+                    "version": "8.x-3.2",
+                    "datestamp": "1580423953",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
                     }
-                },
-                "patches_applied": {
-                    "2907182: Admin UI Pages not Accessible via Permission": "https://www.drupal.org/files/issues/simplesamlphp_auth-admin_ui_pages-2907182-30.patch"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/config/install/user.settings.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/config/install/user.settings.yml
@@ -9,7 +9,7 @@ notify:
   register_admin_created: false
   register_no_approval_required: false
   register_pending_approval: false
-register: visitors_admin_approval
+register: admin_only
 cancel_method: user_cancel_block
 password_reset_timeout: 86400
 password_strength: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_saml_auth_config/config/install/simplesamlphp_auth.settings.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_saml_auth_config/config/install/simplesamlphp_auth.settings.yml
@@ -1,5 +1,4 @@
 langcode: en
-default_langcode: en
 activate: true
 mail_attr: https://federation.nih.gov/person/Mail
 unique_id: https://federation.nih.gov/person/SamAccountName
@@ -27,7 +26,7 @@ allow:
     admin_ui: '0'
   default_login_users: '1'
 logout_goto_url: ''
-user_register_original: visitors_admin_approval
+user_register_original: admin_only
 sync:
   mail: true
   user_name: true


### PR DESCRIPTION
Updates drupal/simplesamlphp_auth to v3.2

- Remove default_langcode from cgov_saml_auth_config to match changes in simplesamlphp_auth.
- Eliminate false positives for feature diffs `user.settings register` in some scenarios.

Closes #3124