### PR TITLE
Add support for the SVPC project

### DIFF
--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/svpc_liver-cancer-causes-risk-factors-and-prevention.content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/svpc_liver-cancer-causes-risk-factors-and-prevention.content.yml
@@ -1,0 +1,153 @@
+- entity: node
+  type: pdq_cancer_information_summary
+  title: 'Liver Cancer Causes, Risk Factors, and Prevention'
+  status: 1
+  langcode: en
+  field_hhs_syndication:
+    - syndicate: 1
+      keywords: ''
+  moderation_state:
+    value: published
+  field_pdq_url:
+    value: /test/types/liver/what-is-liver-cancer/causes-risk-factors
+  field_pdq_cdr_id:
+    value: 2000003
+  field_pdq_audience:
+    value: Patients
+  field_pdq_summary_type:
+    value: Causes, risk factors, and prevention
+  field_date_posted:
+    value: '2021-10-27'
+  field_date_updated:
+    value: '2021-11-17'
+  field_browser_title:
+    value: 'Liver Cancer Causes, Risk Factors, and Prevention'
+  field_page_description:
+    value: 'Placeholder'
+  field_public_use:
+    value: 1
+  field_pdq_is_svpc:
+    value: 1
+  field_pdq_suppress_otp:
+    value: 1
+  field_pdq_intro_text:
+    value:
+  field_summary_sections:
+    - entity: paragraph
+      type: pdq_summary_section
+      field_pdq_section_id:
+        value: _3
+      field_pdq_section_title:
+        - format: plain_text
+          value: 'Liver Cancer Causes'
+      field_pdq_section_html:
+        - format: raw_html
+          value: |
+            <div id="_section_3" class="pdq-sections"><p id="_31" tabindex="-1">Being infected with certain types of the hepatitis virus can cause hepatitis and may lead to liver cancer. <a class="definition" type="GlossaryTermRefs" href="/Common/PopUps/popDefinition.aspx?id=46371&amp;version=patient&amp;language=English&amp;dictionary=Cancer.gov" onclick="javascript:popWindow('defbyid','CDR0000046371&amp;version=patient&amp;language=English&amp;dictionary=Cancer.gov'); return(false);">Hepatitis</a> is most commonly caused by the hepatitis virus. Hepatitis is a disease that causes inflammation (swelling) of the liver. Damage to the liver from hepatitis that lasts a long time can increase the risk of liver cancer.</p><p id="_32" tabindex="-1"><a class="definition" type="GlossaryTermRefs" href="/Common/PopUps/popDefinition.aspx?id=46146&amp;version=patient&amp;language=English&amp;dictionary=Cancer.gov" onclick="javascript:popWindow('defbyid','CDR0000046146&amp;version=patient&amp;language=English&amp;dictionary=Cancer.gov'); return(false);">Hepatitis B</a> (HBV) and <a class="definition" type="GlossaryTermRefs" href="/Common/PopUps/popDefinition.aspx?id=44139&amp;version=patient&amp;language=English&amp;dictionary=Cancer.gov" onclick="javascript:popWindow('defbyid','CDR0000044139&amp;version=patient&amp;language=English&amp;dictionary=Cancer.gov'); return(false);">hepatitis C</a> (HCV) are two types of the hepatitis virus. </p><div class="pdq-content-list"><ul id="_7"><li><strong>Hepatitis B</strong>: HBV is caused by contact with the blood, <a class="definition" type="GlossaryTermRefs" href="/Common/PopUps/popDefinition.aspx?id=46703&amp;version=patient&amp;language=English&amp;dictionary=Cancer.gov" onclick="javascript:popWindow('defbyid','CDR0000046703&amp;version=patient&amp;language=English&amp;dictionary=Cancer.gov'); return(false);">semen</a>, or other body <a class="definition" type="GlossaryTermRefs" href="/Common/PopUps/popDefinition.aspx?id=44669&amp;version=patient&amp;language=English&amp;dictionary=Cancer.gov" onclick="javascript:popWindow('defbyid','CDR0000044669&amp;version=patient&amp;language=English&amp;dictionary=Cancer.gov'); return(false);">fluid</a> of a person infected with HBV virus. The infection can be passed from mother to child during childbirth, through sexual contact, or by sharing needles that are used to <a class="definition" type="GlossaryTermRefs" href="/Common/PopUps/popDefinition.aspx?id=44678&amp;version=patient&amp;language=English&amp;dictionary=Cancer.gov" onclick="javascript:popWindow('defbyid','CDR0000044678&amp;version=patient&amp;language=English&amp;dictionary=Cancer.gov'); return(false);">inject</a> <a class="definition" type="GlossaryTermRefs" href="/Common/PopUps/popDefinition.aspx?id=348921&amp;version=patient&amp;language=English&amp;dictionary=Cancer.gov" onclick="javascript:popWindow('defbyid','CDR0000348921&amp;version=patient&amp;language=English&amp;dictionary=Cancer.gov'); return(false);">drugs</a>. It can cause scarring of the liver (<a class="definition" type="GlossaryTermRefs" href="/Common/PopUps/popDefinition.aspx?id=45478&amp;version=patient&amp;language=English&amp;dictionary=Cancer.gov" onclick="javascript:popWindow('defbyid','CDR0000045478&amp;version=patient&amp;language=English&amp;dictionary=Cancer.gov'); return(false);">cirrhosis</a>) that may lead to liver cancer.</li><li><strong>Hepatitis C</strong>: HCV is caused by contact with the blood of a person infected with HCV virus. The infection can be spread by sharing needles that are used to inject drugs or, less often, through sexual contact. In the past, it was also spread during <a class="definition" type="GlossaryTermRefs" href="/Common/PopUps/popDefinition.aspx?id=45991&amp;version=patient&amp;language=English&amp;dictionary=Cancer.gov" onclick="javascript:popWindow('defbyid','CDR0000045991&amp;version=patient&amp;language=English&amp;dictionary=Cancer.gov'); return(false);">blood transfusions</a> or organ <a class="definition" type="GlossaryTermRefs" href="/Common/PopUps/popDefinition.aspx?id=46631&amp;version=patient&amp;language=English&amp;dictionary=Cancer.gov" onclick="javascript:popWindow('defbyid','CDR0000046631&amp;version=patient&amp;language=English&amp;dictionary=Cancer.gov'); return(false);">transplants</a>. Today, blood banks test all donated blood for HCV, which greatly lowers the risk of getting the virus from blood transfusions. It can cause scarring of the liver (cirrhosis) that may lead to liver cancer.</li></ul></div><p id="_33" tabindex="-1">Chronic infection with HBV or HCV can increase the risk of liver cancer. The risk is even higher for people with both HBV and HCV, and for people who have other <a class="definition" type="GlossaryTermRefs" href="/Common/PopUps/popDefinition.aspx?id=45873&amp;version=patient&amp;language=English&amp;dictionary=Cancer.gov" onclick="javascript:popWindow('defbyid','CDR0000045873&amp;version=patient&amp;language=English&amp;dictionary=Cancer.gov'); return(false);">risk factors</a> in addition to the<a class="definition" type="GlossaryTermRefs" href="/Common/PopUps/popDefinition.aspx?id=46371&amp;version=patient&amp;language=English&amp;dictionary=Cancer.gov" onclick="javascript:popWindow('defbyid','CDR0000046371&amp;version=patient&amp;language=English&amp;dictionary=Cancer.gov'); return(false);"> hepatitis virus</a>. Men with chronic HBV or HCV infection are more likely to develop liver cancer than are women with the same chronic infection.</p><p id="_34" tabindex="-1">Chronic HBV infection is the leading cause of liver cancer in Asia and Africa. Chronic HCV infection is the leading cause of liver cancer in North America, Europe, and Japan.</p></div>
+    - entity: paragraph
+      type: pdq_summary_section
+      field_pdq_section_id:
+        value: _10
+      field_pdq_section_title:
+        - format: plain_text
+          value: 'Liver Cancer Risk Factors'
+      field_pdq_section_html:
+        - format: raw_html
+          value: |
+            <div id="_section_10" class="pdq-sections"><p id="_11" tabindex="-1">Anything that increases your chance of getting cancer is called a risk factor. Having a risk factor does not mean that you will get cancer; not having risk factors doesn't mean that you will not get cancer.</p><p id="_12" tabindex="-1">The following are other risk factors that may increase the risk of liver cancer:</p><div class="pdq-content-list"><ul id="_13"><li><strong>Cirrhosis</strong>
+            <p id="_14" tabindex="-1">The risk of developing liver cancer is increased for people who have cirrhosis, a disease in which healthy liver tissue is replaced by scar tissue. The scar tissue blocks the flow of blood through the liver and keeps it from working as it should. Chronic alcoholism and chronic hepatitis infections are common causes of cirrhosis. People with HCV-related cirrhosis have a higher risk of developing liver cancer than people with cirrhosis related to HBV or alcohol use.</p>
+            </li><li><strong>Heavy alcohol use</strong>
+            <p id="_15" tabindex="-1">Heavy alcohol use can cause cirrhosis, which is a risk factor for liver cancer. Liver cancer can also occur in heavy alcohol users who do not have cirrhosis. Heavy alcohol users who have cirrhosis are ten times more likely to develop liver cancer, compared with heavy alcohol users who do not have cirrhosis.</p><p id="_16" tabindex="-1">Studies have shown there is also an increased risk of liver cancer in people with HBV or HCV infection who use alcohol heavily.</p>
+            </li><li><strong>Aflatoxin B1</strong>
+            <p id="_17" tabindex="-1">The risk of developing liver cancer may be increased by eating foods that contain aflatoxin B1 (poison from a fungus that can grow on foods, such as corn and nuts, that have been stored in hot, humid places). It is most common in sub-Saharan Africa, Southeast Asia, and China.</p>
+            </li><li><strong>Nonalcoholic steatohepatitis (NASH)</strong>
+            <p id="_18" tabindex="-1">Nonalcoholic steatohepatitis (NASH) is a condition that can cause scarring of the liver (cirrhosis) that may lead to liver cancer. It is the most severe form of nonalcoholic fatty liver disease (NAFLD), where there is an abnormal amount of fat in the liver. In some people, this can cause inflammation (swelling) and injury to the cells of the liver.</p><p id="_19" tabindex="-1">Having NASH-related cirrhosis increases the risk of developing liver cancer. Liver cancer has also been found in people with NASH who do not have cirrhosis.</p>
+            </li><li><strong>Cigarette smoking</strong>
+            <p id="_20" tabindex="-1">Cigarette smoking has been linked to a higher risk of liver cancer. The risk increases with the number of cigarettes smoked per day and the number of years the person has smoked.</p>
+            </li><li><strong>Other conditions</strong>
+            <p id="_21" tabindex="-1">Certain rare medical and genetic conditions may increase the risk of liver cancer. These conditions include the following:</p><div class="pdq-content-list"><ul id="_22" class="list-dash"><li>Untreated <a class="definition" type="GlossaryTermRefs" href="/Common/PopUps/popDefinition.aspx?id=797037&amp;version=patient&amp;language=English&amp;dictionary=Cancer.gov" onclick="javascript:popWindow('defbyid','CDR0000797037&amp;version=patient&amp;language=English&amp;dictionary=Cancer.gov'); return(false);">hereditary hemochromatosis</a> (HH)</li><li><a class="definition" type="GlossaryTermRefs" href="/Common/PopUps/popDefinition.aspx?id=797047&amp;version=patient&amp;language=English&amp;dictionary=Cancer.gov" onclick="javascript:popWindow('defbyid','CDR0000797047&amp;version=patient&amp;language=English&amp;dictionary=Cancer.gov'); return(false);">Alpha-1 antitrypsin (AAT) deficiency</a></li><li><a class="definition" type="GlossaryTermRefs" href="/Common/PopUps/popDefinition.aspx?id=748984&amp;version=patient&amp;language=English&amp;dictionary=Cancer.gov" onclick="javascript:popWindow('defbyid','CDR0000748984&amp;version=patient&amp;language=English&amp;dictionary=Cancer.gov'); return(false);">Glycogen storage disease</a></li><li><a class="definition" type="GlossaryTermRefs" href="/Common/PopUps/popDefinition.aspx?id=797043&amp;version=patient&amp;language=English&amp;dictionary=Cancer.gov" onclick="javascript:popWindow('defbyid','CDR0000797043&amp;version=patient&amp;language=English&amp;dictionary=Cancer.gov'); return(false);">Porphyria cutanea tarda</a> (PCT)</li><li><a class="definition" type="GlossaryTermRefs" href="/Common/PopUps/popDefinition.aspx?id=797039&amp;version=patient&amp;language=English&amp;dictionary=Cancer.gov" onclick="javascript:popWindow('defbyid','CDR0000797039&amp;version=patient&amp;language=English&amp;dictionary=Cancer.gov'); return(false);">Wilson disease</a></li></ul></div>
+            </li></ul></div></div>
+    - entity: paragraph
+      type: pdq_summary_section
+      field_pdq_section_id:
+        value: _23
+      field_pdq_section_title:
+        - format: plain_text
+          value: 'Liver Cancer Prevention'
+      field_pdq_section_html:
+        - format: raw_html
+          value: |
+            <div id="_section_23" class="pdq-sections"><div class="pdq-content-list"><ul id="_24"><li><strong>Hepatitis B vaccine
+            </strong><p id="_25" tabindex="-1">Preventing HBV infection (by being vaccinated for HBV as a newborn) has been shown to lower the risk of liver cancer in children. It is not yet known if being vaccinated lowers the risk of liver cancer in adults.</p>
+            </li><li><strong>Treatment for chronic hepatitis B infection
+            </strong><p id="_26" tabindex="-1">Treatment options for people with chronic HBV infection include <a class="definition" type="GlossaryTermRefs" href="/Common/PopUps/popDefinition.aspx?id=45324&amp;version=patient&amp;language=English&amp;dictionary=Cancer.gov" onclick="javascript:popWindow('defbyid','CDR0000045324&amp;version=patient&amp;language=English&amp;dictionary=Cancer.gov'); return(false);">interferon</a> and nucleos(t)ide <a class="definition" type="GlossaryTermRefs" href="/Common/PopUps/popDefinition.aspx?id=44919&amp;version=patient&amp;language=English&amp;dictionary=Cancer.gov" onclick="javascript:popWindow('defbyid','CDR0000044919&amp;version=patient&amp;language=English&amp;dictionary=Cancer.gov'); return(false);">analog</a> (NA) <a class="definition" type="GlossaryTermRefs" href="/Common/PopUps/popDefinition.aspx?id=44737&amp;version=patient&amp;language=English&amp;dictionary=Cancer.gov" onclick="javascript:popWindow('defbyid','CDR0000044737&amp;version=patient&amp;language=English&amp;dictionary=Cancer.gov'); return(false);">therapy</a>. These treatments may reduce the risk of developing liver cancer.</p>
+            </li><li>
+            <strong>Reduced exposure to aflatoxin B1
+            </strong><p id="_27" tabindex="-1">Replacing foods that contain high amounts of aflatoxin B1 with foods that contain a much lower level of the poison can reduce the risk of liver cancer.</p>
+            </li></ul></div></div>
+  title__ES:
+    value: 'Causas, factores de riesgo y prevención del cáncer de hígado'
+  status__ES:
+    value: 1
+  langcode__ES:
+    value: es
+  moderation_state:__ES:
+    value: published
+  field_pdq_url__ES:
+    value: /test/espanol/typos/higado/que-es-el-cancer-de-higado/causas-factores-de-riesgo
+  field_pdq_cdr_id__ES:
+    value: 2000004
+  field_pdq_audience__ES:
+    value: Patients
+  field_pdq_summary_type__ES:
+    value: Causes, risk factors, and prevention
+  field_date_posted__ES:
+    value: '2022-02-11'
+  field_date_updated__ES:
+    value: '2022-02-14'
+  field_browser_title__ES:
+    value: 'Causas, factores de riesgo y prevención del cáncer de hígado'
+  field_page_description__ES:
+    value: 'Marcador de posición'
+  field_public_use__ES:
+    value: 1
+  field_pdq_is_svpc__ES:
+    value: 1
+  field_pdq_suppress_otp__ES:
+    value: 1
+  field_pdq_intro_text__ES:
+    value:
+  field_summary_sections__ES:
+    - entity: paragraph
+      type: pdq_summary_section
+      field_pdq_section_id:
+        value: _1
+      field_pdq_section_title:
+        - format: plain_text
+          value: 'Causas del cáncer de hígado'
+      field_pdq_section_html:
+        - format: raw_html
+          value: |
+            <div id="_section_1" class="pdq-sections"><p>Envoltura tejida tutor kraut, unas glándulas sudoríparas de ricino añaden Any-bally, den vomitado maldito tutor gruñido un dardo robado honra a las gallinas, una neblina deformada honra a las gallinas peniques.</p><div>
+    - entity: paragraph
+      type: pdq_summary_section
+      field_pdq_section_id:
+        value: _2
+      field_pdq_section_title:
+        - format: plain_text
+          value: 'Factores de riesgo del cáncer de hígado'
+      field_pdq_section_html:
+        - format: raw_html
+          value: |
+            <div id="_section_1" class="pdq-sections"><p>Compró menos, tenedores! ¿ Pasear ni verrugas saltando ? Wail, doze putty versus becalm cerebrated—un Casing becalm cerebrated, toe! Bolsa de sutura kraut fuera de la espinilla del dedo del pie de la leva Mutt-fill toe shag gallinas más húmedo hansom borsch hervir alicates deuda Carcasa ganar entrar trucos de salón, un gat vomitar. Una, arcada intestinal que relincha (¿conjurar gas?) La carcasa encalma la puerta desviada del establo de la cuchara de masilla Any-bally.</p><div>
+    - entity: paragraph
+      type: pdq_summary_section
+      field_pdq_section_id:
+        value: _3
+      field_pdq_section_title:
+        - format: plain_text
+          value: 'Prevención del cáncer de hígado'
+      field_pdq_section_html:
+        - format: raw_html
+          value: |
+            <div id="_section_1" class="pdq-sections"><p>Sonrisa interior, cucharón Any-bally, azada, laca, vidente, holgazán, mucker, bolsa, potro, nutria, jamón, estante, bay-ganso, limpiaparabrisas, hielo, mojado, rojizo, cucharón, perezoso, anhelo, oler.</p><div>

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/svpc_liver-cancer-diagnosis.content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/svpc_liver-cancer-diagnosis.content.yml
@@ -1,0 +1,90 @@
+- entity: node
+  type: pdq_cancer_information_summary
+  title: 'Liver Cancer Diagnosis'
+  status: 1
+  langcode: en
+  field_hhs_syndication:
+    - syndicate: 1
+      keywords: ''
+  moderation_state:
+    value: published
+  field_pdq_url:
+    value: /test/types/liver/what-is-liver-cancer/diagnosis
+  field_pdq_cdr_id:
+    value: 2000005
+  field_pdq_audience:
+    value: Patients
+  field_pdq_summary_type:
+    value: Genetics
+  field_date_posted:
+    value: '2021-11-17'
+  field_date_updated:
+    value: '2022-01-12'
+  field_browser_title:
+    value: 'Liver Cancer Diagnosis'
+  field_page_description:
+    value: 'Medical tests that examine the liver and the blood are used to detect and diagnose liver cancer. Learn about liver cancer diagnosis from the nation’s top health experts.'
+  field_public_use:
+    value: 1
+  field_pdq_is_svpc:
+    value: 1
+  field_pdq_suppress_otp:
+    value: 0
+  field_pdq_intro_text:
+    value:
+  field_summary_sections:
+    - entity: paragraph
+      type: pdq_summary_section
+      field_pdq_section_id:
+        value: _1
+      field_pdq_section_title:
+        - format: plain_text
+          value: 'Diagnosing Liver Cancer'
+      field_pdq_section_html:
+        - format: raw_html
+          value: |
+            <div id="_section_1" class="pdq-sections"><p id="_2" tabindex="-1">Tests that examine the liver and the blood are used to detect and diagnose liver cancer. Every person will not receive all the tests described below.</p><p id="_3" tabindex="-1">The following tests and procedures may be used:</p><div class="pdq-content-list"><ul id="_4"><li><strong>Physical exam&#8239;and&#8239;history:</strong> A physical exam of the body will be done to check a person&#8217;s health, including checking for signs of disease, such as lumps or anything else that seems unusual. A history of the patient&#8217;s health habits and past illnesses and treatments will also be taken.</li><li><strong>Alpha-fetoprotein tumor marker test:</strong> Tumor markers are released into the blood by organs, tissues, or tumor cells in the body. An increased level of alpha-fetoprotein (AFP) in the blood may be a sign of liver cancer. Other cancers and certain noncancerous conditions, including cirrhosis and hepatitis, may also increase AFP levels. Sometimes the AFP level is normal even when there is liver cancer.</li><li><strong>Liver function tests:</strong> These blood tests measure the amounts of certain substances released into the blood by the liver. A higher-than-normal amount of a substance can be a sign of liver cancer.</li><li><strong>CT scan&#8239;(CAT scan):</strong> This procedure uses a computer linked to an x-ray machine to make a series of detailed pictures of areas inside the body, such as the abdomen, taken from different angles. A dye may be injected into a vein or swallowed to help the organs or tissues show up more clearly. This procedure is also called computed tomography, computerized tomography, or computerized axial tomography. Images may be taken at three different times after the dye is injected, to get the best picture of abnormal areas in the liver. This is called triple-phase CT. A spiral or helical CT scan makes a series of very detailed pictures of areas inside the body using an x-ray machine that scans the body in a spiral path.</li><li><strong>MRI&#8239;(magnetic resonance imaging):</strong> This procedure uses a magnet, radio waves, and a computer to make a series of detailed pictures of areas inside the body, such as the liver. This procedure is also called nuclear magnetic resonance imaging (NMRI). To create detailed pictures of blood vessels in and near the liver, dye is injected into a vein. This procedure is called MRA (magnetic resonance angiography). Images may be taken at three different times after the dye is injected, to get the best picture of abnormal areas in the liver. This is called triple-phase MRI.</li><li><strong>Ultrasound&#8239;exam:</strong> This procedure uses high-energy sound waves (ultrasound) that are bounced off the liver and make echoes. The echoes form a picture of the liver called a sonogram.</li><li><strong>Biopsy:</strong> During a biopsy, cells or tissues are removed so they can be viewed under a microscope by a pathologist to check for signs of cancer. Procedures used to collect the sample of cells or tissues include the following:<div class="pdq-content-list"><ul id="_5"><li><strong>Fine-needle aspiration biopsy:</strong> A sample of fluid, tissue, or cells is removed using a thin needle.</li><li><strong>Core needle biopsy:</strong> A sample of cells or tissue is removed using a slightly wider needle.</li><li><strong>Laparoscopy:</strong> This surgical procedure is done to look at the organs inside the abdomen to check for signs of disease. Small incisions (cuts) are made in the wall of the abdomen and a laparoscope (a thin, lighted tube) is inserted into one of the incisions. Another instrument is inserted through the same or another incision to remove the tissue samples.</li></ul></div><p id="_75" tabindex="-1">A biopsy is not always needed to diagnose liver cancer. Sometimes the doctors can diagnose liver cancer based on the results of imaging tests such as CT scans and MRI.</p></li></ul></div><p id="_6" tabindex="-1">After primary liver cancer has been diagnosed, tests are done to find out if cancer cells have spread within the liver or to other parts of the body. The process of determining the size and location of the cancer and whether it has spread is called staging.</p><p id="_76" tabindex="-1">The following tests and procedures may be used in the staging process:</p><div class="pdq-content-list"><ul id="_77"><li><strong>CT scan (CAT scan):</strong> A procedure that makes a series of detailed pictures of areas inside the body, such as the chest, abdomen, and pelvis, taken from different angles. The pictures are made by a computer linked to an x-ray machine. A dye may be injected into a vein or swallowed to help the organs or tissues show up more clearly. This procedure is also called computed tomography, computerized tomography, or computerized axial tomography.</li><li><strong>MRI (magnetic resonance imaging):</strong> A procedure that uses a magnet, radio waves, and a computer to make a series of detailed pictures of areas inside the body. This procedure is also called nuclear magnetic resonance imaging (NMRI).</li><li><strong>PET scan (positron emission tomography scan):</strong> A procedure to find malignant tumor cells in the body. A small amount of radioactive glucose (sugar) is injected into a vein. The PET scanner rotates around the body and makes a picture of where glucose is being used in the body. Malignant tumor cells show up brighter in the picture because they are more active and take up more glucose than normal cells do.</li></ul></div></div>
+  title__ES:
+    value: 'Diagnóstico de cáncer de hígado'
+  status__ES:
+    value: 1
+  langcode__ES:
+    value: es
+  moderation_state:__ES:
+    value: published
+  field_pdq_url__ES:
+    value: /test/espanol/typos/higado/que-es-el-cancer-de-higado/diagnostico
+  field_pdq_cdr_id__ES:
+    value: 2000006
+  field_pdq_audience__ES:
+    value: Patients
+  field_pdq_summary_type__ES:
+    value: Genetics
+  field_date_posted__ES:
+    value: '2022-02-11'
+  field_date_updated__ES:
+    value: '2022-02-14'
+  field_browser_title__ES:
+    value: 'Diagnóstico de cáncer de hígado'
+  field_page_description__ES:
+    value: 'Las pruebas médicas que examinan el hígado y la sangre se utilizan para detectar y diagnosticar el cáncer de hígado. Obtenga información sobre el diagnóstico de cáncer de hígado de parte de los principales expertos en salud del país.'
+  field_public_use__ES:
+    value: 1
+  field_pdq_is_svpc__ES:
+    value: 1
+  field_pdq_suppress_otp__ES:
+    value: 0
+  field_pdq_intro_text__ES:
+    value:
+  field_summary_sections__ES:
+    - entity: paragraph
+      type: pdq_summary_section
+      field_pdq_section_id:
+        value: _1
+      field_pdq_section_title:
+        - format: plain_text
+          value: 'Diagnóstico del cáncer de hígado'
+      field_pdq_section_html:
+        - format: raw_html
+          value: |
+            <div id="_section_1" class="pdq-sections"><p>Violar el forraje más húmedo, aceitado Antiguos descascarillados, repetición del sombrerero de la azada, explosión de piel, arcadas peludas, un hedor peludo. Infectar, espinilla huérfana establecer deuda Violar forraje peor olfateando mouser aceitado. Violar, honrar la ubre de la gallina, los mosquitos peludos de estambre, el párroco, el cucharón de masilla de bufón, la forma de la gaviota, la muestra, la mortaja, una no afligida.</p><div>

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/svpc_liver-cancer-treatment.content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/svpc_liver-cancer-treatment.content.yml
@@ -1,0 +1,313 @@
+- entity: node
+  type: pdq_cancer_information_summary
+  title: 'Liver Cancer Treatment'
+  status: 1
+  langcode: en
+  field_hhs_syndication:
+    - syndicate: 1
+      keywords: ''
+  moderation_state:
+    value: published
+  field_pdq_url:
+    value: /test/types/liver/what-is-liver-cancer/treatment
+  field_pdq_cdr_id:
+    value: 2000007
+  field_pdq_audience:
+    value: Patients
+  field_pdq_summary_type:
+    value: Treatment
+  field_date_posted:
+    value: '2021-11-16'
+  field_date_updated:
+    value: '2021-11-15'
+  field_browser_title:
+    value: 'Liver Cancer Treatment'
+  field_page_description:
+    value: 'Treatment of liver cancer in adults depends on the stage. Treatment options include hepatectomy, liver transplant, ablation, electroporation therapy (EPT), embolization therapy, targeted therapy, and/or radiation therapy. Learn more about treatment for the different stages of liver cancer.'
+  field_public_use:
+    value: 1
+  field_pdq_is_svpc:
+    value: 1
+  field_pdq_suppress_otp:
+    value: 0
+  field_pdq_intro_text:
+    value: |
+      <div id="_section_44" class="pdq-sections"><p id="_47" tabindex="-1">This is an intro text. For more information, see <a href="https://www.cancer.gov/about-cancer/treatment/side-effects" title="https://www.cancer.gov/about-cancer/treatment/side-effects">Side Effects of Cancer Treatment.</a></p></div>
+  field_summary_sections:
+    - entity: paragraph
+      type: pdq_summary_section
+      field_pdq_section_id:
+        value: _265
+      field_pdq_section_title:
+        - format: plain_text
+          value: 'Surveillance'
+      field_pdq_section_html:
+        - format: raw_html
+          value: |
+            <div id="_section_265" class="pdq-sections"><p id="_267" tabindex="-1"><a class="definition" type="GlossaryTermRefs" href="/Common/PopUps/popDefinition.aspx?id=496506&amp;version=patient&amp;language=English&amp;dictionary=Cancer.gov" onclick="javascript:popWindow('defbyid','CDR0000496506&amp;version=patient&amp;language=English&amp;dictionary=Cancer.gov'); return(false);">Surveillance</a> for lesions smaller than 1 centimeter found during screening.  Follow-up every three months is common.</p></div>
+    - entity: paragraph
+      type: pdq_summary_section
+      field_pdq_section_id:
+        value: _51
+      field_pdq_section_title:
+        - format: plain_text
+          value: 'Surgery'
+      field_pdq_section_html:
+        - format: raw_html
+          value: |
+            <div id="_section_51" class="pdq-sections"><p id="_53" tabindex="-1">A partial hepatectomy (surgery to remove the part of the liver where cancer is found) may be done. A wedge of tissue, an entire lobe, or a larger part of the liver, along with some of the healthy tissue around  it is removed. The remaining liver tissue takes over the functions of the liver and may regrow.</p></div>
+    - entity: paragraph
+      type: pdq_summary_section
+      field_pdq_section_id:
+        value: _232
+      field_pdq_section_title:
+        - format: plain_text
+          value: 'Ablation therapy'
+      field_pdq_section_html:
+        - format: raw_html
+          value: |
+            <div id="_section_232" class="pdq-sections"><p id="_234" tabindex="-1">Ablation therapy removes or destroys tissue. Different types of ablation therapy are used for liver cancer:</p><div class="pdq-content-list"><ul id="_235"><li><strong>Radiofrequency ablation:</strong> The use of special needles  that are inserted directly through the skin or through an incision in the abdomen to reach the tumor. High-energy radio waves heat the needles and tumor which kills cancer cells.</li><li><strong>Microwave therapy:   </strong>A type of treatment in which the tumor is exposed to high temperatures created by microwaves. This can damage and kill cancer cells or make them more sensitive to the effects of radiation and certain anticancer drugs. </li><li><strong>Percutaneous ethanol injection:</strong> A cancer treatment in which a small needle is used to inject ethanol (pure alcohol) directly into a tumor to kill cancer cells. Several treatments may be needed. Usually local anesthesia is used, but if the patient has many tumors in the liver, general anesthesia may be used.
+            </li><li><strong>Cryoablation:</strong> A treatment that uses an instrument to freeze and destroy cancer cells.  This type of treatment is also called cryotherapy and cryosurgery. The doctor may use ultrasound to guide the instrument.</li><li><strong>Electroporation therapy:</strong>  A treatment that sends electrical pulses through an electrode placed in a tumor to kill cancer cells. Electroporation therapy is being studied in clinical trials.</li></ul></div></div>
+    - entity: paragraph
+      type: pdq_summary_section
+      field_pdq_section_id:
+        value: _250
+      field_pdq_section_title:
+        - format: plain_text
+          value: 'Embolization therapy'
+      field_pdq_section_html:
+        - format: raw_html
+          value: |
+            <div id="_section_250" class="pdq-sections"><p id="_256" tabindex="-1">Embolization therapy is the use of substances to block or decrease the flow of blood through the hepatic artery to the tumor. When the tumor does not get the oxygen and nutrients it needs, it will not continue to grow. Embolization therapy is used for patients who cannot have surgery to remove the tumor or ablation therapy and whose tumor has not spread outside the liver.</p><p id="_252" tabindex="-1">The liver receives blood from the hepatic portal vein and the hepatic artery. Blood that comes into the liver from the hepatic portal vein usually goes to the healthy liver tissue. Blood that comes from the hepatic artery usually goes to the tumor. When the hepatic artery is blocked during embolization therapy, the healthy  liver tissue continues to receive blood from the hepatic portal vein. </p><p id="_253" tabindex="-1">There are two main types of embolization therapy:</p><div class="pdq-content-list"><ul id="_254"><li><strong>Transarterial embolization (TAE)</strong>: A small incision (cut) is made in the inner thigh and a catheter (thin, flexible tube) is inserted and threaded up into the hepatic artery. Once the catheter is in place, a substance that blocks the hepatic artery and stops blood flow to the tumor is injected.</li><li><strong>Transarterial chemoembolization (TACE)</strong>: This procedure is like TAE except an anticancer drug is also given. The procedure can be done by attaching the anticancer drug to small beads that are injected into the hepatic artery or by injecting the anticancer drug through the catheter into the hepatic artery and then injecting the substance to block the hepatic artery. Most of the anticancer drug is trapped near  the tumor and only a small amount of the drug  reaches other parts of the body. This type of treatment is also called chemoembolization.</li></ul></div></div>
+    - entity: paragraph
+      type: pdq_summary_section
+      field_pdq_section_id:
+        value: _187
+      field_pdq_section_title:
+        - format: plain_text
+          value: 'Targeted therapy'
+      field_pdq_section_html:
+        - format: raw_html
+          value: |
+            <div id="_section_187" class="pdq-sections"><p id="_189" tabindex="-1">Targeted therapy is a treatment that uses drugs or other substances to identify and attack specific cancer cells without harming normal cells.  Tyrosine kinase inhibitors are a type of targeted therapy used in the treatment of adult primary liver cancer.</p><p id="_459" tabindex="-1">Tyrosine kinase inhibitors are&#8239;small-molecule drugs&#8239;that go through the cell&#8239;membrane&#8239;and work inside cancer cells to block signals that cancer cells need to grow and divide. Some tyrosine kinase inhibitors also have&#8239;angiogenesis inhibitor effects. Types of tyrosine kinase inhibitors used to treat advanced liver cancer include:</p><div class="pdq-content-list"><ul id="_534"><li><a class="definition" type="GlossaryTermRefs" href="/Common/PopUps/popDefinition.aspx?id=509041&amp;version=patient&amp;language=English&amp;dictionary=Cancer.gov" onclick="javascript:popWindow('defbyid','CDR0000509041&amp;version=patient&amp;language=English&amp;dictionary=Cancer.gov'); return(false);">Sorafenib</a></li><li><a class="definition" type="GlossaryTermRefs" href="/Common/PopUps/popDefinition.aspx?id=769612&amp;version=patient&amp;language=English&amp;dictionary=Cancer.gov" onclick="javascript:popWindow('defbyid','CDR0000769612&amp;version=patient&amp;language=English&amp;dictionary=Cancer.gov'); return(false);">lenvatinib</a></li><li><a class="definition" type="GlossaryTermRefs" href="/Common/PopUps/popDefinition.aspx?id=740896&amp;version=patient&amp;language=English&amp;dictionary=Cancer.gov" onclick="javascript:popWindow('defbyid','CDR0000740896&amp;version=patient&amp;language=English&amp;dictionary=Cancer.gov'); return(false);">regorafenib</a></li><li><a class="definition" type="GlossaryTermRefs" href="/Common/PopUps/popDefinition.aspx?id=743915&amp;version=patient&amp;language=English&amp;dictionary=Cancer.gov" onclick="javascript:popWindow('defbyid','CDR0000743915&amp;version=patient&amp;language=English&amp;dictionary=Cancer.gov'); return(false);">Cabozantinib</a></li></ul></div><p id="_190" tabindex="-1">For more information, see <a href="https://www.cancer.gov/about-cancer/treatment/drugs/liver" title="https://www.cancer.gov/about-cancer/treatment/drugs/liver">Drugs Approved for Liver Cancer</a> for more information.</p></div>
+    - entity: paragraph
+      type: pdq_summary_section
+      field_pdq_section_id:
+        value: _533
+      field_pdq_section_title:
+        - format: plain_text
+          value: 'Immunotherapy'
+      field_pdq_section_html:
+        - format: raw_html
+          value: |
+            <div id="_section_533" class="pdq-sections"><p id="_529" tabindex="-1">Immunotherapy is a treatment that uses the patient's immune system to fight cancer.  Substances made by the body or made in a laboratory are used to boost, direct, or restore the body's natural defenses against cancer.  Learn more about <a href="https://ncigovcdode412.prod.acquia-sites.com/about-cancer/treatment/types/immunotherapy" title="https://ncigovcdode412.prod.acquia-sites.com/about-cancer/treatment/types/immunotherapy">Immunotherapy to Treat Cancer.</a></p></div>
+    - entity: paragraph
+      type: pdq_summary_section
+      field_pdq_section_id:
+        value: _57
+      field_pdq_section_title:
+        - format: plain_text
+          value: 'Radiation therapy'
+      field_pdq_section_html:
+        - format: raw_html
+          value: |
+            <div id="_section_57" class="pdq-sections"><p id="_157" tabindex="-1">Radiation therapy is a cancer treatment that uses high-energy x-rays or other types of radiation to kill cancer cells or keep them from growing. There are two types of radiation therapy:</p><div class="pdq-content-list"><ul id="_155"><li> <a class="definition" type="GlossaryTermRefs" href="/Common/PopUps/popDefinition.aspx?id=46686&amp;version=patient&amp;language=English&amp;dictionary=Cancer.gov" onclick="javascript:popWindow('defbyid','CDR0000046686&amp;version=patient&amp;language=English&amp;dictionary=Cancer.gov'); return(false);">External radiation therapy</a> uses a machine outside the body to send radiation toward the cancer.  Certain ways of giving radiation therapy can help keep radiation from damaging nearby healthy tissue. These types of external radiation therapy include the following:<div class="pdq-content-list"><ul id="_237" class="list-dash"><li><strong>Conformal radiation therapy:  </strong>Conformal radiation therapy  is a type of external radiation therapy that uses a computer to make a 3-dimensional (3-D) picture of the tumor and shapes the radiation beams to fit the tumor. This allows a high dose of radiation to reach the tumor and causes less damage to nearby healthy tissue.</li><li><strong>Stereotactic body radiation therapy</strong>:   Stereotactic body radiation therapy is a type of external radiation therapy. Special equipment is used to place the patient in the same position for each radiation treatment. Once a day for several days, a radiation machine aims a larger than usual dose of radiation directly at the tumor. By having the patient in the same position for each treatment, there is less damage to nearby healthy tissue.  This procedure is also called stereotactic external-beam radiation therapy and stereotaxic radiation therapy.</li><li><strong>Proton beam radiation therapy:</strong>   Proton-beam therapy is a type of high-energy, external radiation therapy. A radiation therapy machine aims streams of protons (tiny, invisible, positively-charged particles) at the cancer cells to kill them. This type of treatment causes less damage to nearby healthy tissue.</li></ul></div></li><li>	<a class="definition" type="GlossaryTermRefs" href="/Common/PopUps/popDefinition.aspx?id=46345&amp;version=patient&amp;language=English&amp;dictionary=Cancer.gov" onclick="javascript:popWindow('defbyid','CDR0000046345&amp;version=patient&amp;language=English&amp;dictionary=Cancer.gov'); return(false);">Internal radiation therapy</a> uses a radioactive substance sealed in needles, seeds, wires, or catheters that are placed directly into or near the cancer.</li></ul></div><p id="_270" tabindex="-1">The way the radiation therapy is given depends on the type and stage of the cancer being treated. External radiation therapy is used to treat adult primary liver cancer. </p></div>
+    - entity: paragraph
+      type: pdq_summary_section
+      field_pdq_section_id:
+        value: _535
+      field_pdq_section_title:
+        - format: plain_text
+          value: 'Clinical Trials'
+      field_pdq_section_html:
+        - format: raw_html
+          value: |
+            <div id="_section_535" class="pdq-sections"><p id="_536" tabindex="-1">A treatment clinical trial is a <a class="definition" type="GlossaryTermRefs" href="/Common/PopUps/popDefinition.aspx?id=651211&amp;version=patient&amp;language=English&amp;dictionary=Cancer.gov" onclick="javascript:popWindow('defbyid','CDR0000651211&amp;version=patient&amp;language=English&amp;dictionary=Cancer.gov'); return(false);">research study</a> meant to help improve current treatments or obtain information on new treatments for patients with&#8239;cancer.&#8239;For some patients, taking part in a&#8239;clinical trial&#8239;may be the best treatment choice.</p><p id="_537" tabindex="-1">Use our&#8239;<a href="https://ncigovcdode412.prod.acquia-sites.com/about-cancer/treatment/clinical-trials/search" title="https://ncigovcdode412.prod.acquia-sites.com/about-cancer/treatment/clinical-trials/search">clinical trial search</a> to find NCI-supported cancer clinical trials that are accepting patients. You can search for trials based on the type of cancer, the age of the patient, and&#8239;where the trials are being done.&#8239;Clinical trials supported by other organizations can be found on the <a href="https://clinicaltrials.gov/" title="https://clinicaltrials.gov/">ClinicalTrials.gov</a> website.</p><p id="_538" tabindex="-1">To learn more about clinical trials, see <a href="https://ncigovcdode412.prod.acquia-sites.com/about-cancer/treatment/clinical-trials" title="https://ncigovcdode412.prod.acquia-sites.com/about-cancer/treatment/clinical-trials">Clinical Trials Information for Patients and Caregivers</a>.</p></div>
+    - entity: paragraph
+      type: pdq_summary_section
+      field_pdq_section_id:
+        value: _539
+      field_pdq_section_title:
+        - format: plain_text
+          value: 'Treatment of Localized Liver Cancer'
+      field_pdq_section_html:
+        - format: raw_html
+          value: |
+            <div id="_section_539" class="pdq-sections"><p id="_540" tabindex="-1">Treatment of localized liver cancer may include the following:</p><div class="pdq-content-list"><ul id="_541"><li>Surveillance for lesions smaller than 1 centimeter</li><li>Partial&#8239;hepatectomy</li><li>Total&#8239;hepatectomy&#8239;and&#8239;liver&#8239;transplant</li><li>Ablation&#8239;of the&#8239;tumor&#8239;using one of the following methods:<div class="pdq-content-list"><ul id="_542"><li>Radiofrequency ablation</li><li>Microwave therapy</li><li>Percutaneous ethanol injection</li><li>Cryoablation</li></ul></div></li><li>A&#8239;clinical trial&#8239;of&#8239;electroporation therapy</li></ul></div></div>
+    - entity: paragraph
+      type: pdq_summary_section
+      field_pdq_section_id:
+        value: _543
+      field_pdq_section_title:
+        - format: plain_text
+          value: 'Treatment of Locally Advanced or Metastatic Liver Cancer'
+      field_pdq_section_html:
+        - format: raw_html
+          value: |
+            <div id="_section_543" class="pdq-sections"><p id="_544" tabindex="-1">Treatment of locally advanced or metastatic liver cancer that cannot be treated with surgery may include the following:</p><div class="pdq-content-list"><ul id="_545"><li>Embolization&#8239;therapy&#8239;using&#8239;transarterial embolization&#8239;(TAE) or&#8239;transarterial chemoembolization&#8239;(TACE)</li><li>Targeted therapy&#8239;with&#8239;sorafenib,&#8239;lenvatinib,&#8239;regorafenib, or&#8239;cabozantinib</li><li>Immune checkpoint inhibitor&#8239;therapy with&#8239;pembrolizumab</li><li>Radiation therapy</li><li>A&#8239;clinical trial&#8239;of targeted therapy after&#8239;chemoembolization&#8239;or combined with&#8239;chemotherapy</li><li>A clinical trial of new targeted therapy&#8239;drugs</li><li>A clinical trial of&#8239;immunotherapy</li><li>A clinical trial of immunotherapy combined with targeted therapy</li><li>A clinical trial of&#8239;stereotactic body radiation therapy&#8239;or&#8239;proton-beam radiation therapy</li></ul></div></div>
+    - entity: paragraph
+      type: pdq_summary_section
+      field_pdq_section_id:
+        value: _546
+      field_pdq_section_title:
+        - format: plain_text
+          value: 'Treatment of Recurrent Liver Cancer'
+      field_pdq_section_html:
+        - format: raw_html
+          value: |
+            <div id="_section_546" class="pdq-sections"><p id="_547" tabindex="-1">Treatment options for recurrent primary liver cancer may include the following:</p><div class="pdq-content-list"><ul id="_548"><li>Total&#8239;hepatectomy&#8239;and&#8239;liver&#8239;transplant</li><li>Partial&#8239;hepatectomy</li><li>Ablation</li><li>Transarterial chemoembolization&#8239;and&#8239;targeted therapy&#8239;with&#8239;sorafenib, as&#8239;palliative therapy&#8239;to relieve&#8239;symptoms&#8239;and improve&#8239;quality of life</li><li>A&#8239;clinical trial&#8239;of a new treatment</li></ul></div></div>
+  title__ES:
+    value: 'Tratamiento del cáncer de hígado'
+  status__ES:
+    value: 1
+  langcode__ES:
+    value: es
+  moderation_state:__ES:
+    value: published
+  field_pdq_url__ES:
+    value: /test/espanol/typos/higado/que-es-el-cancer-de-higado/tratamiento
+  field_pdq_cdr_id__ES:
+    value: 2000008
+  field_pdq_audience__ES:
+    value: Patients
+  field_pdq_summary_type__ES:
+    value: Overview
+  field_date_posted__ES:
+    value: '2022-02-11'
+  field_date_updated__ES:
+    value: '2022-02-14'
+  field_browser_title__ES:
+    value: 'Tratamiento del cáncer de hígado'
+  field_page_description__ES:
+    value: 'El tratamiento del cáncer de hígado en adultos depende del estadio. Las opciones de tratamiento incluyen hepatectomía, trasplante de hígado, ablación, terapia de electroporación (EPT), terapia de embolización, terapia dirigida y/o radioterapia. Obtenga más información sobre el tratamiento para las diferentes etapas del cáncer de hígado.'
+  field_public_use__ES:
+    value: 1
+  field_pdq_is_svpc__ES:
+    value: 1
+  field_pdq_suppress_otp__ES:
+    value: 0
+  field_pdq_intro_text__ES:
+    value: |
+      <div id="_section_1" class="pdq-sections"><p>El primer elemento de esta colección es una historia familiar para todos los lectores : Caperucita Roja . O, como probablemente puedas decir ahora en Angustia, Ladle Rat Rotten Hut.</p><div>
+  field_summary_sections__ES:
+    - entity: paragraph
+      type: pdq_summary_section
+      field_pdq_section_id:
+        value: _1
+      field_pdq_section_title:
+        - format: plain_text
+          value: 'Vigilancia'
+      field_pdq_section_html:
+        - format: raw_html
+          value: |
+            <div id="_section_1" class="pdq-sections"><p>Quiere peón plazo reto estambre cucharón gaviota azada levantar más húmedo asesinato cucharón interior cordaje honor picazón oferta alojamiento, muelle, floristería. Disco cucharón gaviota huérfano preocupación masilla cucharón rata cloqueo más húmedo cucharón rata choza, un disco de piel pasa espinilla más frío Cucharón Rata Rotten Hut.</p><div>
+    - entity: paragraph
+      type: pdq_summary_section
+      field_pdq_section_id:
+        value: _2
+      field_pdq_section_title:
+        - format: plain_text
+          value: 'Cirugía'
+      field_pdq_section_html:
+        - format: raw_html
+          value: |
+            <div id="_section_1" class="pdq-sections"><p>Soda wicket woof tucker shirt court, un relincho vomitó una oferta de cuerdas en la ingle-asesinato, recogió la hilera interior, un aceite de poro deudor dolorido gusano peor apuesta interior de león. Carne interior, disco abdominal guau labio honor apuesta, barriga honor poro aceite gusanos, una erupción distorsionada. Den disco trinquete ammonol pot honor ingle-asesinato copa de nuez una pistola de mosquitos, cualquier apuesta interior abierta cuajada.</p><div>
+    - entity: paragraph
+      type: pdq_summary_section
+      field_pdq_section_id:
+        value: _3
+      field_pdq_section_title:
+        - format: plain_text
+          value: 'Terapia de ablación'
+      field_pdq_section_html:
+        - format: raw_html
+          value: |
+            <div id="_section_1" class="pdq-sections"><p>Aturdimiento, preocupación por las verrugas de la gaviota del cucharón de nuez falsificador. La oferta de aceite empapada, la oferta apelmazada talla una apuesta de nutria rociada, el disco atesorado atesorado guau labio propio poro Cucharón Rata Rotten Hut una erupción confusa.</p><div>
+    - entity: paragraph
+      type: pdq_summary_section
+      field_pdq_section_id:
+        value: _4
+      field_pdq_section_title:
+        - format: plain_text
+          value: 'Terapia de embolización'
+      field_pdq_section_html:
+        - format: raw_html
+          value: |
+            <div id="_section_1" class="pdq-sections"><p>Quiere empeñar a término atrevimiento estambre cucharón gaviota azada sombrero búsqueda masilla aullador bobinas deuda espinilla más frío Miradas culpables. Miradas culpables levantan cucharón interior cordaje saturado víbora camisa disidencia bolsa más firme florista, cualquier cucharón gaviota huérfano aster asesinato dedo del pie letra gore entidad florista aceite comprador plataforma.</p><div>
+    - entity: paragraph
+      type: pdq_summary_section
+      field_pdq_section_id:
+        value: _5
+      field_pdq_section_title:
+        - format: plain_text
+          value: 'Terapia Dirigida'
+      field_pdq_section_html:
+        - format: raw_html
+          value: |
+            <div id="_section_1" class="pdq-sections"><p>Piel de pulmón, disco vengador gaviota más húmedo masilla aullador bobinas leva desgarrada cucharón cordaje inhibido comprador casco firmemente de cervezas: Forraje Cerveza (grano casero, pasas ajenas a la piel, "Elaboración de cerveza" enrollada), Murder Beer, una Cucharón Bore Cerveza. Disco gimiendo, engrasador cervezas sombrero broma levantador cordaje, cucharón haciendo tictac tomando el sol, un sombrero pistola entidad floristería dedo del pie picotean barreras de bloques y barreras de erupción. Bola de masa de ranker de Miradas culpables; comprado, fuera de maldición, ni-obsceno peor zumbido, soda mancillar cucharón gaviota ganar calvamente rata entidad cerveza caballo!</p><div>
+    - entity: paragraph
+      type: pdq_summary_section
+      field_pdq_section_id:
+        value: _6
+      field_pdq_section_title:
+        - format: plain_text
+          value: 'inmunoterapia'
+      field_pdq_section_html:
+        - format: raw_html
+          value: |
+            <div id="_section_1" class="pdq-sections"><p>Cucharón interno mientras, los donantes ofrecen cordaje cam beck extradición de picoteo de barrera más firme, curry baskings barreras de erupción más completas. Entidad quejumbrosa zurciendo ron, Fodder Beer tartamudeó olfateando un extenuante estante de tumba.</p><div>
+    - entity: paragraph
+      type: pdq_summary_section
+      field_pdq_section_id:
+        value: _7
+      field_pdq_section_title:
+        - format: plain_text
+          value: 'Radioterapia'
+      field_pdq_section_html:
+        - format: raw_html
+          value: |
+            <div id="_section_1" class="pdq-sections"><p>Pulmón de piel, pelotas de guata, disputas de guerra, un desgaste de invierno de Center Alley más firme wicket stop-asesinato caballo, un colchón de puerta becalm ofrecen mención de gargantas de cabriolas. Callejón central, peores nudos de broma a bordo de un coche de caballos, un establo, un ascensor, aturdimiento, hedor de sorgo arpía, pulmón peludo, pulmón, tam.</p><div>
+    - entity: paragraph
+      type: pdq_summary_section
+      field_pdq_section_id:
+        value: _8
+      field_pdq_section_title:
+        - format: plain_text
+          value: 'Ensayos clínicos'
+      field_pdq_section_html:
+        - format: raw_html
+          value: |
+            <div id="_section_1" class="pdq-sections"><p>Oferta de aceite puerta empapada cloqueo cigüeña mit-gnat. La carne interior, la masilla de Center Alley cerrando los bastidores de respaldo de chintz, ingresa poro gaviota sombrerero dasher ware hervir más firme. Corriendo novillos donantes, Center Alley apelmazado oferta cucharón brillo baba. Cajero traidor cabriolas de puerta, compró tripa aceitosa peor baba de puerta.</p><div>
+    - entity: paragraph
+      type: pdq_summary_section
+      field_pdq_section_id:
+        value: _9
+      field_pdq_section_title:
+        - format: plain_text
+          value: 'Tratamiento del cáncer de hígado localizado'
+      field_pdq_section_html:
+        - format: raw_html
+          value: |
+            <div id="_section_1" class="pdq-sections"><p>Soda wicket stop-asesinato cualquier dedo del pie igling cisternas honor de cierre expansivo, un tartamudeo a menudo tutor hervir, poro vivo Center Alley ajuste comprador lejos interior cierre de raqueta, ingenio cizaña rasgueando pollitos darner.</p><div>
+    - entity: paragraph
+      type: pdq_summary_section
+      field_pdq_section_id:
+        value: _10
+      field_pdq_section_title:
+        - format: plain_text
+          value: 'Tratamiento del cáncer de hígado localmente avanzado o metastásico'
+      field_pdq_section_html:
+        - format: raw_html
+          value: |
+            <div id="_section_1" class="pdq-sections"><p>Callejón central peor bufón poro cucharón gaviota azada ascensor más húmedo parada-asesinato un dedo del pie heft-cisternas. Daze worming war peludo wicket an shellfish parsons, espacialmente paro stop-asesinato, hoe no falta Center Alley an, infect, palabra huérfano traidor poro gaviota mar liquen ammonol cena hormona bang. Disco interno aceitoso que gime wicket aceitado gusano en cortocircuito, "Callejón central, apuesta de nutria gad, ¡una guerra de bocio! ¡Bomba de cucharón de encaje de sutura! ¡Lago agitador!" un gemido firme decir mosquito disco trinquete gaviota palabra novilla wark laca coche fúnebre dedo del pie arenque a caballo ardor, lavadora heft-cierre de cisterna, fabricante de apuestas, gore tutor estrella perversiones de piel, machos de cocina, lavadora corre una cierva ubre aceitosa atesoran wark. ¡Ni vagar por el Callejón del Centro peor alquitranado y vomitado!</p><div>
+    - entity: paragraph
+      type: pdq_summary_section
+      field_pdq_section_id:
+        value: _11
+      field_pdq_section_title:
+        - format: plain_text
+          value: 'Tratamiento del cáncer de hígado recurrente'
+      field_pdq_section_html:
+        - format: raw_html
+          value: |
+            <div id="_section_1" class="pdq-sections"><p>Finamente, cerveza de forraje, bolsa de grado de alcantarilla, chicle, rifa inquietante de alcantarilla de cerveza de asesinato, un cucharón de cucharón leonado de cucharón de cerveza Bore, una cripta de cervezas engrasadoras estrellas superiores, artículos Culpable Parece peor apuesta de honor de línea, resbalón bajo y resoplido. Cervezas de la puerta del arenque, shay debilitado, hilera de la puerta de la nutria de labios, un scrabble fascista de los bufones del daño consciente.</p><div>

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/svpc_what-is-liver-cancer.content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/svpc_what-is-liver-cancer.content.yml
@@ -1,0 +1,117 @@
+- entity: node
+  type: pdq_cancer_information_summary
+  title: 'What is Liver Cancer?'
+  status: 1
+  langcode: en
+  field_hhs_syndication:
+    - syndicate: 1
+      keywords: ''
+  moderation_state:
+    value: published
+  field_pdq_url:
+    value: /test/types/liver/what-is-liver-cancer
+  field_pdq_cdr_id:
+    value: 2000001
+  field_pdq_audience:
+    value: Patients
+  field_pdq_summary_type:
+    value: Overview
+  field_date_posted:
+    value: '2021-11-15'
+  field_date_updated:
+    value: '2022-01-13'
+  field_browser_title:
+    value: 'What is Liver Cancer?'
+  field_page_description:
+    value: 'Primary liver cancer is a disease that forms in the liver. The most common type is hepatocellular carcinoma. Learn about liver cancer, signs, and symptoms from the nation’s top health experts.'
+  field_public_use:
+    value: 1
+  field_pdq_is_svpc:
+    value: 1
+  field_pdq_suppress_otp:
+    value: 0
+  field_pdq_intro_text:
+    value: |
+      <div id="_section_20" class="pdq-sections"><p id="_22" tabindex="-1">Primary liver cancer is a disease in which malignant (cancer) cells form in the tissues of the liver. Cancer that forms in other parts of the body and spreads to the liver is not primary liver cancer. The liver is one of the largest organs in the body. It has two lobes and fills the upper right side of the abdomen inside the rib cage. Three of the many important functions of the liver are:</p><div class="pdq-content-list"><ul id="_23"><li>To filter harmful substances from the blood so they can be passed from the body in stools and urine.</li><li>To make <a class="definition" type="GlossaryTermRefs" href="/Common/PopUps/popDefinition.aspx?id=46508&amp;version=patient&amp;language=English&amp;dictionary=Cancer.gov" onclick="javascript:popWindow('defbyid','CDR0000046508&amp;version=patient&amp;language=English&amp;dictionary=Cancer.gov'); return(false);">bile</a> to help digest fat that comes from food.</li><li>To store glycogen (sugar), which the body uses for energy.</li></ul></div><figure id="figure_24" class="image-center"><a href="https://nci-media-dev.cancer.gov/pdq/media/images/658698.jpg" target="_blank" class="article-image-enlarge">Enlarge</a><img id="_24" alt="Anatomy of the liver; drawing shows the right and left lobes of the liver. Also shown are the bile ducts, gallbladder, stomach, spleen, pancreas, small intestine, and colon." title="Anatomy of the liver; drawing shows the right and left lobes of the liver. Also shown are the bile ducts, gallbladder, stomach, spleen, pancreas, small intestine, and colon." src="https://nci-media-dev.cancer.gov/pdq/media/images/658698-750.jpg"><figcaption class="caption-container">Anatomy of the  liver. The liver is in the upper abdomen near the stomach, intestines, gallbladder, and pancreas.  The liver has a right lobe and a left lobe. Each lobe is divided into two sections (not shown). </figcaption></figure></div>
+  field_summary_sections:
+    - entity: paragraph
+      type: pdq_summary_section
+      field_pdq_section_id:
+        value: _25
+      field_pdq_section_title:
+        - format: plain_text
+          value: 'Types of Liver Cancer'
+      field_pdq_section_html:
+        - format: raw_html
+          value: |
+            <div id="_section_25" class="pdq-sections"><p id="_26" tabindex="-1">The two types of adult primary liver cancer are:</p><div class="pdq-content-list"><ul id="_27"><li><a class="definition" type="GlossaryTermRefs" href="/Common/PopUps/popDefinition.aspx?id=46363&amp;version=patient&amp;language=English&amp;dictionary=Cancer.gov" onclick="javascript:popWindow('defbyid','CDR0000046363&amp;version=patient&amp;language=English&amp;dictionary=Cancer.gov'); return(false);">Hepatocellular carcinoma</a>.</li><li><a href="/types/liver/patient/bile-duct-treatment-pdq">Cholangiocarcinoma (bile duct cancer)</a>.</li></ul></div><p id="_28" tabindex="-1">The most common type of adult primary liver cancer is hepatocellular carcinoma. This type of liver cancer is the third leading cause of cancer-related deaths worldwide.</p><p id="_29" tabindex="-1">Primary liver cancer can occur in both adults and children. However, treatment for children is different than treatment for adults. For more information, see <a href="/types/liver/patient/child-liver-treatment-pdq">Childhood Liver Cancer</a>.</p></div>
+    - entity: paragraph
+      type: pdq_summary_section
+      field_pdq_section_id:
+        value: _30
+      field_pdq_section_title:
+        - format: plain_text
+          value: 'Signs and Symptoms of Liver Cancer'
+      field_pdq_section_html:
+        - format: raw_html
+          value: |
+            <div id="_section_30" class="pdq-sections"><p id="_31" tabindex="-1">These and other signs and symptoms may be caused by adult primary liver cancer or by other conditions. Check with your doctor if you have any of the following:</p><div class="pdq-content-list"><ul id="_17"><li>A hard lump on the right side just below the rib cage.</li><li>
+            Discomfort in the upper abdomen on the right side.</li><li>A swollen abdomen.</li><li>
+            Pain near the right  shoulder blade or in the back.</li><li>Jaundice
+            (yellowing of the skin and whites of the eyes).</li><li>Easy bruising or bleeding.</li><li>Unusual tiredness or weakness.</li><li>Nausea and vomiting.</li><li>Loss of appetite or feelings of fullness after eating a small meal.</li><li>Weight loss for no known reason.</li><li>Pale, chalky <a class="definition" type="GlossaryTermRefs" href="/Common/PopUps/popDefinition.aspx?id=651179&amp;version=patient&amp;language=English&amp;dictionary=Cancer.gov" onclick="javascript:popWindow('defbyid','CDR0000651179&amp;version=patient&amp;language=English&amp;dictionary=Cancer.gov'); return(false);">bowel movements</a> and dark urine.</li><li>Fever.</li></ul></div></div>
+  title__ES:
+    value: '¿Qué es el cáncer de hígado?'
+  status__ES:
+    value: 1
+  langcode__ES:
+    value: es
+  moderation_state:__ES:
+    value: published
+  field_pdq_url__ES:
+    value: /test/espanol/typos/higado/que-es-el-cancer-de-higado
+  field_pdq_cdr_id__ES:
+    value: 2000002
+  field_pdq_audience__ES:
+    value: Patients
+  field_pdq_summary_type__ES:
+    value: Overview
+  field_date_posted__ES:
+    value: '2022-02-11'
+  field_date_updated__ES:
+    value: '2022-02-14'
+  field_browser_title__ES:
+    value: '¿Qué es el cáncer de hígado?'
+  field_page_description__ES:
+    value: 'El cáncer de hígado primario es una enfermedad que se forma en el hígado. El tipo más común es el carcinoma hepatocelular. Obtenga información sobre el cáncer de hígado, los signos y los síntomas de los principales expertos en salud del país.'
+  field_public_use__ES:
+    value: 1
+  field_pdq_is_svpc__ES:
+    value: 1
+  field_pdq_suppress_otp__ES:
+    value: 0
+  field_pdq_intro_text__ES:
+    value: |
+      <div id="_section_1" class="pdq-sections"><p>Si se puede hacer que las palabras cumplan una función doble, triple o incluso cuádruple, es obvio que no necesitamos tantas. ¿No sería un consuelo saber que, en el caso de un desastre impredecible que acabe con la mitad de nuestro vocabulario en inglés, podríamos, si hubiéramos aprendido Angustia, arreglárnoslas bien con lo que nos queda?</p><div>
+  field_summary_sections__ES:
+    - entity: paragraph
+      type: pdq_summary_section
+      field_pdq_section_id:
+        value: _1
+      field_pdq_section_title:
+        - format: plain_text
+          value: 'Tipos de cáncer de hígado'
+      field_pdq_section_html:
+        - format: raw_html
+          value: |
+            <div id="_section_1" class="pdq-sections"><p>Cucharón de masilla Any-bally, configuración de plataforma de comprador de aceite postura de sonrisa interna, peor oferta de pinchazo peludo holgazán al acecho. Espinilla de la ubre del engrasador de la falta, cualquier peor deuda de la costa que encajona el peor ganador del granero hervir la piel del gam Mutt-fill.</p><div>
+    - entity: paragraph
+      type: pdq_summary_section
+      field_pdq_section_id:
+        value: _2
+      field_pdq_section_title:
+        - format: plain_text
+          value: 'Signos y síntomas del cáncer de hígado'
+      field_pdq_section_html:
+        - format: raw_html
+          value: |
+            <div id="_section_1" class="pdq-sections"><p>Encajonando peor tripa al acecho, un álamo peludo, gaviota espacialmente más húmeda enrollada Any-bally. Cualquier-bally peor Casing's sudor-duro, cualquier adoquín arpía vagó dedo del pie gat mérito, compró Casing peor toe pore toe becalm Any-bally's horsestarn, (hervir alicates honor Mutt-fill domar dint gat papilla ofrecer apio; infectar, día tripa olfateando atolón.)</p><div>

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/z042_liver-cthp.content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/z042_liver-cthp.content.yml
@@ -1,0 +1,140 @@
+## TESTS:
+### CTHP
+
+- entity: "node"
+  type: "cgov_cthp"
+  langcode: en
+  status: 1
+  moderation_state:
+    value: 'published'
+  title: "Liver and Bile Duct Cancer—Patient Version"
+  title__ES:
+    value: "Cáncer de hígado y de conducto biliar—Versión para pacientes"
+  field_page_description:
+    value: "Liver cancer includes hepatocellular carcinoma (HCC) and bile duct cancer (cholangiocarcinoma). Risk factors for HCC include chronic infection with hepatitis B or C and cirrhosis of the liver. Explore the links on this page to learn more about liver cancer treatment, prevention, screening, statistics, research, and clinical trials."
+  field_page_description__ES:
+    value: "El cáncer de hígado incluye el carcinoma hepatocelular y el cáncer de vías biliares (colangiocarcinoma). Los factores de riesgo para el carcinoma hepatocelular incluyen la infección crónica de hepatitis B o C, y la cirrosis del hígado. Para obtener más información sobre tratamiento, prevención, exámenes de detección, estadísticas, investigación y ensayos clínicos relacionados con el cáncer de hígado, consulte los enlaces en esta página."
+  field_card_title:
+    value: "Overview"
+  field_card_title__ES:
+    value: "Aspectos generales"
+  field_browser_title:
+    value: "Liver and Bile Duct Cancer—Patient Version"
+  field_browser_title__ES:
+    value: "Cáncer de hígado y de conducto biliar—Versión para pacientes"
+  field_site_section:
+    - '#process':
+        callback: 'reference'
+        args:
+          - 'taxonomy_term'
+          - vid: 'cgov_site_sections'
+            computed_path: '/types/liver'
+  field_site_section__ES:
+    - '#process':
+        callback: 'reference'
+        args:
+          - 'taxonomy_term'
+          - vid: 'cgov_site_sections'
+            computed_path: '/tipos/higado'
+  field_audience:
+    value: "patient"
+  field_audience__ES:
+    value: "patient"
+  field_audience_toggle:
+    - '#process':
+        callback: 'reference'
+        args:
+          - 'node'
+          - type: 'cgov_cthp'
+            title: 'Go to Health Professional Version'
+  field_audience_toggle__ES:
+    - '#process':
+        callback: 'reference'
+        args:
+          - 'node'
+          - type: 'cgov_cthp'
+            title: 'Vaya a la versión para profesionales de salud'
+######## BEGIN ENGLISH CTHP CARDS ########
+  field_cthp_cards:
+    - entity: 'paragraph'
+      type: "cgov_cthp_overview_card"
+      field_cthp_card_title:
+        - value: 'Overview'
+      field_cthp_card_theme:
+        - value: 'cthp-overview'
+      field_cthp_overview_card_text:
+        - format: "streamlined"
+          value: |
+            <p>Liver cancer includes hepatocellular carcinoma (HCC) and bile duct cancer (cholangiocarcinoma). Risk factors for HCC include chronic infection with hepatitis B or C and cirrhosis of the liver. Explore the links on this page to learn more about liver cancer treatment, prevention, screening, statistics, research, and clinical trials.</p>
+    - entity: 'paragraph'
+      type: "cgov_cthp_guide_card"
+      field_cthp_card_title:
+        - value: 'Treatment'
+      field_cthp_card_theme:
+        - value: 'cthp-treatment'
+      field_cthp_pdq_link_heading:
+        - value: "PDQ Treatment Information for Patients"
+      field_cthp_pdq_links:
+        - '#process':
+            callback: 'reference'
+            args:
+              - 'node'
+              - type: 'pdq_cancer_information_summary'
+                title: 'Liver and Bile Duct Cancer–Patient Version'
+######## End English CTHP Cards ##############
+######## BEGIN SPANISH CTHP CARDS ########
+  field_cthp_cards__ES:
+    - entity: 'paragraph'
+      type: "cgov_cthp_overview_card"
+      field_cthp_card_title:
+        - value: 'Aspectos generales'
+      field_cthp_card_theme:
+        - value: 'cthp-overview'
+      field_cthp_overview_card_text:
+        - format: "streamlined"
+          value: |
+            <p>El cáncer de hígado incluye el carcinoma hepatocelular y el cáncer de vías biliares (colangiocarcinoma). Los factores de riesgo para el carcinoma hepatocelular incluyen la infección crónica de hepatitis B o C, y la cirrosis del hígado. Para obtener más información sobre tratamiento, prevención, exámenes de detección, estadísticas, investigación y ensayos clínicos relacionados con el cáncer de hígado, consulte los enlaces en esta página.</p>
+    - entity: 'paragraph'
+      type: "cgov_cthp_guide_card"
+      field_cthp_card_title:
+        - value: 'Tratamiento'
+      field_cthp_card_theme:
+        - value: 'cthp-treatment'
+      field_cthp_pdq_link_heading:
+        - value: "Información de PDQ para pacientes sobre tratamiento"
+    - entity: 'paragraph'
+      type: "cgov_cthp_guide_card"
+      field_cthp_card_title:
+        - value: 'Causas y prevención'
+      field_cthp_card_theme:
+        - value: 'cthp-causes'
+      field_cthp_pdq_link_heading:
+        - value: "Información de PDQ para pacientes sobre prevención"
+    - entity: 'paragraph'
+      type: "cgov_cthp_guide_card"
+      field_cthp_card_title:
+        - value: 'Exámenes de detección'
+      field_cthp_card_theme:
+        - value: 'cthp-screening'
+      field_cthp_pdq_link_heading:
+        - value: "Información de PDQ para pacientes sobre exámenes de detección"
+    - entity: 'paragraph'
+      type: "cgov_cthp_block_card"
+      field_cthp_card_title:
+        - value: 'Cómo hacer frente al cáncer'
+      field_cthp_card_theme:
+        - value: 'cthp-general'
+      field_cthp_block_card_content:
+        - '#process':
+            callback: 'reference'
+            args:
+              - 'block_content'
+              - type: 'content_block'
+                info: 'Coping With Cancer CTHP Block Card - Spanish'
+    - entity: 'paragraph'
+      type: "cgov_cthp_research_card"
+      field_cthp_card_title:
+        - value: 'Investigación'
+      field_cthp_card_theme:
+        - value: 'cthp-research'
+######## End Spanish CTHP Cards ##############

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_form_display.node.pdq_cancer_information_summary.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_form_display.node.pdq_cancer_information_summary.default.yml
@@ -12,6 +12,7 @@ dependencies:
     - field.field.node.pdq_cancer_information_summary.field_pdq_audience
     - field.field.node.pdq_cancer_information_summary.field_pdq_cdr_id
     - field.field.node.pdq_cancer_information_summary.field_pdq_summary_type
