### PR TITLE
Add new fields for SVPC project

### DIFF
--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_form_display.node.pdq_cancer_information_summary.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_form_display.node.pdq_cancer_information_summary.default.yml
@@ -12,6 +12,7 @@ dependencies:
     - field.field.node.pdq_cancer_information_summary.field_pdq_audience
     - field.field.node.pdq_cancer_information_summary.field_pdq_cdr_id
     - field.field.node.pdq_cancer_information_summary.field_pdq_summary_type
+    - field.field.node.pdq_cancer_information_summary.field_pdq_suppress_otp
     - field.field.node.pdq_cancer_information_summary.field_pdq_url
     - field.field.node.pdq_cancer_information_summary.field_public_use
     - field.field.node.pdq_cancer_information_summary.field_summary_sections
@@ -65,6 +66,13 @@ content:
     region: content
   field_pdq_is_svpc:
     weight: 101
+    settings:
+      display_label: true
+    third_party_settings: {  }
+    type: boolean_checkbox
+    region: content
+  field_pdq_suppress_otp:
+    weight: 102
     settings:
       display_label: true
     third_party_settings: {  }

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_form_display.node.pdq_cancer_information_summary.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_form_display.node.pdq_cancer_information_summary.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.node.pdq_cancer_information_summary.field_date_posted
     - field.field.node.pdq_cancer_information_summary.field_date_updated
     - field.field.node.pdq_cancer_information_summary.field_hhs_syndication
+    - field.field.node.pdq_cancer_information_summary.field_pdq_is_svpc
     - field.field.node.pdq_cancer_information_summary.field_meta_tags
     - field.field.node.pdq_cancer_information_summary.field_page_description
     - field.field.node.pdq_cancer_information_summary.field_pdq_audience
@@ -61,6 +62,13 @@ content:
     settings: {  }
     third_party_settings: {  }
     type: cgov_syndication_widget
+    region: content
+  field_pdq_is_svpc:
+    weight: 101
+    settings:
+      display_label: true
+    third_party_settings: {  }
+    type: boolean_checkbox
     region: content
   field_page_description:
     weight: 15

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_form_display.node.pdq_cancer_information_summary.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_form_display.node.pdq_cancer_information_summary.default.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.node.pdq_cancer_information_summary.field_page_description
     - field.field.node.pdq_cancer_information_summary.field_pdq_audience
     - field.field.node.pdq_cancer_information_summary.field_pdq_cdr_id
+    - field.field.node.pdq_cancer_information_summary.field_pdq_intro_text
     - field.field.node.pdq_cancer_information_summary.field_pdq_summary_type
     - field.field.node.pdq_cancer_information_summary.field_pdq_suppress_otp
     - field.field.node.pdq_cancer_information_summary.field_pdq_url
@@ -77,6 +78,14 @@ content:
       display_label: true
     third_party_settings: {  }
     type: boolean_checkbox
+    region: content
+  field_pdq_intro_text:
+    weight: 25
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+    type: text_textarea
     region: content
   field_page_description:
     weight: 15

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_view_display.node.pdq_cancer_information_summary.cthp_guide_card_list_item.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_view_display.node.pdq_cancer_information_summary.cthp_guide_card_list_item.yml
@@ -13,6 +13,7 @@ dependencies:
     - field.field.node.pdq_cancer_information_summary.field_pdq_audience
     - field.field.node.pdq_cancer_information_summary.field_pdq_cdr_id
     - field.field.node.pdq_cancer_information_summary.field_pdq_summary_type
+    - field.field.node.pdq_cancer_information_summary.field_pdq_suppress_otp
     - field.field.node.pdq_cancer_information_summary.field_pdq_url
     - field.field.node.pdq_cancer_information_summary.field_public_use
     - field.field.node.pdq_cancer_information_summary.field_summary_sections
@@ -47,6 +48,7 @@ hidden:
   field_pdq_audience: true
   field_pdq_cdr_id: true
   field_pdq_summary_type: true
+  field_pdq_suppress_otp: true
   field_pdq_url: true
   field_public_use: true
   field_summary_sections: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_view_display.node.pdq_cancer_information_summary.cthp_guide_card_list_item.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_view_display.node.pdq_cancer_information_summary.cthp_guide_card_list_item.yml
@@ -12,6 +12,7 @@ dependencies:
     - field.field.node.pdq_cancer_information_summary.field_page_description
     - field.field.node.pdq_cancer_information_summary.field_pdq_audience
     - field.field.node.pdq_cancer_information_summary.field_pdq_cdr_id
+    - field.field.node.pdq_cancer_information_summary.field_pdq_intro_text
     - field.field.node.pdq_cancer_information_summary.field_pdq_summary_type
     - field.field.node.pdq_cancer_information_summary.field_pdq_suppress_otp
     - field.field.node.pdq_cancer_information_summary.field_pdq_url
@@ -47,6 +48,7 @@ hidden:
   field_page_description: true
   field_pdq_audience: true
   field_pdq_cdr_id: true
+  field_pdq_intro_text: true
   field_pdq_summary_type: true
   field_pdq_suppress_otp: true
   field_pdq_url: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_view_display.node.pdq_cancer_information_summary.cthp_guide_card_list_item.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_view_display.node.pdq_cancer_information_summary.cthp_guide_card_list_item.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.pdq_cancer_information_summary.field_date_posted
     - field.field.node.pdq_cancer_information_summary.field_date_updated
     - field.field.node.pdq_cancer_information_summary.field_hhs_syndication
