### PR TITLE
(#3275) Fix theme variant sprite path.

### DIFF
--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/variants/blue/styles/sprites/_svg-sprite.scss
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/variants/blue/styles/sprites/_svg-sprite.scss
@@ -1,7 +1,7 @@
 @import "svg-sprite-map";
 
 $sprite-path:(
-  svgPath: '~Core/../cgov_common/dist/images/sprites/svg-sprite-blue.svg'
+  svgPath: '~ImageDist/sprites/svg-sprite-blue.svg'
 );
 
 $svg-sprite: map-merge(map-get($svg-icons, sprite),$sprite-path);

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/variants/connect/styles/sprites/_svg-sprite.scss
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/variants/connect/styles/sprites/_svg-sprite.scss
@@ -1,7 +1,7 @@
 @import "svg-sprite-map";
 
 $sprite-path:(
-  svgPath: '~Core/../cgov_common/dist/images/sprites/svg-sprite-connect.svg'
+  svgPath: '~ImageDist/sprites/svg-sprite-connect.svg'
 );
 
 $svg-sprite: map-merge(map-get($svg-icons, sprite),$sprite-path);

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/variants/green/styles/sprites/_svg-sprite.scss
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/variants/green/styles/sprites/_svg-sprite.scss
@@ -1,7 +1,7 @@
 @import "svg-sprite-map";
 
 $sprite-path:(
-  svgPath: '~Core/../cgov_common/dist/images/sprites/svg-sprite-green.svg'
+  svgPath: '~ImageDist/sprites/svg-sprite-green.svg'
 );
 
 $svg-sprite: map-merge(map-get($svg-icons, sprite),$sprite-path);

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/variants/purple/styles/sprites/_svg-sprite.scss
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/variants/purple/styles/sprites/_svg-sprite.scss
@@ -1,7 +1,7 @@
 @import "svg-sprite-map";
 
 $sprite-path:(
-  svgPath: '~Core/../cgov_common/dist/images/sprites/svg-sprite-purple.svg'
+  svgPath: '~ImageDist/sprites/svg-sprite-purple.svg'
 );
 
 $svg-sprite: map-merge(map-get($svg-icons, sprite),$sprite-path);

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/webpack.config.js
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/webpack.config.js
@@ -12,7 +12,9 @@ const themeConfig = {
       Utilities: path.resolve(__dirname, "..", "src", "utilities"),
       Polyfills: path.resolve(__dirname, "..", "src", "polyfills"),
       Styles: path.resolve(__dirname, "src", "styles"),
-      Libraries: path.resolve(__dirname, "src", "libraries")
+      Libraries: path.resolve(__dirname, "src", "libraries"),
+      // This is used to reference sprites.
+      ImageDist: path.resolve(__dirname, "dist/images"),
     }
   },
   output: {

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/src/styles/sprites/sprite-template.scss
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/src/styles/sprites/sprite-template.scss
@@ -4,7 +4,7 @@ $svg-icons: (
       width: {{spriteWidth}}px,
       height: {{spriteHeight}}px,
       padding: {{padding.top}}px,
-      svgPath: '../../dist/images/sprites/svg-sprite.svg'
+      svgPath: '~ImageDist/sprites/svg-sprite.svg'
   ),
   {{#shapes}}
     {{base}}: (

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/webpack.base.config.js
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/webpack.base.config.js
@@ -32,7 +32,19 @@ const config = {
           {
             loader: MiniCssExtractPlugin.loader
           },
-          "css-loader?url=false",
+          {
+            loader: "css-loader",
+            options: {
+              url: (uri, resourcePath) => {
+                // Ignore absolute paths.
+                if (uri.startsWith('/')) {
+                  return false;
+                }
+
+                return true;
+              }
+            }
+          },
           "postcss-loader",
           "sass-loader"
         ]
@@ -44,8 +56,8 @@ const config = {
             loader: "file-loader",
             options: {
               outputPath: "../images/sprites",
-              name: "[name].[ext]",
-              emitFile: false
+              name: "[name].[ext]?v=[hash]",
+              emitFile: false,
             }
           }
         ]


### PR DESCRIPTION
This fixes an issue in the develop branch where Sprite paths are incorrect for microsite variants.

ODE: http://ncigovcdode451.prod.acquia-sites.com/AH_VIEW

Closes #3275