+    - field.field.node.pdq_cancer_information_summary.field_pdq_suppress_otp
     - field.field.node.pdq_cancer_information_summary.field_pdq_url
     - field.field.node.pdq_cancer_information_summary.field_public_use
     - field.field.node.pdq_cancer_information_summary.field_summary_sections
@@ -65,6 +66,13 @@ content:
     region: content
   field_pdq_is_svpc:
     weight: 101
+    settings:
+      display_label: true
+    third_party_settings: {  }
+    type: boolean_checkbox
+    region: content
+  field_pdq_suppress_otp:
+    weight: 102
     settings:
       display_label: true
     third_party_settings: {  }

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_form_display.node.pdq_cancer_information_summary.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_form_display.node.pdq_cancer_information_summary.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.node.pdq_cancer_information_summary.field_date_posted
     - field.field.node.pdq_cancer_information_summary.field_date_updated
     - field.field.node.pdq_cancer_information_summary.field_hhs_syndication
+    - field.field.node.pdq_cancer_information_summary.field_pdq_is_svpc
     - field.field.node.pdq_cancer_information_summary.field_meta_tags
     - field.field.node.pdq_cancer_information_summary.field_page_description
     - field.field.node.pdq_cancer_information_summary.field_pdq_audience
@@ -61,6 +62,13 @@ content:
     settings: {  }
     third_party_settings: {  }
     type: cgov_syndication_widget