+    - field.field.node.pdq_cancer_information_summary.field_pdq_is_svpc
     - field.field.node.pdq_cancer_information_summary.field_meta_tags
     - field.field.node.pdq_cancer_information_summary.field_page_description
     - field.field.node.pdq_cancer_information_summary.field_pdq_audience
@@ -23,6 +24,11 @@ targetEntityType: node
 bundle: pdq_cancer_information_summary
 mode: cthp_guide_card_list_item
 content:
+  content_moderation_control:
+    weight: -20
+    settings: {  }
+    third_party_settings: {  }
+    region: content
   field_browser_title:
     weight: 2
     label: hidden
@@ -35,6 +41,7 @@ hidden:
   field_date_posted: true
   field_date_updated: true
   field_hhs_syndication: true
+  field_pdq_is_svpc: true
   field_meta_tags: true
   field_page_description: true
   field_pdq_audience: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_view_display.node.pdq_cancer_information_summary.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_view_display.node.pdq_cancer_information_summary.default.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.node.pdq_cancer_information_summary.field_page_description
     - field.field.node.pdq_cancer_information_summary.field_pdq_audience
     - field.field.node.pdq_cancer_information_summary.field_pdq_cdr_id
+    - field.field.node.pdq_cancer_information_summary.field_pdq_intro_text
     - field.field.node.pdq_cancer_information_summary.field_pdq_summary_type
     - field.field.node.pdq_cancer_information_summary.field_pdq_suppress_otp
     - field.field.node.pdq_cancer_information_summary.field_pdq_url
@@ -24,6 +25,7 @@ dependencies:
     - datetime
     - entity_reference_revisions
     - options
+    - text
     - user
 id: node.pdq_cancer_information_summary.default
 targetEntityType: node
@@ -75,6 +77,13 @@ content:
       prefix_suffix: true
     third_party_settings: {  }
     type: number_integer
+    region: content
+  field_pdq_intro_text:
+    weight: 7
+    label: above
+    settings: { }
+    third_party_settings: { }
+    type: text_default
     region: content
   field_pdq_summary_type:
     weight: 5

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_view_display.node.pdq_cancer_information_summary.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_view_display.node.pdq_cancer_information_summary.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.node.pdq_cancer_information_summary.field_date_posted
     - field.field.node.pdq_cancer_information_summary.field_date_updated
     - field.field.node.pdq_cancer_information_summary.field_hhs_syndication
+    - field.field.node.pdq_cancer_information_summary.field_pdq_is_svpc
     - field.field.node.pdq_cancer_information_summary.field_meta_tags
     - field.field.node.pdq_cancer_information_summary.field_page_description
     - field.field.node.pdq_cancer_information_summary.field_pdq_audience
@@ -29,12 +30,12 @@ bundle: pdq_cancer_information_summary
 mode: default
 content:
   content_moderation_control:
-    weight: -20
+    weight: 0
+    region: content
     settings: {  }
     third_party_settings: {  }
-    region: content
   field_browser_title:
-    weight: 101
+    weight: 2
     label: above
     settings:
       link_to_entity: false
@@ -42,7 +43,7 @@ content:
     type: string
     region: content
   field_date_updated:
-    weight: 103
+    weight: 3
     label: above
     settings:
       format_type: cgov_display_date
@@ -51,7 +52,7 @@ content:
     type: datetime_default
     region: content
   field_page_description:
-    weight: 104
+    weight: 4
     label: above
     settings:
       link_to_entity: false
@@ -59,14 +60,14 @@ content:
     type: string
     region: content
   field_pdq_audience:
-    weight: 108
+    weight: 7
     label: above
     settings: {  }
     third_party_settings: {  }
     type: list_default
     region: content
   field_pdq_cdr_id:
-    weight: 106
+    weight: 6
     label: above
     settings:
       thousand_separator: ''
@@ -75,14 +76,14 @@ content:
     type: number_integer
     region: content
   field_pdq_summary_type:
-    weight: 105
+    weight: 5
     label: above
     settings: {  }
     third_party_settings: {  }
     type: list_default
     region: content
   field_pdq_url:
-    weight: 110
+    weight: 9
     label: above
     settings:
       link_to_entity: false
@@ -91,7 +92,7 @@ content:
     region: content
   field_summary_sections:
     type: entity_reference_revisions_entity_view
-    weight: 109
+    weight: 8
     label: above
     settings:
       view_mode: default
@@ -99,13 +100,14 @@ content:
     third_party_settings: {  }
     region: content
   links:
-    weight: 100
+    weight: 1
+    region: content
     settings: {  }
     third_party_settings: {  }
-    region: content
 hidden:
   field_date_posted: true
   field_hhs_syndication: true
+  field_pdq_is_svpc: true
   field_meta_tags: true
   field_public_use: true
   langcode: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_view_display.node.pdq_cancer_information_summary.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_view_display.node.pdq_cancer_information_summary.default.yml
@@ -12,6 +12,7 @@ dependencies:
     - field.field.node.pdq_cancer_information_summary.field_pdq_audience
     - field.field.node.pdq_cancer_information_summary.field_pdq_cdr_id
     - field.field.node.pdq_cancer_information_summary.field_pdq_summary_type
+    - field.field.node.pdq_cancer_information_summary.field_pdq_suppress_otp
     - field.field.node.pdq_cancer_information_summary.field_pdq_url
     - field.field.node.pdq_cancer_information_summary.field_public_use
     - field.field.node.pdq_cancer_information_summary.field_summary_sections
