### PR TITLE
(#3180) Remove Adobe DTM Module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,19 +25,6 @@
         "clinical-trial-search": {
             "type": "vcs",
             "url": "https://github.com/NCIOCPL/clinical-trials-search-client.php"
-        },
-        "bad-adobe-module": {
-            "type": "package",
-            "package": {
-                "name": "drupal/adobe_dtm",
-                "version": "dev-8.x-1.x",
-                "type": "drupal-module",
-                "source": {
-                    "type": "git",
-                    "url": "https://git.drupalcode.org/project/adobe_dtm.git",
-                    "reference": "8.x-1.x"
-                }
-            }
         }
     },
     "require": {
@@ -54,7 +41,6 @@
         "drupal/acsf": "^2.67",
         "drupal/address": "~1.0",
         "drupal/admin_toolbar": "^3.0",
-        "drupal/adobe_dtm": "dev-8.x-1.x",
         "drupal/akamai": "3.x-dev@dev",
         "drupal/config_perms": "^2",
         "drupal/console": "^1.9.7",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fd7b7bfcdfbca473d29c3237040fcbc8",
+    "content-hash": "d51a9f6611d95148c04cfca0eb632090",
     "packages": [
         {
             "name": "acquia/acsf-tools",
@@ -4100,17 +4100,6 @@
                 "source": "https://git.drupalcode.org/project/admin_toolbar",
                 "issues": "https://www.drupal.org/project/issues/admin_toolbar"
             }
-        },
-        {
-            "name": "drupal/adobe_dtm",
-            "version": "dev-8.x-1.x",
-            "source": {
-                "type": "git",
-                "url": "https://git.drupalcode.org/project/adobe_dtm.git",
-                "reference": "8.x-1.x"
-            },
-            "type": "drupal-module",
-            "time": "2019-09-27T08:20:25+00:00"
         },
         {
             "name": "drupal/akamai",
@@ -17785,7 +17774,6 @@
         "acquia/blt-require-dev": 20,
         "behat/mink-selenium2-driver": 20,
         "drupal/acquia_purge": 10,
-        "drupal/adobe_dtm": 20,
         "drupal/akamai": 20,
         "drupal/page_manager": 10,
         "nciocpl/clinical-trial-search-client.php": 20


### PR DESCRIPTION
This removes the module from the codebase -- it is assumed this will be deployed immediately after release 1.2.14.

Closes #3180