+    region: content
+  field_pdq_is_svpc:
+    weight: 101
+    settings:
+      display_label: true
+    third_party_settings: {  }
+    type: boolean_checkbox
     region: content
   field_page_description:
     weight: 15

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_form_display.node.pdq_cancer_information_summary.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_form_display.node.pdq_cancer_information_summary.default.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.node.pdq_cancer_information_summary.field_page_description
     - field.field.node.pdq_cancer_information_summary.field_pdq_audience
     - field.field.node.pdq_cancer_information_summary.field_pdq_cdr_id
+    - field.field.node.pdq_cancer_information_summary.field_pdq_intro_text
     - field.field.node.pdq_cancer_information_summary.field_pdq_summary_type
     - field.field.node.pdq_cancer_information_summary.field_pdq_suppress_otp
     - field.field.node.pdq_cancer_information_summary.field_pdq_url
@@ -77,6 +78,14 @@ content:
       display_label: true
     third_party_settings: {  }
     type: boolean_checkbox
+    region: content
+  field_pdq_intro_text:
+    weight: 25
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+    type: text_textarea
     region: content
   field_page_description:
     weight: 15

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_form_display.node.pdq_cancer_information_summary.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_form_display.node.pdq_cancer_information_summary.default.yml
@@ -6,12 +6,12 @@ dependencies:
     - field.field.node.pdq_cancer_information_summary.field_date_posted
     - field.field.node.pdq_cancer_information_summary.field_date_updated
     - field.field.node.pdq_cancer_information_summary.field_hhs_syndication