@@ -108,6 +109,7 @@ hidden:
   field_date_posted: true
   field_hhs_syndication: true
   field_pdq_is_svpc: true
+  field_pdq_suppress_otp: true
   field_meta_tags: true
   field_public_use: true
   langcode: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_view_display.node.pdq_cancer_information_summary.full.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_view_display.node.pdq_cancer_information_summary.full.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.pdq_cancer_information_summary.field_date_posted
     - field.field.node.pdq_cancer_information_summary.field_date_updated
     - field.field.node.pdq_cancer_information_summary.field_hhs_syndication
+    - field.field.node.pdq_cancer_information_summary.field_pdq_is_svpc
     - field.field.node.pdq_cancer_information_summary.field_meta_tags
     - field.field.node.pdq_cancer_information_summary.field_page_description
     - field.field.node.pdq_cancer_information_summary.field_pdq_audience
@@ -107,6 +108,7 @@ content:
 hidden:
   field_date_posted: true
   field_hhs_syndication: true
+  field_pdq_is_svpc: true
   field_meta_tags: true
   field_public_use: true
   langcode: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_view_display.node.pdq_cancer_information_summary.full.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_view_display.node.pdq_cancer_information_summary.full.yml
@@ -12,6 +12,7 @@ dependencies:
     - field.field.node.pdq_cancer_information_summary.field_page_description
     - field.field.node.pdq_cancer_information_summary.field_pdq_audience
     - field.field.node.pdq_cancer_information_summary.field_pdq_cdr_id
+    - field.field.node.pdq_cancer_information_summary.field_pdq_intro_text
     - field.field.node.pdq_cancer_information_summary.field_pdq_summary_type
     - field.field.node.pdq_cancer_information_summary.field_pdq_suppress_otp
     - field.field.node.pdq_cancer_information_summary.field_pdq_url
@@ -77,6 +78,13 @@ content:
     third_party_settings: {  }
     type: number_integer
     region: content
+  field_pdq_intro_text:
+    weight: 109
+    label: above
+    settings: { }
+    third_party_settings: { }
+    type: text_default
+    region: content
   field_pdq_summary_type:
     weight: 105
     label: above
@@ -85,7 +93,7 @@ content:
     type: list_default
     region: content
   field_pdq_url:
-    weight: 110
+    weight: 111
     label: above
     settings:
       link_to_entity: false
@@ -94,7 +102,7 @@ content:
     region: content
   field_summary_sections:
     type: entity_reference_revisions_entity_view
-    weight: 109
+    weight: 110
     label: above
     settings:
       view_mode: default

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_view_display.node.pdq_cancer_information_summary.full.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_view_display.node.pdq_cancer_information_summary.full.yml
@@ -13,6 +13,7 @@ dependencies:
     - field.field.node.pdq_cancer_information_summary.field_pdq_audience
     - field.field.node.pdq_cancer_information_summary.field_pdq_cdr_id
     - field.field.node.pdq_cancer_information_summary.field_pdq_summary_type
+    - field.field.node.pdq_cancer_information_summary.field_pdq_suppress_otp
     - field.field.node.pdq_cancer_information_summary.field_pdq_url
     - field.field.node.pdq_cancer_information_summary.field_public_use
     - field.field.node.pdq_cancer_information_summary.field_summary_sections
@@ -109,6 +110,7 @@ hidden:
   field_date_posted: true
   field_hhs_syndication: true
   field_pdq_is_svpc: true
+  field_pdq_suppress_otp: true
   field_meta_tags: true
   field_public_use: true
   langcode: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_view_display.node.pdq_cancer_information_summary.teaser.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_view_display.node.pdq_cancer_information_summary.teaser.yml
@@ -12,6 +12,7 @@ dependencies:
     - field.field.node.pdq_cancer_information_summary.field_page_description
     - field.field.node.pdq_cancer_information_summary.field_pdq_audience
     - field.field.node.pdq_cancer_information_summary.field_pdq_cdr_id
+    - field.field.node.pdq_cancer_information_summary.field_pdq_intro_text
     - field.field.node.pdq_cancer_information_summary.field_pdq_summary_type
     - field.field.node.pdq_cancer_information_summary.field_pdq_suppress_otp
     - field.field.node.pdq_cancer_information_summary.field_pdq_url
@@ -48,6 +49,7 @@ hidden:
   field_page_description: true
   field_pdq_audience: true
   field_pdq_cdr_id: true
+  field_pdq_intro_text: true
   field_pdq_summary_type: true
   field_pdq_suppress_otp: true
   field_pdq_url: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_view_display.node.pdq_cancer_information_summary.teaser.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_view_display.node.pdq_cancer_information_summary.teaser.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.pdq_cancer_information_summary.field_date_posted
     - field.field.node.pdq_cancer_information_summary.field_date_updated
     - field.field.node.pdq_cancer_information_summary.field_hhs_syndication
+    - field.field.node.pdq_cancer_information_summary.field_pdq_is_svpc
     - field.field.node.pdq_cancer_information_summary.field_meta_tags
     - field.field.node.pdq_cancer_information_summary.field_page_description
     - field.field.node.pdq_cancer_information_summary.field_pdq_audience
@@ -16,6 +17,9 @@ dependencies:
     - field.field.node.pdq_cancer_information_summary.field_public_use
     - field.field.node.pdq_cancer_information_summary.field_summary_sections
     - node.type.pdq_cancer_information_summary
