### PR TITLE
(#3197) Load front-end globals on reinstall

### DIFF
--- a/blt/blt.yml
+++ b/blt/blt.yml
@@ -101,8 +101,10 @@ command-hooks:
     dir: '${docroot}'
     command: null
 simplesamlphp: true
+
 cgov:
   drupal_users_file: '${repo.root}/cgov-drupal-users.yml'
+  front_end_globals_file: '${repo.root}/FrontendGlobals.json'
 
 validate:
   deprecation: false

--- a/hooks/common/post-code-deploy/post-code-deploy.sh
+++ b/hooks/common/post-code-deploy/post-code-deploy.sh
@@ -48,9 +48,6 @@ if [[ $PRESERVE_ON_REDEPLOY == "true" ]]; then
 
   ## Reload translation pack.
   blt cgov:locales:translate --no-interaction -D drush.ansi=false
-
-  ## Setup some default JS globals.
-  cat FrontendGlobals.json | drush config:set cgov_core.frontend_globals config_object -
 else
   ## Clear last install out of Memcache.
   ## Drush CR will not work on a non-existant site. Drush CC will not find the memcached
@@ -68,7 +65,7 @@ else
   blt cgov:locales:translate --no-interaction -D drush.ansi=false
 
   ## Setup some default JS globals.
-  cat FrontendGlobals.json | drush config:set cgov_core.frontend_globals config_object -
+  blt cgov:load-fe-globals --environment=$target_env --no-interaction -D drush.ansi=false
 
   ## Execute a migration.
   case $MIGRATION in

--- a/hooks/common/post-code-update/post-code-update.sh
+++ b/hooks/common/post-code-update/post-code-update.sh
@@ -51,9 +51,6 @@ if [[ $PRESERVE_ON_REDEPLOY == "true" ]]; then
 
   ## Reload translation pack.
   blt cgov:locales:translate --no-interaction -D drush.ansi=false
-
-  ## Setup some default JS globals.
-  cat FrontendGlobals.json | drush config:set cgov_core.frontend_globals config_object -
 else
   ## Clear last install out of Memcache.
   ## Drush CR will not work on a non-existant site. Drush CC will not find the memcached
@@ -71,7 +68,7 @@ else
   blt cgov:locales:translate --no-interaction -D drush.ansi=false
 
   ## Setup some default JS globals.
-  cat FrontendGlobals.json | drush config:set cgov_core.frontend_globals config_object -
+  blt cgov:load-fe-globals --environment=$target_env --no-interaction -D drush.ansi=false
 
   ## Execute a migration.
   case $MIGRATION in


### PR DESCRIPTION
- Created new BLT command to load the front-end globals config. The config path is set in the blt.yml file under `cgov:front_end_globals_file`, but this should not really ever change.
- Added our command to `blt cgov:reinstall` so now that is handled automatically.
- Updated both post-code-update and post-code-deploy to use the new command

>**_NOTE:_** I removed the front-end globals reloading when the $PRESERVE_ON_REDEPOY flag is set to true. This is because these globals act as content, or else they would be packaged as features. So it is not appropriate to reset these configurations on each load from what is in the codebase.
  
Closes #3197