-    - field.field.node.pdq_cancer_information_summary.field_pdq_is_svpc
     - field.field.node.pdq_cancer_information_summary.field_meta_tags
     - field.field.node.pdq_cancer_information_summary.field_page_description
     - field.field.node.pdq_cancer_information_summary.field_pdq_audience
     - field.field.node.pdq_cancer_information_summary.field_pdq_cdr_id
     - field.field.node.pdq_cancer_information_summary.field_pdq_intro_text
+    - field.field.node.pdq_cancer_information_summary.field_pdq_is_svpc
     - field.field.node.pdq_cancer_information_summary.field_pdq_summary_type
     - field.field.node.pdq_cancer_information_summary.field_pdq_suppress_otp
     - field.field.node.pdq_cancer_information_summary.field_pdq_url
@@ -28,6 +28,7 @@ dependencies:
     - datetime
     - paragraphs_asymmetric_translation_widgets
     - path
+    - text
 id: node.pdq_cancer_information_summary.default
 targetEntityType: node
 bundle: pdq_cancer_information_summary

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_view_display.node.pdq_cancer_information_summary.cthp_guide_card_list_item.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_view_display.node.pdq_cancer_information_summary.cthp_guide_card_list_item.yml
@@ -7,12 +7,12 @@ dependencies:
     - field.field.node.pdq_cancer_information_summary.field_date_posted
     - field.field.node.pdq_cancer_information_summary.field_date_updated
     - field.field.node.pdq_cancer_information_summary.field_hhs_syndication