+  enforced:
+    module:
+      - pdq_cancer_information_summary
   module:
     - user
 id: node.pdq_cancer_information_summary.teaser
@@ -23,6 +27,11 @@ targetEntityType: node
 bundle: pdq_cancer_information_summary
 mode: teaser
 content:
+  content_moderation_control:
+    weight: -20
+    settings: {  }
+    third_party_settings: {  }
+    region: content
   links:
     weight: 100
     settings: {  }
@@ -33,6 +42,7 @@ hidden:
   field_date_posted: true
   field_date_updated: true
   field_hhs_syndication: true
+  field_pdq_is_svpc: true
   field_meta_tags: true
   field_page_description: true
   field_pdq_audience: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_view_display.node.pdq_cancer_information_summary.teaser.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_view_display.node.pdq_cancer_information_summary.teaser.yml
@@ -13,6 +13,7 @@ dependencies:
     - field.field.node.pdq_cancer_information_summary.field_pdq_audience
     - field.field.node.pdq_cancer_information_summary.field_pdq_cdr_id
     - field.field.node.pdq_cancer_information_summary.field_pdq_summary_type
+    - field.field.node.pdq_cancer_information_summary.field_pdq_suppress_otp
     - field.field.node.pdq_cancer_information_summary.field_pdq_url
     - field.field.node.pdq_cancer_information_summary.field_public_use
     - field.field.node.pdq_cancer_information_summary.field_summary_sections
@@ -48,6 +49,7 @@ hidden:
   field_pdq_audience: true
   field_pdq_cdr_id: true
   field_pdq_summary_type: true
+  field_pdq_suppress_otp: true
   field_pdq_url: true
   field_public_use: true
   field_summary_sections: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/field.field.node.pdq_cancer_information_summary.field_pdq_intro_text.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/field.field.node.pdq_cancer_information_summary.field_pdq_intro_text.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_pdq_intro_text
+    - node.type.pdq_cancer_information_summary
+  module:
+    - node
+    - text
+id: node.pdq_cancer_information_summary.field_pdq_intro_text
+field_name: field_pdq_intro_text
+entity_type: node
+bundle: pdq_cancer_information_summary
+label: 'Intro Text'
+description: 'Optional introductory section displayed at the top of the summary without a title.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text_long

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/field.field.node.pdq_cancer_information_summary.field_pdq_is_svpc.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/field.field.node.pdq_cancer_information_summary.field_pdq_is_svpc.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_pdq_is_svpc
+    - node.type.pdq_cancer_information_summary
+id: node.pdq_cancer_information_summary.field_pdq_is_svpc
+field_name: field_pdq_is_svpc
+entity_type: node
+bundle: pdq_cancer_information_summary
+label: 'SVPC Summary'
+description: 'Flag indicating whether this Cancer Information Summary was created as part of the <em>Single View Patient Content</em> project.'
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'Yes'
+  off_label: 'No'
+field_type: boolean

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/field.field.node.pdq_cancer_information_summary.field_pdq_suppress_otp.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/field.field.node.pdq_cancer_information_summary.field_pdq_suppress_otp.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_pdq_suppress_otp
+    - node.type.pdq_cancer_information_summary
+id: node.pdq_cancer_information_summary.field_pdq_suppress_otp
+field_name: field_pdq_suppress_otp
+entity_type: node
+bundle: pdq_cancer_information_summary
+label: 'Hide "On This Page" Section'
+description: "Flag indicating whether the list of top-level sections with jump links should not be displayed for this summary's page."
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'Yes'
+  off_label: 'No'
+field_type: boolean

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/field.storage.node.field_pdq_intro_text.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/field.storage.node.field_pdq_intro_text.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+      - pdq_cancer_information_summary
+  module:
+    - node
+    - text
+id: node.field_pdq_intro_text
+field_name: field_pdq_intro_text
+entity_type: node
+type: text_long
+settings: {  }
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/field.storage.node.field_pdq_is_svpc.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/field.storage.node.field_pdq_is_svpc.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+      - pdq_cancer_information_summary
+  module:
+    - node
+id: node.field_pdq_is_svpc
+field_name: field_pdq_is_svpc
+entity_type: node
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/field.storage.node.field_pdq_suppress_otp.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/field.storage.node.field_pdq_suppress_otp.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+      - pdq_cancer_information_summary
+  module:
+    - node
+id: node.field_pdq_suppress_otp
+field_name: field_pdq_suppress_otp
+entity_type: node
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/pdq_cancer_information_summary.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/pdq_cancer_information_summary.info.yml
@@ -2,31 +2,31 @@ name: 'PDQ Cancer Information Summary'
 type: module
 package: 'CGov Digital Platform'
 description: 'The PDQ Cancer Information Summary content type'
-core_version_requirement: ^8.9 || ^9
+core_version_requirement: '^8.9 || ^9'
 dependencies:
-  - basic_auth
-  - cgov_core
-  - cgov_syndication
-  - content_moderation
-  - content_translation
-  - datetime
-  - entity_browser
-  - entity_reference_revisions
-  - field
-  - language
-  - metatag
-  - metatag_dc
-  - node
-  - options
-  - paragraphs
-  - paragraphs_asymmetric_translation_widgets
-  - path
-  - pathauto
-  - pdq_cancer_information_summary
-  - pdq_core
-  - rest
-  - serialization
-  - simple_sitemap
-  - text
-  - user
-  - views
+  - 'cgov_core:cgov_core'
+  - 'cgov_syndication:cgov_syndication'
+  - 'drupal:basic_auth'
+  - 'drupal:content_moderation'
+  - 'drupal:content_translation'
+  - 'drupal:datetime'
+  - 'drupal:field'
+  - 'drupal:language'
+  - 'drupal:node'
+  - 'drupal:options'
+  - 'drupal:path'
+  - 'drupal:rest'
+  - 'drupal:serialization'
+  - 'drupal:text'
+  - 'drupal:user'
+  - 'drupal:views'
+  - 'entity_browser:entity_browser'
+  - 'entity_reference_revisions:entity_reference_revisions'
+  - 'metatag:metatag'
+  - 'metatag:metatag_dc'
+  - 'paragraphs:paragraphs'
+  - 'paragraphs_asymmetric_translation_widgets:paragraphs_asymmetric_translation_widgets'
+  - 'pathauto:pathauto'
+  - 'pdq_cancer_information_summary:pdq_cancer_information_summary'
+  - 'pdq_core:pdq_core'
+  - 'simple_sitemap:simple_sitemap'

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/pdq_cancer_information_summary.install
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/pdq_cancer_information_summary.install
@@ -262,3 +262,35 @@ function pdq_cancer_information_summary_update_9002(&$sandbox) {
     \Drupal::logger($bundle)->notice("Created $count rows in $suppress_otp_table.");
   }
 }
+
+/**
+ * Add new field for optional introductory text section without a title.
+ */
+function pdq_cancer_information_summary_update_9003(&$sandbox) {
+
+  // Make sure the field is installed.
+  _pdq_cancer_information_summary_install_node_field('field_pdq_intro_text');
+
+  // Make sure it shows up on the form.
+  $name = 'core.entity_form_display.node.pdq_cancer_information_summary.default';
+  $config = \Drupal::getContainer()->get('config.factory')->getEditable($name);
+  $content = $config->get('content');
+  $hidden = $config->get('hidden');
+  $weight = $content['field_summary_sections']['weight'] ?? 1000;
+  $content['field_pdq_intro_text'] = [
+    'weight' => $weight - 1,
+    'settings' => [
+      'display_label' => TRUE,
+      'rows' => 5,
+      'placeholder' => '',
+    ],
+    'third_party_settings' => [],
+    'type' => 'text_textarea',
+    'region' => 'content',
+  ];
+  unset($hidden['field_pdq_intro_text']);
+  $config->set('content', $content);
+  $config->set('hidden', $hidden);
+  $config->save();
+  \Drupal::logger('pdq_cancer_information_summary')->notice('Installed field_pdq_intro_text on the edit form.');
+}

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/pdq_cancer_information_summary.install
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/pdq_cancer_information_summary.install
@@ -1,5 +1,9 @@
 <?php
 