-    - field.field.node.pdq_cancer_information_summary.field_pdq_is_svpc
     - field.field.node.pdq_cancer_information_summary.field_meta_tags
     - field.field.node.pdq_cancer_information_summary.field_page_description
     - field.field.node.pdq_cancer_information_summary.field_pdq_audience
     - field.field.node.pdq_cancer_information_summary.field_pdq_cdr_id
     - field.field.node.pdq_cancer_information_summary.field_pdq_intro_text
+    - field.field.node.pdq_cancer_information_summary.field_pdq_is_svpc
     - field.field.node.pdq_cancer_information_summary.field_pdq_summary_type
     - field.field.node.pdq_cancer_information_summary.field_pdq_suppress_otp
     - field.field.node.pdq_cancer_information_summary.field_pdq_url

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_view_display.node.pdq_cancer_information_summary.cthp_guide_card_list_item.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_view_display.node.pdq_cancer_information_summary.cthp_guide_card_list_item.yml
@@ -13,6 +13,7 @@ dependencies:
     - field.field.node.pdq_cancer_information_summary.field_pdq_audience
     - field.field.node.pdq_cancer_information_summary.field_pdq_cdr_id
     - field.field.node.pdq_cancer_information_summary.field_pdq_summary_type
+    - field.field.node.pdq_cancer_information_summary.field_pdq_suppress_otp
     - field.field.node.pdq_cancer_information_summary.field_pdq_url
     - field.field.node.pdq_cancer_information_summary.field_public_use
     - field.field.node.pdq_cancer_information_summary.field_summary_sections
@@ -47,6 +48,7 @@ hidden:
   field_pdq_audience: true
   field_pdq_cdr_id: true
   field_pdq_summary_type: true
+  field_pdq_suppress_otp: true
   field_pdq_url: true
   field_public_use: true
   field_summary_sections: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_view_display.node.pdq_cancer_information_summary.cthp_guide_card_list_item.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_view_display.node.pdq_cancer_information_summary.cthp_guide_card_list_item.yml
@@ -12,6 +12,7 @@ dependencies:
     - field.field.node.pdq_cancer_information_summary.field_page_description
     - field.field.node.pdq_cancer_information_summary.field_pdq_audience
     - field.field.node.pdq_cancer_information_summary.field_pdq_cdr_id
+    - field.field.node.pdq_cancer_information_summary.field_pdq_intro_text
     - field.field.node.pdq_cancer_information_summary.field_pdq_summary_type
     - field.field.node.pdq_cancer_information_summary.field_pdq_suppress_otp
     - field.field.node.pdq_cancer_information_summary.field_pdq_url