+use Drupal\Core\Config\FileStorage;
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
+
 /**
  * @file
  * Contains pdq_cancer_information_summary.install.
@@ -58,4 +62,116 @@ function pdq_cancer_information_summary_update_8001() {
   // Install the new permission.
   $perms = ['pdq_importer' => ['restful patch pdq_cis_api']];
   $siteHelper->addRolePermissions($perms);
+}
+
+/**
+ * Install new node field.
+ *
+ * @param string $name
+ */
+function _pdq_cancer_information_summary_install_node_field($name) {
+  $dir = new FileStorage(__DIR__ . '/config/install/');
+  if (!FieldStorageConfig::loadByName('node', $name)) {
+    $record = $dir->read("field.storage.node.$name");
+    FieldStorageConfig::create($record)->save();
+    \Drupal::logger('pdq_cancer_information_summary')->notice("Installed storage config for $name.");
+  }
+  else {
+    \Drupal::logger('pdq_cancer_information_summary')->notice("Storage config for $name already installed.");
+  }
+  if (!FieldConfig::loadByName('node', 'pdq_cancer_information_summary', $name)) {
+    $record = $dir->read("field.field.node.pdq_cancer_information_summary.$name");
+    FieldConfig::create($record)->save();
+    \Drupal::logger('pdq_cancer_information_summary')->notice("Installed field config for $name.");
+  }
+  else {
+    \Drupal::logger('pdq_cancer_information_summary')->notice("Field config for $name already installed.");
+  }
+}
+
+/**
+ * Add new field to indentify "Single-view patient content" summaries.
+ *
+ * Creates the field's database table rows for existing summaries.
+ */
+function pdq_cancer_information_summary_update_9001(&$sandbox) {
+
+  // Make sure the field is installed.
+  _pdq_cancer_information_summary_install_node_field('field_pdq_is_svpc');
+
+  // Make sure it shows up on the form.
+  $name = 'core.entity_form_display.node.pdq_cancer_information_summary.default';
+  $config = \Drupal::getContainer()->get('config.factory')->getEditable($name);
+  $content = $config->get('content');
+  $hidden = $config->get('hidden');
+  $weight = $content['field_summary_sections']['weight'] ?? 1000;
+  $content['field_pdq_is_svpc'] = [
+    'weight' => $weight - 1,
+    'settings' => ['display_label' => TRUE],
+    'third_party_settings' => [],
+    'type' => 'boolean_checkbox',
+    'region' => 'content',
+  ];
+  unset($hidden['field_pdq_is_svpc']);
+  $config->set('content', $content);
+  $config->set('hidden', $hidden);
+  $config->save();
+  \Drupal::logger('pdq_cancer_information_summary')->notice('Installed field_pdq_is_svpc on the edit form.');
+
+  // Make sure software querying the field don't get back a NULL.
+  $db = \Drupal::database();
+  $bundle = 'pdq_cancer_information_summary';
+  $fields = [
+    'bundle',
+    'deleted',
+    'entity_id',
+    'revision_id',
+    'langcode',
+    'delta',
+    'field_pdq_is_svpc_value',
+  ];
+  $prefixes = ['node', 'node_revision'];
+  foreach ($prefixes as $prefix) {
+    $cdr_id_table = "{$prefix}__field_pdq_cdr_id";
+    $svpc_table = "{$prefix}__field_pdq_is_svpc";
+    $results = $db->select($svpc_table, 't')
+      ->fields('t', ['entity_id', 'revision_id', 'langcode'])
+      ->condition('bundle', $bundle)
+      ->condition('deleted', 0)
+      ->distinct()
+      ->execute();
+    $found = [];
+    foreach ($results as $result) {
+      $key = $result->entity_id . '|' . $result->revision_id . '|' . $result->langcode;
+      $found[$key] = $key;
+    }
+    $results = $db->select($cdr_id_table, 't')
+      ->fields('t', ['entity_id', 'revision_id', 'langcode'])
+      ->condition('bundle', $bundle)
+      ->condition('deleted', 0)
+      ->distinct()
+      ->execute();
+    $records = [];
+    foreach ($results as $result) {
+      $key = $result->entity_id . '|' . $result->revision_id . '|' . $result->langcode;
+      if (!array_key_exists($key, $found)) {
+        $records[] = [
+          'bundle' => $bundle,
+          'deleted' => 0,
+          'entity_id' => $result->entity_id,
+          'revision_id' => $result->revision_id,
+          'langcode' => $result->langcode,
+          'delta' => 0,
+          'field_pdq_is_svpc_value' => 0,
+        ];
+      }
+    }
+    $insert = $db->insert($svpc_table)->fields($fields);
+    foreach ($records as $record) {
+      $insert->values($record);
+    }
+    $insert->execute();
+    $count = count($records);
+    \Drupal::logger($bundle)->notice("Created $count rows in $svpc_table.");
+  }
 }

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/pdq_cancer_information_summary.install
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/pdq_cancer_information_summary.install
@@ -118,7 +118,7 @@ function pdq_cancer_information_summary_update_9001(&$sandbox) {
   $config->save();
   \Drupal::logger('pdq_cancer_information_summary')->notice('Installed field_pdq_is_svpc on the edit form.');
 
-  // Make sure software querying the field don't get back a NULL.
+  // Make sure software querying the field doesn't get back a NULL.
   $db = \Drupal::database();
   $bundle = 'pdq_cancer_information_summary';
   $fields = [
@@ -173,5 +173,92 @@ function pdq_cancer_information_summary_update_9001(&$sandbox) {
     $insert->execute();
     $count = count($records);
     \Drupal::logger($bundle)->notice("Created $count rows in $svpc_table.");
+  }
+}
+
+/**
+ * Add new field to suppress display of "On This Page" section.
+ *
+ * Creates the field's database table rows for existing summaries.
+ */
+function pdq_cancer_information_summary_update_9002(&$sandbox) {
+
+  // Make sure the field is installed.
+  _pdq_cancer_information_summary_install_node_field('field_pdq_suppress_otp');
+
+  // Make sure it shows up on the form.
+  $name = 'core.entity_form_display.node.pdq_cancer_information_summary.default';
+  $config = \Drupal::getContainer()->get('config.factory')->getEditable($name);
+  $content = $config->get('content');
+  $hidden = $config->get('hidden');
+  $weight = $content['field_summary_sections']['weight'] ?? 1000;
+  $content['field_pdq_suppress_otp'] = [
+    'weight' => $weight - 1,
+    'settings' => ['display_label' => TRUE],
+    'third_party_settings' => [],
+    'type' => 'boolean_checkbox',
+    'region' => 'content',
+  ];
+  unset($hidden['field_pdq_suppress_otp']);
+  $config->set('content', $content);
+  $config->set('hidden', $hidden);
+  $config->save();
+  \Drupal::logger('pdq_cancer_information_summary')->notice('Installed field_pdq_suppress_otp on the edit form.');
+
+  // Make sure software querying the field doesn't get back a NULL.
+  $db = \Drupal::database();
+  $bundle = 'pdq_cancer_information_summary';
+  $fields = [
+    'bundle',
+    'deleted',
+    'entity_id',
+    'revision_id',
+    'langcode',
+    'delta',
+    'field_pdq_suppress_otp_value',
+  ];
+  $prefixes = ['node', 'node_revision'];
+  foreach ($prefixes as $prefix) {
+    $cdr_id_table = "{$prefix}__field_pdq_cdr_id";
+    $suppress_otp_table = "{$prefix}__field_pdq_suppress_otp";
+    $results = $db->select($suppress_otp_table, 't')
+      ->fields('t', ['entity_id', 'revision_id', 'langcode'])
+      ->condition('bundle', $bundle)
+      ->condition('deleted', 0)
+      ->distinct()
+      ->execute();
+    $found = [];
+    foreach ($results as $result) {
+      $key = $result->entity_id . '|' . $result->revision_id . '|' . $result->langcode;
+      $found[$key] = $key;
+    }
+    $results = $db->select($cdr_id_table, 't')
+      ->fields('t', ['entity_id', 'revision_id', 'langcode'])
+      ->condition('bundle', $bundle)
+      ->condition('deleted', 0)
+      ->distinct()
+      ->execute();
+    $records = [];
+    foreach ($results as $result) {
+      $key = $result->entity_id . '|' . $result->revision_id . '|' . $result->langcode;
+      if (!array_key_exists($key, $found)) {
+        $records[] = [
+          'bundle' => $bundle,
+          'deleted' => 0,
+          'entity_id' => $result->entity_id,
+          'revision_id' => $result->revision_id,
+          'langcode' => $result->langcode,
+          'delta' => 0,
+          'field_pdq_suppress_otp_value' => 0,
+        ];
+      }
+    }
+    $insert = $db->insert($suppress_otp_table)->fields($fields);
+    foreach ($records as $record) {
+      $insert->values($record);
+    }
+    $insert->execute();
+    $count = count($records);
+    \Drupal::logger($bundle)->notice("Created $count rows in $suppress_otp_table.");
   }
 }

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/pdq_cancer_information_summary.module
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/pdq_cancer_information_summary.module
@@ -17,7 +17,10 @@ function pdq_cancer_information_summary_field_widget_form_alter(
   &$element,
   FormStateInterface $form_state,
   $context) {
-  $map = ['field_pdq_section_html' => ['raw_html']];
+  $map = [
+    'field_pdq_section_html' => ['raw_html'],
+    'field_pdq_intro_text' => ['raw_html'],
+  ];
   $form_helper = \Drupal::service('cgov_core.form_tools');
   $form_helper->allowTextFormats($map, $element, $context);
 }

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/src/Plugin/rest/resource/PDQResource.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/src/Plugin/rest/resource/PDQResource.php
@@ -172,6 +172,7 @@ class PDQResource extends ResourceBase {
           'published' => $translation->status->value,
           'sections' => $sections,
           'svpc' => $translation->field_pdq_is_svpc->value,
+          'suppress_otp' => $translation->field_pdq_suppress_otp->value,
         ];
       }
     }
@@ -287,6 +288,7 @@ class PDQResource extends ResourceBase {
     $node->set('field_summary_sections', $sections);
     $node->set('field_public_use', 1);
     $node->set('field_pdq_is_svpc', $summary['svpc']);
+    $node->set('field_pdq_suppress_otp', $summary['suppress_otp']);
 
     // The syndication field is not translatable.
     if ($language == 'en') {

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/src/Plugin/rest/resource/PDQResource.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/src/Plugin/rest/resource/PDQResource.php
@@ -171,6 +171,7 @@ class PDQResource extends ResourceBase {
           'url' => $translation->field_pdq_url->value,
           'published' => $translation->status->value,
           'sections' => $sections,
+          'svpc' => $translation->field_pdq_is_svpc->value,
         ];
       }
     }
@@ -285,6 +286,7 @@ class PDQResource extends ResourceBase {
     $node->set('field_page_description', $summary['description']);
     $node->set('field_summary_sections', $sections);
     $node->set('field_public_use', 1);
+    $node->set('field_pdq_is_svpc', $summary['svpc']);
 
     // The syndication field is not translatable.
     if ($language == 'en') {

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/src/Plugin/rest/resource/PDQResource.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/src/Plugin/rest/resource/PDQResource.php
@@ -173,6 +173,7 @@ class PDQResource extends ResourceBase {
           'sections' => $sections,
           'svpc' => $translation->field_pdq_is_svpc->value,
           'suppress_otp' => $translation->field_pdq_suppress_otp->value,
+          'intro_text' => $translation->field_pdq_intro_text->value,
         ];
       }
     }