@@ -47,6 +48,7 @@ hidden:
   field_page_description: true
   field_pdq_audience: true
   field_pdq_cdr_id: true
+  field_pdq_intro_text: true
   field_pdq_summary_type: true
   field_pdq_suppress_otp: true
   field_pdq_url: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_view_display.node.pdq_cancer_information_summary.cthp_guide_card_list_item.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_view_display.node.pdq_cancer_information_summary.cthp_guide_card_list_item.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.pdq_cancer_information_summary.field_date_posted
     - field.field.node.pdq_cancer_information_summary.field_date_updated
     - field.field.node.pdq_cancer_information_summary.field_hhs_syndication
+    - field.field.node.pdq_cancer_information_summary.field_pdq_is_svpc
     - field.field.node.pdq_cancer_information_summary.field_meta_tags
     - field.field.node.pdq_cancer_information_summary.field_page_description
     - field.field.node.pdq_cancer_information_summary.field_pdq_audience
@@ -23,6 +24,11 @@ targetEntityType: node
 bundle: pdq_cancer_information_summary
 mode: cthp_guide_card_list_item
 content:
+  content_moderation_control:
+    weight: -20
+    settings: {  }
+    third_party_settings: {  }
+    region: content
   field_browser_title:
     weight: 2
     label: hidden
@@ -35,6 +41,7 @@ hidden:
   field_date_posted: true
   field_date_updated: true
   field_hhs_syndication: true
+  field_pdq_is_svpc: true
   field_meta_tags: true
   field_page_description: true
   field_pdq_audience: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_view_display.node.pdq_cancer_information_summary.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_view_display.node.pdq_cancer_information_summary.default.yml
@@ -6,12 +6,12 @@ dependencies:
     - field.field.node.pdq_cancer_information_summary.field_date_posted
     - field.field.node.pdq_cancer_information_summary.field_date_updated
     - field.field.node.pdq_cancer_information_summary.field_hhs_syndication
-    - field.field.node.pdq_cancer_information_summary.field_pdq_is_svpc
     - field.field.node.pdq_cancer_information_summary.field_meta_tags
     - field.field.node.pdq_cancer_information_summary.field_page_description
     - field.field.node.pdq_cancer_information_summary.field_pdq_audience
     - field.field.node.pdq_cancer_information_summary.field_pdq_cdr_id
     - field.field.node.pdq_cancer_information_summary.field_pdq_intro_text
+    - field.field.node.pdq_cancer_information_summary.field_pdq_is_svpc
     - field.field.node.pdq_cancer_information_summary.field_pdq_summary_type
     - field.field.node.pdq_cancer_information_summary.field_pdq_suppress_otp
     - field.field.node.pdq_cancer_information_summary.field_pdq_url

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_view_display.node.pdq_cancer_information_summary.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_view_display.node.pdq_cancer_information_summary.default.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.node.pdq_cancer_information_summary.field_page_description
     - field.field.node.pdq_cancer_information_summary.field_pdq_audience
     - field.field.node.pdq_cancer_information_summary.field_pdq_cdr_id
+    - field.field.node.pdq_cancer_information_summary.field_pdq_intro_text
     - field.field.node.pdq_cancer_information_summary.field_pdq_summary_type
     - field.field.node.pdq_cancer_information_summary.field_pdq_suppress_otp
     - field.field.node.pdq_cancer_information_summary.field_pdq_url
@@ -24,6 +25,7 @@ dependencies:
     - datetime
     - entity_reference_revisions
     - options
+    - text
     - user
 id: node.pdq_cancer_information_summary.default
 targetEntityType: node
@@ -75,6 +77,13 @@ content:
       prefix_suffix: true
     third_party_settings: {  }
     type: number_integer
+    region: content
+  field_pdq_intro_text:
+    weight: 7
+    label: above
+    settings: { }
+    third_party_settings: { }
+    type: text_default
     region: content
   field_pdq_summary_type:
     weight: 5

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_view_display.node.pdq_cancer_information_summary.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_view_display.node.pdq_cancer_information_summary.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.node.pdq_cancer_information_summary.field_date_posted
     - field.field.node.pdq_cancer_information_summary.field_date_updated
     - field.field.node.pdq_cancer_information_summary.field_hhs_syndication
+    - field.field.node.pdq_cancer_information_summary.field_pdq_is_svpc
     - field.field.node.pdq_cancer_information_summary.field_meta_tags
     - field.field.node.pdq_cancer_information_summary.field_page_description
     - field.field.node.pdq_cancer_information_summary.field_pdq_audience
@@ -29,12 +30,12 @@ bundle: pdq_cancer_information_summary
 mode: default
 content:
   content_moderation_control:
-    weight: -20
+    weight: 0
+    region: content
     settings: {  }
     third_party_settings: {  }
-    region: content
   field_browser_title:
-    weight: 101
+    weight: 2
     label: above
     settings:
       link_to_entity: false
@@ -42,7 +43,7 @@ content:
     type: string
     region: content
   field_date_updated:
-    weight: 103
+    weight: 3
     label: above
     settings:
       format_type: cgov_display_date
@@ -51,7 +52,7 @@ content:
     type: datetime_default
     region: content
   field_page_description:
-    weight: 104
+    weight: 4
     label: above
     settings:
       link_to_entity: false
@@ -59,14 +60,14 @@ content:
     type: string
     region: content
   field_pdq_audience:
-    weight: 108
+    weight: 7
     label: above
     settings: {  }
     third_party_settings: {  }
     type: list_default
     region: content
   field_pdq_cdr_id:
-    weight: 106
+    weight: 6
     label: above
     settings:
       thousand_separator: ''
@@ -75,14 +76,14 @@ content:
     type: number_integer
     region: content
   field_pdq_summary_type:
-    weight: 105
+    weight: 5
     label: above
     settings: {  }
     third_party_settings: {  }
     type: list_default
     region: content
   field_pdq_url:
-    weight: 110
+    weight: 9
     label: above
     settings:
       link_to_entity: false
@@ -91,7 +92,7 @@ content:
     region: content
   field_summary_sections:
     type: entity_reference_revisions_entity_view
-    weight: 109
+    weight: 8
     label: above
     settings:
       view_mode: default
@@ -99,13 +100,14 @@ content:
     third_party_settings: {  }
     region: content
   links:
-    weight: 100
+    weight: 1
+    region: content
     settings: {  }
     third_party_settings: {  }
-    region: content
 hidden:
   field_date_posted: true
   field_hhs_syndication: true
+  field_pdq_is_svpc: true
   field_meta_tags: true
   field_public_use: true
   langcode: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_view_display.node.pdq_cancer_information_summary.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_view_display.node.pdq_cancer_information_summary.default.yml
@@ -12,6 +12,7 @@ dependencies:
     - field.field.node.pdq_cancer_information_summary.field_pdq_audience
     - field.field.node.pdq_cancer_information_summary.field_pdq_cdr_id
     - field.field.node.pdq_cancer_information_summary.field_pdq_summary_type
+    - field.field.node.pdq_cancer_information_summary.field_pdq_suppress_otp
     - field.field.node.pdq_cancer_information_summary.field_pdq_url
     - field.field.node.pdq_cancer_information_summary.field_public_use
     - field.field.node.pdq_cancer_information_summary.field_summary_sections
@@ -108,6 +109,7 @@ hidden:
   field_date_posted: true
   field_hhs_syndication: true
   field_pdq_is_svpc: true
+  field_pdq_suppress_otp: true
   field_meta_tags: true
   field_public_use: true
   langcode: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_view_display.node.pdq_cancer_information_summary.full.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_view_display.node.pdq_cancer_information_summary.full.yml
@@ -7,12 +7,12 @@ dependencies:
     - field.field.node.pdq_cancer_information_summary.field_date_posted
     - field.field.node.pdq_cancer_information_summary.field_date_updated
     - field.field.node.pdq_cancer_information_summary.field_hhs_syndication
-    - field.field.node.pdq_cancer_information_summary.field_pdq_is_svpc
     - field.field.node.pdq_cancer_information_summary.field_meta_tags
     - field.field.node.pdq_cancer_information_summary.field_page_description
     - field.field.node.pdq_cancer_information_summary.field_pdq_audience
     - field.field.node.pdq_cancer_information_summary.field_pdq_cdr_id
     - field.field.node.pdq_cancer_information_summary.field_pdq_intro_text
+    - field.field.node.pdq_cancer_information_summary.field_pdq_is_svpc
     - field.field.node.pdq_cancer_information_summary.field_pdq_summary_type
     - field.field.node.pdq_cancer_information_summary.field_pdq_suppress_otp
     - field.field.node.pdq_cancer_information_summary.field_pdq_url
@@ -26,6 +26,7 @@ dependencies:
     - datetime
     - entity_reference_revisions
     - options
+    - text
     - user
 id: node.pdq_cancer_information_summary.full
 targetEntityType: node

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_view_display.node.pdq_cancer_information_summary.full.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_view_display.node.pdq_cancer_information_summary.full.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.pdq_cancer_information_summary.field_date_posted
     - field.field.node.pdq_cancer_information_summary.field_date_updated
     - field.field.node.pdq_cancer_information_summary.field_hhs_syndication
+    - field.field.node.pdq_cancer_information_summary.field_pdq_is_svpc
     - field.field.node.pdq_cancer_information_summary.field_meta_tags
     - field.field.node.pdq_cancer_information_summary.field_page_description
     - field.field.node.pdq_cancer_information_summary.field_pdq_audience
@@ -107,6 +108,7 @@ content:
 hidden:
   field_date_posted: true
   field_hhs_syndication: true
+  field_pdq_is_svpc: true
   field_meta_tags: true
   field_public_use: true
   langcode: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_view_display.node.pdq_cancer_information_summary.full.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_view_display.node.pdq_cancer_information_summary.full.yml
@@ -12,6 +12,7 @@ dependencies:
     - field.field.node.pdq_cancer_information_summary.field_page_description
     - field.field.node.pdq_cancer_information_summary.field_pdq_audience
     - field.field.node.pdq_cancer_information_summary.field_pdq_cdr_id
+    - field.field.node.pdq_cancer_information_summary.field_pdq_intro_text
     - field.field.node.pdq_cancer_information_summary.field_pdq_summary_type
     - field.field.node.pdq_cancer_information_summary.field_pdq_suppress_otp
     - field.field.node.pdq_cancer_information_summary.field_pdq_url
@@ -77,6 +78,13 @@ content:
     third_party_settings: {  }
     type: number_integer
     region: content
+  field_pdq_intro_text:
+    weight: 109
+    label: above
+    settings: { }
+    third_party_settings: { }
+    type: text_default
+    region: content
   field_pdq_summary_type:
     weight: 105
     label: above
@@ -85,7 +93,7 @@ content:
     type: list_default
     region: content
   field_pdq_url:
-    weight: 110
+    weight: 111
     label: above
     settings:
       link_to_entity: false
@@ -94,7 +102,7 @@ content:
     region: content
   field_summary_sections:
     type: entity_reference_revisions_entity_view
-    weight: 109
+    weight: 110
     label: above
     settings:
       view_mode: default

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_view_display.node.pdq_cancer_information_summary.full.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_view_display.node.pdq_cancer_information_summary.full.yml
@@ -13,6 +13,7 @@ dependencies:
     - field.field.node.pdq_cancer_information_summary.field_pdq_audience
     - field.field.node.pdq_cancer_information_summary.field_pdq_cdr_id
     - field.field.node.pdq_cancer_information_summary.field_pdq_summary_type
+    - field.field.node.pdq_cancer_information_summary.field_pdq_suppress_otp
     - field.field.node.pdq_cancer_information_summary.field_pdq_url
     - field.field.node.pdq_cancer_information_summary.field_public_use
     - field.field.node.pdq_cancer_information_summary.field_summary_sections
@@ -109,6 +110,7 @@ hidden:
   field_date_posted: true
   field_hhs_syndication: true
   field_pdq_is_svpc: true
+  field_pdq_suppress_otp: true
   field_meta_tags: true
   field_public_use: true
   langcode: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_view_display.node.pdq_cancer_information_summary.teaser.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_view_display.node.pdq_cancer_information_summary.teaser.yml
@@ -7,12 +7,12 @@ dependencies:
     - field.field.node.pdq_cancer_information_summary.field_date_posted
     - field.field.node.pdq_cancer_information_summary.field_date_updated
     - field.field.node.pdq_cancer_information_summary.field_hhs_syndication
-    - field.field.node.pdq_cancer_information_summary.field_pdq_is_svpc
     - field.field.node.pdq_cancer_information_summary.field_meta_tags
     - field.field.node.pdq_cancer_information_summary.field_page_description
     - field.field.node.pdq_cancer_information_summary.field_pdq_audience
     - field.field.node.pdq_cancer_information_summary.field_pdq_cdr_id
     - field.field.node.pdq_cancer_information_summary.field_pdq_intro_text
+    - field.field.node.pdq_cancer_information_summary.field_pdq_is_svpc
     - field.field.node.pdq_cancer_information_summary.field_pdq_summary_type
     - field.field.node.pdq_cancer_information_summary.field_pdq_suppress_otp
     - field.field.node.pdq_cancer_information_summary.field_pdq_url

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_view_display.node.pdq_cancer_information_summary.teaser.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_view_display.node.pdq_cancer_information_summary.teaser.yml
@@ -12,6 +12,7 @@ dependencies:
     - field.field.node.pdq_cancer_information_summary.field_page_description
     - field.field.node.pdq_cancer_information_summary.field_pdq_audience
     - field.field.node.pdq_cancer_information_summary.field_pdq_cdr_id
+    - field.field.node.pdq_cancer_information_summary.field_pdq_intro_text
     - field.field.node.pdq_cancer_information_summary.field_pdq_summary_type
     - field.field.node.pdq_cancer_information_summary.field_pdq_suppress_otp
     - field.field.node.pdq_cancer_information_summary.field_pdq_url
@@ -48,6 +49,7 @@ hidden:
   field_page_description: true
   field_pdq_audience: true
   field_pdq_cdr_id: true
+  field_pdq_intro_text: true
   field_pdq_summary_type: true
   field_pdq_suppress_otp: true
   field_pdq_url: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_view_display.node.pdq_cancer_information_summary.teaser.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_view_display.node.pdq_cancer_information_summary.teaser.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.pdq_cancer_information_summary.field_date_posted
     - field.field.node.pdq_cancer_information_summary.field_date_updated
     - field.field.node.pdq_cancer_information_summary.field_hhs_syndication
+    - field.field.node.pdq_cancer_information_summary.field_pdq_is_svpc
     - field.field.node.pdq_cancer_information_summary.field_meta_tags
     - field.field.node.pdq_cancer_information_summary.field_page_description
     - field.field.node.pdq_cancer_information_summary.field_pdq_audience
@@ -16,6 +17,9 @@ dependencies:
     - field.field.node.pdq_cancer_information_summary.field_public_use
     - field.field.node.pdq_cancer_information_summary.field_summary_sections
     - node.type.pdq_cancer_information_summary
+  enforced:
+    module:
+      - pdq_cancer_information_summary
   module:
     - user
 id: node.pdq_cancer_information_summary.teaser
@@ -23,6 +27,11 @@ targetEntityType: node
 bundle: pdq_cancer_information_summary
 mode: teaser
 content:
+  content_moderation_control:
+    weight: -20
+    settings: {  }
+    third_party_settings: {  }
+    region: content
   links:
     weight: 100
     settings: {  }
@@ -33,6 +42,7 @@ hidden:
   field_date_posted: true
   field_date_updated: true
   field_hhs_syndication: true
+  field_pdq_is_svpc: true
   field_meta_tags: true
   field_page_description: true
   field_pdq_audience: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_view_display.node.pdq_cancer_information_summary.teaser.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_view_display.node.pdq_cancer_information_summary.teaser.yml
@@ -13,6 +13,7 @@ dependencies:
     - field.field.node.pdq_cancer_information_summary.field_pdq_audience
     - field.field.node.pdq_cancer_information_summary.field_pdq_cdr_id
     - field.field.node.pdq_cancer_information_summary.field_pdq_summary_type
+    - field.field.node.pdq_cancer_information_summary.field_pdq_suppress_otp
     - field.field.node.pdq_cancer_information_summary.field_pdq_url
     - field.field.node.pdq_cancer_information_summary.field_public_use
     - field.field.node.pdq_cancer_information_summary.field_summary_sections
@@ -48,6 +49,7 @@ hidden:
   field_pdq_audience: true
   field_pdq_cdr_id: true
   field_pdq_summary_type: true
+  field_pdq_suppress_otp: true
   field_pdq_url: true
   field_public_use: true
   field_summary_sections: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/field.field.node.pdq_cancer_information_summary.field_pdq_intro_text.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/field.field.node.pdq_cancer_information_summary.field_pdq_intro_text.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_pdq_intro_text
+    - node.type.pdq_cancer_information_summary
+  module:
+    - node
+    - text
+id: node.pdq_cancer_information_summary.field_pdq_intro_text
+field_name: field_pdq_intro_text
+entity_type: node
+bundle: pdq_cancer_information_summary
+label: 'Intro Text'
+description: 'Optional introductory section displayed at the top of the summary without a title.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text_long

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/field.field.node.pdq_cancer_information_summary.field_pdq_intro_text.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/field.field.node.pdq_cancer_information_summary.field_pdq_intro_text.yml
@@ -5,7 +5,6 @@ dependencies:
     - field.storage.node.field_pdq_intro_text
     - node.type.pdq_cancer_information_summary
   module:
-    - node
     - text
 id: node.pdq_cancer_information_summary.field_pdq_intro_text
 field_name: field_pdq_intro_text

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/field.field.node.pdq_cancer_information_summary.field_pdq_is_svpc.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/field.field.node.pdq_cancer_information_summary.field_pdq_is_svpc.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_pdq_is_svpc
+    - node.type.pdq_cancer_information_summary
+id: node.pdq_cancer_information_summary.field_pdq_is_svpc
+field_name: field_pdq_is_svpc
+entity_type: node
+bundle: pdq_cancer_information_summary
+label: 'SVPC Summary'
+description: 'Flag indicating whether this Cancer Information Summary was created as part of the <em>Single View Patient Content</em> project.'
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'Yes'
+  off_label: 'No'
+field_type: boolean

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/field.field.node.pdq_cancer_information_summary.field_pdq_suppress_otp.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/field.field.node.pdq_cancer_information_summary.field_pdq_suppress_otp.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_pdq_suppress_otp
+    - node.type.pdq_cancer_information_summary
+id: node.pdq_cancer_information_summary.field_pdq_suppress_otp
+field_name: field_pdq_suppress_otp
+entity_type: node
+bundle: pdq_cancer_information_summary
+label: 'Hide "On This Page" Section'
+description: "Flag indicating whether the list of top-level sections with jump links should not be displayed for this summary's page."
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'Yes'
+  off_label: 'No'
+field_type: boolean

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/field.storage.node.field_pdq_intro_text.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/field.storage.node.field_pdq_intro_text.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+      - pdq_cancer_information_summary
+  module:
+    - node
+    - text
+id: node.field_pdq_intro_text
+field_name: field_pdq_intro_text
+entity_type: node
+type: text_long
+settings: {  }
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/field.storage.node.field_pdq_is_svpc.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/field.storage.node.field_pdq_is_svpc.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+      - pdq_cancer_information_summary
+  module:
+    - node
+id: node.field_pdq_is_svpc
+field_name: field_pdq_is_svpc
+entity_type: node
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/field.storage.node.field_pdq_suppress_otp.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/field.storage.node.field_pdq_suppress_otp.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+      - pdq_cancer_information_summary
+  module:
+    - node
+id: node.field_pdq_suppress_otp
+field_name: field_pdq_suppress_otp
+entity_type: node
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/pdq_cancer_information_summary.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/pdq_cancer_information_summary.info.yml
@@ -2,31 +2,31 @@ name: 'PDQ Cancer Information Summary'
 type: module
 package: 'CGov Digital Platform'
 description: 'The PDQ Cancer Information Summary content type'
-core_version_requirement: ^8.9 || ^9
+core_version_requirement: '^8.9 || ^9'
 dependencies:
-  - basic_auth
-  - cgov_core
-  - cgov_syndication
-  - content_moderation
-  - content_translation
-  - datetime
-  - entity_browser
-  - entity_reference_revisions
-  - field
-  - language
-  - metatag
-  - metatag_dc
-  - node
-  - options
-  - paragraphs
-  - paragraphs_asymmetric_translation_widgets
-  - path
-  - pathauto
-  - pdq_cancer_information_summary
-  - pdq_core
-  - rest
-  - serialization
-  - simple_sitemap
-  - text
-  - user
-  - views
+  - 'cgov_core:cgov_core'
+  - 'cgov_syndication:cgov_syndication'
+  - 'drupal:basic_auth'
+  - 'drupal:content_moderation'
+  - 'drupal:content_translation'
+  - 'drupal:datetime'
+  - 'drupal:field'
+  - 'drupal:language'
+  - 'drupal:node'
+  - 'drupal:options'
+  - 'drupal:path'
+  - 'drupal:rest'
+  - 'drupal:serialization'
+  - 'drupal:text'
+  - 'drupal:user'
+  - 'drupal:views'
+  - 'entity_browser:entity_browser'
+  - 'entity_reference_revisions:entity_reference_revisions'
+  - 'metatag:metatag'
+  - 'metatag:metatag_dc'
+  - 'paragraphs:paragraphs'
+  - 'paragraphs_asymmetric_translation_widgets:paragraphs_asymmetric_translation_widgets'
+  - 'pathauto:pathauto'
+  - 'pdq_cancer_information_summary:pdq_cancer_information_summary'
+  - 'pdq_core:pdq_core'
+  - 'simple_sitemap:simple_sitemap'

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/pdq_cancer_information_summary.install
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/pdq_cancer_information_summary.install
@@ -262,3 +262,35 @@ function pdq_cancer_information_summary_update_9002(&$sandbox) {
     \Drupal::logger($bundle)->notice("Created $count rows in $suppress_otp_table.");
   }
 }
+
+/**
+ * Add new field for optional introductory text section without a title.
+ */
+function pdq_cancer_information_summary_update_9003(&$sandbox) {
+
+  // Make sure the field is installed.
+  _pdq_cancer_information_summary_install_node_field('field_pdq_intro_text');
+
+  // Make sure it shows up on the form.
+  $name = 'core.entity_form_display.node.pdq_cancer_information_summary.default';
+  $config = \Drupal::getContainer()->get('config.factory')->getEditable($name);
+  $content = $config->get('content');
+  $hidden = $config->get('hidden');
+  $weight = $content['field_summary_sections']['weight'] ?? 1000;
+  $content['field_pdq_intro_text'] = [
+    'weight' => $weight - 1,
+    'settings' => [
+      'display_label' => TRUE,
+      'rows' => 5,
+      'placeholder' => '',
+    ],
+    'third_party_settings' => [],
+    'type' => 'text_textarea',
+    'region' => 'content',
+  ];
+  unset($hidden['field_pdq_intro_text']);
+  $config->set('content', $content);
+  $config->set('hidden', $hidden);
+  $config->save();
+  \Drupal::logger('pdq_cancer_information_summary')->notice('Installed field_pdq_intro_text on the edit form.');
+}

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/pdq_cancer_information_summary.install
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/pdq_cancer_information_summary.install
@@ -1,5 +1,9 @@
 <?php
 