@@ -287,8 +288,9 @@ class PDQResource extends ResourceBase {
     $node->set('field_page_description', $summary['description']);
     $node->set('field_summary_sections', $sections);
     $node->set('field_public_use', 1);
-    $node->set('field_pdq_is_svpc', $summary['svpc']);
-    $node->set('field_pdq_suppress_otp', $summary['suppress_otp']);
+    $node->set('field_pdq_is_svpc', $summary['svpc'] ?? 0);
+    $node->set('field_pdq_suppress_otp', $summary['suppress_otp'] ?? 0);
+    $node->set('field_pdq_intro_text', $summary['intro_text'] ?? '');
 
     // The syndication field is not translatable.
     if ($language == 'en') {

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/tests/src/Functional/ApiTest.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/tests/src/Functional/ApiTest.php
@@ -58,6 +58,7 @@ class ApiTest extends BrowserTestBase {
       ['id' => '_2', 'title' => 'Section 2', 'html' => '<p>two</p>'],
     ],
     'svpc' => 0,
+    'suppress_otp' => 0,
   ];
 
   /**
@@ -85,6 +86,7 @@ class ApiTest extends BrowserTestBase {
       ['id' => '_2', 'title' => "Secci\u{f3}n 2", 'html' => '<p>Dos</p>'],
     ],
     'svpc' => 1,
+    'suppress_otp' => 1,
   ];
 
   /**
@@ -107,6 +109,7 @@ class ApiTest extends BrowserTestBase {
     'updated_date',
     'url',
     'svpc',
+    'suppress_otp',
   ];
 
   /**
@@ -172,6 +175,7 @@ class ApiTest extends BrowserTestBase {
     $this->english['sections'][] = $section;
     $this->english['description'] = 'Revised test description';
     $this->english['svpc'] = 1;
+    $this->english['suppress_otp'] = 1;
     $payload = $this->store($this->english, 200);
     $summary_sections_created += count($this->english['sections']);
     $this->assertEquals($payload['nid'], $nid, 'Uses same node');

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/tests/src/Functional/ApiTest.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/tests/src/Functional/ApiTest.php
@@ -59,6 +59,7 @@ class ApiTest extends BrowserTestBase {
     ],
     'svpc' => 0,
     'suppress_otp' => 0,
+    'intro_text' => '<p><em>Look!</em></p>',
   ];
 
   /**
@@ -87,6 +88,7 @@ class ApiTest extends BrowserTestBase {
     ],
     'svpc' => 1,
     'suppress_otp' => 1,
+    'intro_text' => '<p><em>¡Mira!</em></p>',
   ];
 
   /**
@@ -110,6 +112,7 @@ class ApiTest extends BrowserTestBase {
     'url',
     'svpc',
     'suppress_otp',
+    'intro_text',
   ];
 
   /**
@@ -176,6 +179,7 @@ class ApiTest extends BrowserTestBase {
     $this->english['description'] = 'Revised test description';
     $this->english['svpc'] = 1;
     $this->english['suppress_otp'] = 1;
+    $this->english['intro_text'] = '<p>Oh, look!</p>';
     $payload = $this->store($this->english, 200);
     $summary_sections_created += count($this->english['sections']);
     $this->assertEquals($payload['nid'], $nid, 'Uses same node');

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/tests/src/Functional/ApiTest.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/tests/src/Functional/ApiTest.php
@@ -57,6 +57,7 @@ class ApiTest extends BrowserTestBase {
       ['id' => '_1', 'title' => 'Section 1', 'html' => '<p>one</p>'],
       ['id' => '_2', 'title' => 'Section 2', 'html' => '<p>two</p>'],
     ],
+    'svpc' => 0,
   ];
 
   /**
@@ -83,6 +84,7 @@ class ApiTest extends BrowserTestBase {
       ['id' => '_1', 'title' => "Secci\u{f3}n 1", 'html' => '<p>Uno</p>'],
       ['id' => '_2', 'title' => "Secci\u{f3}n 2", 'html' => '<p>Dos</p>'],
     ],
+    'svpc' => 1,
   ];
 
   /**
@@ -104,6 +106,7 @@ class ApiTest extends BrowserTestBase {
     'summary_type',
     'updated_date',
     'url',
+    'svpc',
   ];
 
   /**
@@ -168,6 +171,7 @@ class ApiTest extends BrowserTestBase {
     $section = ['id' => '_3', 'title' => 'Section 3', 'html' => '<p>3</p>'];
     $this->english['sections'][] = $section;
     $this->english['description'] = 'Revised test description';
+    $this->english['svpc'] = 1;
     $payload = $this->store($this->english, 200);
     $summary_sections_created += count($this->english['sections']);
     $this->assertEquals($payload['nid'], $nid, 'Uses same node');
@@ -237,7 +241,7 @@ class ApiTest extends BrowserTestBase {
     $response = $this->request('GET', "$this->pdqUrl/list");
     $this->assertEquals($response->getStatusCode(), 200);
     $values = json_decode($response->getBody()->__toString(), TRUE);
-    $this->assertCount(2, $values, 'One entries in catalog');
+    $this->assertCount(2, $values, 'Two entries in catalog');
 
     // Results are ordered by CDR ID, so this is the Spanish summary.
     $entry = array_pop($values);

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/pdq/node--pdq-cancer-information-summary--full.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/pdq/node--pdq-cancer-information-summary--full.html.twig
@@ -9,6 +9,9 @@
     {{ drupal_block('page_options') }}
     <div id="cgvBody">
       <div class="summary-sections">
+        {% if node.field_pdq_intro_text.value is not empty %}
+          {{ node.field_pdq_intro_text.value|raw }}
+        {% endif %}
         {% if node.field_pdq_suppress_otp.value == '0' %}
           {{ content.otp_toc }}
         {% endif %}

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/pdq/node--pdq-cancer-information-summary--full.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/pdq/node--pdq-cancer-information-summary--full.html.twig
@@ -9,7 +9,9 @@
     {{ drupal_block('page_options') }}
     <div id="cgvBody">
       <div class="summary-sections">
-        {{ content.otp_toc }}
+        {% if node.field_pdq_suppress_otp.value == '0' %}
+          {{ content.otp_toc }}
+        {% endif %}
         <div class="accordion">
           {{ content.field_summary_sections }}
         </div>

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/pdq/node--pdq-cancer-information-summary--hhs-syndication.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/pdq/node--pdq-cancer-information-summary--hhs-syndication.html.twig
@@ -16,6 +16,9 @@
 <h2 id="bodyTitle">{{ node.label }}</h2>
 <div id="bodyContent">
     <div class="summaryPage">
+        {% if node.field_pdq_intro_text.value is not empty %}
+          {{ node.field_pdq_intro_text.value|raw }}
+        {% endif %}
         {{ content.field_summary_sections }}
     </div>
 </div>


### PR DESCRIPTION
Three fields have been added to the `pdq_cancer_information_summary` content type to support the _Single View Patient Content_ project.

- A new flag (`field_pdq_is_svpc`) indicating that the summary is an SVPC summary (#3231)
- A new flag (`field_pdq_suppress_otp`) indicating that the _On This Page_ links section should not be displayed (#3230)
- A new raw HTML field (`field_pdq_intro_text`) to be displayed if present at the top of the page for the summary, following the title but preceding the summary sections (and the _On This Page_ links if those are present) (#3229)

Closes #3229
Closes #3230
Closes #3231