+use Drupal\Core\Config\FileStorage;
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
+
 /**
  * @file
  * Contains pdq_cancer_information_summary.install.
@@ -58,4 +62,116 @@ function pdq_cancer_information_summary_update_8001() {
   // Install the new permission.
   $perms = ['pdq_importer' => ['restful patch pdq_cis_api']];
   $siteHelper->addRolePermissions($perms);
+}
+
+/**
+ * Install new node field.
+ *
+ * @param string $name
+ */
+function _pdq_cancer_information_summary_install_node_field($name) {
+  $dir = new FileStorage(__DIR__ . '/config/install/');
+  if (!FieldStorageConfig::loadByName('node', $name)) {
+    $record = $dir->read("field.storage.node.$name");
+    FieldStorageConfig::create($record)->save();
+    \Drupal::logger('pdq_cancer_information_summary')->notice("Installed storage config for $name.");
+  }
+  else {
+    \Drupal::logger('pdq_cancer_information_summary')->notice("Storage config for $name already installed.");
+  }
+  if (!FieldConfig::loadByName('node', 'pdq_cancer_information_summary', $name)) {
+    $record = $dir->read("field.field.node.pdq_cancer_information_summary.$name");
+    FieldConfig::create($record)->save();
+    \Drupal::logger('pdq_cancer_information_summary')->notice("Installed field config for $name.");
+  }
+  else {
+    \Drupal::logger('pdq_cancer_information_summary')->notice("Field config for $name already installed.");
+  }
+}
+
+/**
+ * Add new field to indentify "Single-view patient content" summaries.
+ *
+ * Creates the field's database table rows for existing summaries.
+ */
+function pdq_cancer_information_summary_update_9001(&$sandbox) {
+
+  // Make sure the field is installed.
+  _pdq_cancer_information_summary_install_node_field('field_pdq_is_svpc');
+
+  // Make sure it shows up on the form.
+  $name = 'core.entity_form_display.node.pdq_cancer_information_summary.default';
+  $config = \Drupal::getContainer()->get('config.factory')->getEditable($name);
+  $content = $config->get('content');
+  $hidden = $config->get('hidden');
+  $weight = $content['field_summary_sections']['weight'] ?? 1000;
+  $content['field_pdq_is_svpc'] = [
+    'weight' => $weight - 1,
+    'settings' => ['display_label' => TRUE],
+    'third_party_settings' => [],
+    'type' => 'boolean_checkbox',
+    'region' => 'content',
+  ];
+  unset($hidden['field_pdq_is_svpc']);
+  $config->set('content', $content);
+  $config->set('hidden', $hidden);
+  $config->save();
+  \Drupal::logger('pdq_cancer_information_summary')->notice('Installed field_pdq_is_svpc on the edit form.');
+
+  // Make sure software querying the field don't get back a NULL.
+  $db = \Drupal::database();
+  $bundle = 'pdq_cancer_information_summary';
+  $fields = [
+    'bundle',
+    'deleted',
+    'entity_id',
+    'revision_id',
+    'langcode',
+    'delta',
+    'field_pdq_is_svpc_value',
+  ];
+  $prefixes = ['node', 'node_revision'];
+  foreach ($prefixes as $prefix) {
+    $cdr_id_table = "{$prefix}__field_pdq_cdr_id";
+    $svpc_table = "{$prefix}__field_pdq_is_svpc";
+    $results = $db->select($svpc_table, 't')
+      ->fields('t', ['entity_id', 'revision_id', 'langcode'])
+      ->condition('bundle', $bundle)
+      ->condition('deleted', 0)
+      ->distinct()
+      ->execute();
+    $found = [];
+    foreach ($results as $result) {
+      $key = $result->entity_id . '|' . $result->revision_id . '|' . $result->langcode;
+      $found[$key] = $key;
+    }
+    $results = $db->select($cdr_id_table, 't')
+      ->fields('t', ['entity_id', 'revision_id', 'langcode'])
+      ->condition('bundle', $bundle)
+      ->condition('deleted', 0)
+      ->distinct()
+      ->execute();
+    $records = [];
+    foreach ($results as $result) {
+      $key = $result->entity_id . '|' . $result->revision_id . '|' . $result->langcode;
+      if (!array_key_exists($key, $found)) {
+        $records[] = [
+          'bundle' => $bundle,
+          'deleted' => 0,
+          'entity_id' => $result->entity_id,
+          'revision_id' => $result->revision_id,
+          'langcode' => $result->langcode,
+          'delta' => 0,
+          'field_pdq_is_svpc_value' => 0,
+        ];
+      }
+    }
+    $insert = $db->insert($svpc_table)->fields($fields);
+    foreach ($records as $record) {
+      $insert->values($record);
+    }
+    $insert->execute();
+    $count = count($records);
+    \Drupal::logger($bundle)->notice("Created $count rows in $svpc_table.");
+  }
 }

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/pdq_cancer_information_summary.install
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/pdq_cancer_information_summary.install
@@ -118,7 +118,7 @@ function pdq_cancer_information_summary_update_9001(&$sandbox) {
   $config->save();
   \Drupal::logger('pdq_cancer_information_summary')->notice('Installed field_pdq_is_svpc on the edit form.');
 
-  // Make sure software querying the field don't get back a NULL.
+  // Make sure software querying the field doesn't get back a NULL.
   $db = \Drupal::database();
   $bundle = 'pdq_cancer_information_summary';
   $fields = [
@@ -173,5 +173,92 @@ function pdq_cancer_information_summary_update_9001(&$sandbox) {
     $insert->execute();
     $count = count($records);
     \Drupal::logger($bundle)->notice("Created $count rows in $svpc_table.");
+  }
+}
+
+/**
+ * Add new field to suppress display of "On This Page" section.
+ *
+ * Creates the field's database table rows for existing summaries.
+ */
+function pdq_cancer_information_summary_update_9002(&$sandbox) {
+
+  // Make sure the field is installed.
+  _pdq_cancer_information_summary_install_node_field('field_pdq_suppress_otp');
+
+  // Make sure it shows up on the form.
+  $name = 'core.entity_form_display.node.pdq_cancer_information_summary.default';
+  $config = \Drupal::getContainer()->get('config.factory')->getEditable($name);
+  $content = $config->get('content');
+  $hidden = $config->get('hidden');
+  $weight = $content['field_summary_sections']['weight'] ?? 1000;
+  $content['field_pdq_suppress_otp'] = [
+    'weight' => $weight - 1,
+    'settings' => ['display_label' => TRUE],
+    'third_party_settings' => [],
+    'type' => 'boolean_checkbox',
+    'region' => 'content',
+  ];
+  unset($hidden['field_pdq_suppress_otp']);
+  $config->set('content', $content);
+  $config->set('hidden', $hidden);
+  $config->save();
+  \Drupal::logger('pdq_cancer_information_summary')->notice('Installed field_pdq_suppress_otp on the edit form.');
+
+  // Make sure software querying the field doesn't get back a NULL.
+  $db = \Drupal::database();
+  $bundle = 'pdq_cancer_information_summary';
+  $fields = [
+    'bundle',
+    'deleted',
+    'entity_id',
+    'revision_id',
+    'langcode',
+    'delta',
+    'field_pdq_suppress_otp_value',
+  ];
+  $prefixes = ['node', 'node_revision'];
+  foreach ($prefixes as $prefix) {
+    $cdr_id_table = "{$prefix}__field_pdq_cdr_id";
+    $suppress_otp_table = "{$prefix}__field_pdq_suppress_otp";
+    $results = $db->select($suppress_otp_table, 't')
+      ->fields('t', ['entity_id', 'revision_id', 'langcode'])
+      ->condition('bundle', $bundle)
+      ->condition('deleted', 0)
+      ->distinct()
+      ->execute();
+    $found = [];
+    foreach ($results as $result) {
+      $key = $result->entity_id . '|' . $result->revision_id . '|' . $result->langcode;
+      $found[$key] = $key;
+    }
+    $results = $db->select($cdr_id_table, 't')
+      ->fields('t', ['entity_id', 'revision_id', 'langcode'])
+      ->condition('bundle', $bundle)
+      ->condition('deleted', 0)
+      ->distinct()
+      ->execute();
+    $records = [];
+    foreach ($results as $result) {
+      $key = $result->entity_id . '|' . $result->revision_id . '|' . $result->langcode;
+      if (!array_key_exists($key, $found)) {
+        $records[] = [
+          'bundle' => $bundle,
+          'deleted' => 0,
+          'entity_id' => $result->entity_id,
+          'revision_id' => $result->revision_id,
+          'langcode' => $result->langcode,
+          'delta' => 0,
+          'field_pdq_suppress_otp_value' => 0,
+        ];
+      }
+    }
+    $insert = $db->insert($suppress_otp_table)->fields($fields);
+    foreach ($records as $record) {
+      $insert->values($record);
+    }
+    $insert->execute();
+    $count = count($records);
+    \Drupal::logger($bundle)->notice("Created $count rows in $suppress_otp_table.");
   }
 }

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/pdq_cancer_information_summary.module
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/pdq_cancer_information_summary.module
@@ -160,7 +160,7 @@ function pdq_cancer_information_summary_node_view(array &$build, EntityInterface
     return;
   }
 
-  if (isset($build['field_summary_sections'])) {
+  if (!empty($build['field_summary_sections']['#items'])) {
     // Copy summary sections into a new "field" using TOC display.
     $build['otp_toc'] = $build['field_summary_sections']['#items']->view([
       'type' => 'entity_reference_revisions_entity_view',

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/pdq_cancer_information_summary.module
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/pdq_cancer_information_summary.module
@@ -17,7 +17,10 @@ function pdq_cancer_information_summary_field_widget_form_alter(
   &$element,
   FormStateInterface $form_state,
   $context) {
-  $map = ['field_pdq_section_html' => ['raw_html']];
+  $map = [
+    'field_pdq_section_html' => ['raw_html'],
+    'field_pdq_intro_text' => ['raw_html'],
+  ];
   $form_helper = \Drupal::service('cgov_core.form_tools');
   $form_helper->allowTextFormats($map, $element, $context);
 }

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/pdq_cancer_information_summary.module
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/pdq_cancer_information_summary.module
@@ -161,15 +161,20 @@ function pdq_cancer_information_summary_node_view(array &$build, EntityInterface
   }
 
   if (!empty($build['field_summary_sections']['#items'])) {
-    // Copy summary sections into a new "field" using TOC display.
-    $build['otp_toc'] = $build['field_summary_sections']['#items']->view([
-      'type' => 'entity_reference_revisions_entity_view',
-      'settings' => [
-        'view_mode' => 'otp_toc',
-        'link' => 'link',
-      ],
-    ]);
-    $build['otp_toc']['#theme'] = 'field__otp_toc';
+
+    // Make sure the field isn't being suppressed.
+    if ($entity->field_pdq_suppress_otp->value == '0') {
+
+      // Copy summary sections into a new "field" using TOC display.
+      $build['otp_toc'] = $build['field_summary_sections']['#items']->view([
+        'type' => 'entity_reference_revisions_entity_view',
+        'settings' => [
+          'view_mode' => 'otp_toc',
+          'link' => 'link',
+        ],
+      ]);
+      $build['otp_toc']['#theme'] = 'field__otp_toc';
+    }
   }
 }
 

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/src/Plugin/rest/resource/PDQResource.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/src/Plugin/rest/resource/PDQResource.php
@@ -172,6 +172,7 @@ class PDQResource extends ResourceBase {
           'published' => $translation->status->value,
           'sections' => $sections,
           'svpc' => $translation->field_pdq_is_svpc->value,
+          'suppress_otp' => $translation->field_pdq_suppress_otp->value,
         ];
       }
     }
@@ -287,6 +288,7 @@ class PDQResource extends ResourceBase {
     $node->set('field_summary_sections', $sections);
     $node->set('field_public_use', 1);
     $node->set('field_pdq_is_svpc', $summary['svpc']);
+    $node->set('field_pdq_suppress_otp', $summary['suppress_otp']);
 
     // The syndication field is not translatable.
     if ($language == 'en') {

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/src/Plugin/rest/resource/PDQResource.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/src/Plugin/rest/resource/PDQResource.php
@@ -171,6 +171,7 @@ class PDQResource extends ResourceBase {
           'url' => $translation->field_pdq_url->value,
           'published' => $translation->status->value,
           'sections' => $sections,
+          'svpc' => $translation->field_pdq_is_svpc->value,
         ];
       }
     }
@@ -285,6 +286,7 @@ class PDQResource extends ResourceBase {
     $node->set('field_page_description', $summary['description']);
     $node->set('field_summary_sections', $sections);
     $node->set('field_public_use', 1);
+    $node->set('field_pdq_is_svpc', $summary['svpc']);
 
     // The syndication field is not translatable.
     if ($language == 'en') {

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/src/Plugin/rest/resource/PDQResource.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/src/Plugin/rest/resource/PDQResource.php
@@ -173,6 +173,7 @@ class PDQResource extends ResourceBase {
           'sections' => $sections,
           'svpc' => $translation->field_pdq_is_svpc->value,
           'suppress_otp' => $translation->field_pdq_suppress_otp->value,
+          'intro_text' => $translation->field_pdq_intro_text->value,
         ];
       }
     }
@@ -287,8 +288,9 @@ class PDQResource extends ResourceBase {
     $node->set('field_page_description', $summary['description']);
     $node->set('field_summary_sections', $sections);
     $node->set('field_public_use', 1);
-    $node->set('field_pdq_is_svpc', $summary['svpc']);
-    $node->set('field_pdq_suppress_otp', $summary['suppress_otp']);
+    $node->set('field_pdq_is_svpc', $summary['svpc'] ?? 0);
+    $node->set('field_pdq_suppress_otp', $summary['suppress_otp'] ?? 0);
+    $node->set('field_pdq_intro_text', $summary['intro_text'] ?? '');
 
     // The syndication field is not translatable.
     if ($language == 'en') {

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/tests/src/Functional/ApiTest.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/tests/src/Functional/ApiTest.php
@@ -58,6 +58,7 @@ class ApiTest extends BrowserTestBase {
       ['id' => '_2', 'title' => 'Section 2', 'html' => '<p>two</p>'],
     ],
     'svpc' => 0,
+    'suppress_otp' => 0,
   ];
 
   /**
@@ -85,6 +86,7 @@ class ApiTest extends BrowserTestBase {
       ['id' => '_2', 'title' => "Secci\u{f3}n 2", 'html' => '<p>Dos</p>'],
     ],
     'svpc' => 1,
+    'suppress_otp' => 1,
   ];
 
   /**
@@ -107,6 +109,7 @@ class ApiTest extends BrowserTestBase {
     'updated_date',
     'url',
     'svpc',
+    'suppress_otp',
   ];
 
   /**
@@ -172,6 +175,7 @@ class ApiTest extends BrowserTestBase {
     $this->english['sections'][] = $section;
     $this->english['description'] = 'Revised test description';
     $this->english['svpc'] = 1;
+    $this->english['suppress_otp'] = 1;
     $payload = $this->store($this->english, 200);
     $summary_sections_created += count($this->english['sections']);
     $this->assertEquals($payload['nid'], $nid, 'Uses same node');

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/tests/src/Functional/ApiTest.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/tests/src/Functional/ApiTest.php
@@ -59,6 +59,7 @@ class ApiTest extends BrowserTestBase {
     ],
     'svpc' => 0,
     'suppress_otp' => 0,
+    'intro_text' => '<p><em>Look!</em></p>',
   ];
 
   /**
@@ -87,6 +88,7 @@ class ApiTest extends BrowserTestBase {
     ],
     'svpc' => 1,
     'suppress_otp' => 1,
+    'intro_text' => '<p><em>¡Mira!</em></p>',
   ];
 
   /**
@@ -110,6 +112,7 @@ class ApiTest extends BrowserTestBase {
     'url',
     'svpc',
     'suppress_otp',
+    'intro_text',
   ];
 
   /**
@@ -176,6 +179,7 @@ class ApiTest extends BrowserTestBase {
     $this->english['description'] = 'Revised test description';
     $this->english['svpc'] = 1;
     $this->english['suppress_otp'] = 1;
+    $this->english['intro_text'] = '<p>Oh, look!</p>';
     $payload = $this->store($this->english, 200);
     $summary_sections_created += count($this->english['sections']);
     $this->assertEquals($payload['nid'], $nid, 'Uses same node');

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/tests/src/Functional/ApiTest.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/tests/src/Functional/ApiTest.php
@@ -57,6 +57,7 @@ class ApiTest extends BrowserTestBase {
       ['id' => '_1', 'title' => 'Section 1', 'html' => '<p>one</p>'],
       ['id' => '_2', 'title' => 'Section 2', 'html' => '<p>two</p>'],
     ],
+    'svpc' => 0,
   ];
 
   /**
@@ -83,6 +84,7 @@ class ApiTest extends BrowserTestBase {
       ['id' => '_1', 'title' => "Secci\u{f3}n 1", 'html' => '<p>Uno</p>'],
       ['id' => '_2', 'title' => "Secci\u{f3}n 2", 'html' => '<p>Dos</p>'],
     ],
+    'svpc' => 1,
   ];
 
   /**
@@ -104,6 +106,7 @@ class ApiTest extends BrowserTestBase {
     'summary_type',
     'updated_date',
     'url',
+    'svpc',
   ];
 
   /**
@@ -168,6 +171,7 @@ class ApiTest extends BrowserTestBase {
     $section = ['id' => '_3', 'title' => 'Section 3', 'html' => '<p>3</p>'];
     $this->english['sections'][] = $section;
     $this->english['description'] = 'Revised test description';
+    $this->english['svpc'] = 1;
     $payload = $this->store($this->english, 200);
     $summary_sections_created += count($this->english['sections']);
     $this->assertEquals($payload['nid'], $nid, 'Uses same node');
@@ -237,7 +241,7 @@ class ApiTest extends BrowserTestBase {
     $response = $this->request('GET', "$this->pdqUrl/list");
     $this->assertEquals($response->getStatusCode(), 200);
     $values = json_decode($response->getBody()->__toString(), TRUE);
-    $this->assertCount(2, $values, 'One entries in catalog');
+    $this->assertCount(2, $values, 'Two entries in catalog');
 
     // Results are ordered by CDR ID, so this is the Spanish summary.
     $entry = array_pop($values);

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/entrypoints/pdq/PDQ.js
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/entrypoints/pdq/PDQ.js
@@ -1,6 +1,3 @@
-// import $ from 'jquery';
-import { getNodeArray } from 'Core/utilities/domManipulation';
-import { lang } from 'Core/libraries/nciConfig/NCI.config';
 import linkAudioPlayer from 'Core/libraries/linkAudioPlayer/linkAudioPlayer';
 import './PDQ.scss';
 
@@ -9,8 +6,6 @@ const language = document.documentElement.lang;
 const onDOMContentLoaded = () => {
   // move health professional/patient toggle up to article head
   moveToggle();
-
-  buildInThisSection(getNodeArray('#cgvBody .accordion > section'));
 
   buildAudioLinks();
 
@@ -27,40 +22,6 @@ const moveToggle = () => {
     pageTitle.insertAdjacentElement('afterend',toggle);
 
   }
-};
-
-/* TODO: create an object or field on the content type that holds In This Section link structure */
-const buildInThisSection = (sections) => {
-  sections.map((section)=>{
-    const headers = getNodeArray('h3, h4',section);
-
-    // filter out "About This PDQ" section, sections with no h3's or h4's and sections with Key Points
-    if(section.id !== '_AboutThis_1' && headers.length > 0 && !headers[0].id.match(/kpBox/)) {
-      let nav = `<nav class="in-this-section role="navigation"><h6>${lang.InThisSection[language]}</h6><ul>`;
-      headers.map((header,i) => {
-        // check to see if we need to nest a new unordered list for h4's
-        if( i !== 0 && headers[i-1].nodeName.toLowerCase() === 'h3' && header.nodeName.toLowerCase() === 'h4' ){
-          nav += `<ul><li><a href="#${header.id}">${header.innerHTML}</a>`;
-        } else {
-          if(i === 0) {
-            // this is the first item in the list
-            nav += `<li><a href="#${header.id}">${header.innerHTML}</a>`;
-          } else {
-            // this is an h3 with a previous sibling of h3 or
-            // this is an h4 with a previous sibling of h4
-            nav += `</li><li><a href="#${header.id}">${header.innerHTML}</a>`;
-          }
-        }
-        // next header is an h3 so close this nested list
-        if (headers[i+1] && headers[i+1].nodeName.toLowerCase() === 'h3' && header.nodeName.toLowerCase() === 'h4') {
-          nav += `</li></ul>`;
-        }
-      });
-      nav += `</li></ul></nav>`;
-
-      section.querySelector(".pdq-sections").insertAdjacentHTML('afterbegin',nav);
-    }
-  });
 };
 
 // fix citation anchor links

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/pdq/node--pdq-cancer-information-summary--full.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/pdq/node--pdq-cancer-information-summary--full.html.twig
@@ -9,6 +9,9 @@
     {{ drupal_block('page_options') }}
     <div id="cgvBody">
       <div class="summary-sections">
+        {% if node.field_pdq_intro_text.value is not empty %}
+          {{ node.field_pdq_intro_text.value|raw }}
+        {% endif %}
         {{ content.otp_toc }}
         <div class="{{ content.otp_toc is not empty ? 'accordion' : '' }}">
           {{ content.field_summary_sections }}

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/pdq/node--pdq-cancer-information-summary--full.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/pdq/node--pdq-cancer-information-summary--full.html.twig
@@ -10,7 +10,7 @@
     <div id="cgvBody">
       <div class="summary-sections">
         {{ content.otp_toc }}
-        <div class="accordion">
+        <div class="{{ content.otp_toc is not empty ? 'accordion' : '' }}">
           {{ content.field_summary_sections }}
         </div>
       </div>

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/pdq/node--pdq-cancer-information-summary--hhs-syndication.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/pdq/node--pdq-cancer-information-summary--hhs-syndication.html.twig
@@ -16,6 +16,9 @@
 <h2 id="bodyTitle">{{ node.label }}</h2>
 <div id="bodyContent">
     <div class="summaryPage">
+        {% if node.field_pdq_intro_text.value is not empty %}
+          {{ node.field_pdq_intro_text.value|raw }}
+        {% endif %}
         {{ content.field_summary_sections }}
     </div>
 </div>


### PR DESCRIPTION
Three fields have been added to the pdq_cancer_information_summary content type to support the Single View Patient Content project.

- A new flag (field_pdq_is_svpc) indicating that the summary is an SVPC summary (Story: Update Cancer Information Summary content type with SVPC field #3231)
- A new flag (field_pdq_suppress_otp) indicating that the On This Page links section should not be displayed (Story: Update Cancer Information Summary content type with Hide On This Page field #3230)
- A new raw HTML field (field_pdq_intro_text) to be displayed if present at the top of the page for the summary, following the title but preceding the summary sections (and the On This Page links if those are present) (Story: Update Cancer Information Summary content type with Intro Text field #3229)

In addition, a bug in the test to determine whether summary sections are present in a CIS node was fixed in the view hook for PDQ CIS content. (#3244)

The JavaScript which generated the "In This Section" blocks on the client side has been removed (these blocks are now created upstream by the CDR publishing software).

YAML test content has been added for SVPC summaries and cancer-type home pages.

Closes #3229
Closes #3230
Closes #3231
Closes #3244
Closes #3260 
Closes #3300