### PR TITLE
(#3288) Hack to fix legacy links in PDQ

### DIFF
--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/911_cct_chatbot_pages.content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/911_cct_chatbot_pages.content.yml
@@ -1,0 +1,112 @@
+## This is mock content for allowing the CBIIT team to test their CCT chatbot
+## Root URL for Testing (Very long)
+- entity: "node"
+  type: "cgov_article"
+  langcode: en
+  status: 1
+  moderation_state:
+    value: 'published'
+  title: "Funding for Cancer Training"
+  field_browser_title:
+    value: "Funding for Cancer Training"
+  field_page_description:
+    value: "Mock Content for Funding for Cancer Training"
+  field_site_section:
+    - '#process':
+        callback: 'reference'
+        args:
+          - 'taxonomy_term'
+          - vid: 'cgov_site_sections'
+            computed_path: '/grants-training/training/funding'
+  field_article_body:
+    - entity: 'paragraph'
+      type: "body_section"
+      field_body_section_content:
+        - format: "full_html"
+          value: |
+            <div id="lipsum">
+              <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum viverra arcu a lectus rutrum facilisis. Quisque luctus sem a suscipit posuere. Proin bibendum imperdiet nisi, sed commodo libero varius non. Pellentesque magna erat, facilisis quis malesuada quis, ornare convallis felis. Mauris eu mi vitae dolor convallis vulputate. Aenean in ante id nunc blandit porttitor sed in nunc. Vestibulum rhoncus velit nec neque condimentum facilisis. Nulla sagittis placerat mi, vitae varius nunc auctor at. Proin sagittis vestibulum leo et laoreet. Aliquam volutpat arcu quam, eget iaculis odio facilisis ac.</p>
+              <p>Praesent suscipit elementum odio eu sodales. Sed sodales elit in dolor tristique eleifend. Etiam sapien nibh, iaculis nec auctor nec, laoreet in justo. Duis mi sem, mattis in tellus ac, semper aliquet turpis. Pellentesque eu mi a tellus accumsan molestie. Nunc vitae ligula nulla. Quisque ac urna vestibulum, luctus sem eget, molestie neque. Morbi lobortis nibh risus, sed sollicitudin neque consequat eget.</p>
+              <p>Nullam non placerat nisl, vitae pulvinar arcu. Etiam rhoncus justo quis justo sagittis gravida. Donec vehicula vel magna in varius. Vestibulum bibendum non velit non tincidunt. Nam ornare magna magna, vulputate commodo sem pretium ut. Vivamus eu facilisis lorem. Suspendisse sagittis dolor dui, et lobortis mi ornare eget. Ut lacinia eros quis orci luctus, id dictum nulla cursus. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Suspendisse sit amet odio porttitor, tempus diam ut, ultricies dolor. Aenean pellentesque nunc ac nulla semper ornare. Nunc sodales suscipit arcu, quis scelerisque nisl. Cras pharetra erat quam, a lobortis lacus ullamcorper vel. Integer porttitor nisi varius, tristique metus in, posuere ex. In hac habitasse platea dictumst. Phasellus non imperdiet quam.</p>
+              <p>Vivamus eleifend varius sapien, vitae ornare lacus faucibus quis. Quisque efficitur ac elit dignissim tempus. Fusce pulvinar luctus nisl, non egestas eros semper sed. Maecenas rhoncus consequat massa. Curabitur nec egestas purus. Vivamus lorem justo, finibus vitae sem vel, vulputate malesuada dolor. Aenean fringilla tempus est, id tincidunt leo tristique at. Aliquam velit elit, sodales sit amet libero sit amet, fermentum condimentum ipsum. Aenean non finibus mi. Aliquam urna magna, dictum sed elementum eget, molestie vel mi. Pellentesque ultricies vitae enim eget lobortis. Donec eget mattis sem.</p>
+              <p>Morbi et urna vitae erat egestas elementum. Nullam vel semper lectus. Cras ultrices, justo in porttitor blandit, dui nisl finibus nunc, sodales rutrum turpis leo ac nisl. Nunc eget ullamcorper metus. Sed velit enim, eleifend nec vulputate quis, pulvinar in ipsum. Suspendisse ornare a tellus non dignissim. Nullam congue ante in turpis feugiat, ut pharetra magna dignissim. In eleifend laoreet lectus id efficitur. Vestibulum lacus urna, aliquam et rutrum sit amet, suscipit ac diam. Quisque ornare facilisis libero. Nam fermentum dolor et turpis consectetur convallis. Suspendisse sagittis ex metus, at elementum nisi tincidunt commodo.</p>
+              <p>Praesent suscipit elementum odio eu sodales. Sed sodales elit in dolor tristique eleifend. Etiam sapien nibh, iaculis nec auctor nec, laoreet in justo. Duis mi sem, mattis in tellus ac, semper aliquet turpis. Pellentesque eu mi a tellus accumsan molestie. Nunc vitae ligula nulla. Quisque ac urna vestibulum, luctus sem eget, molestie neque. Morbi lobortis nibh risus, sed sollicitudin neque consequat eget.</p>
+              <p>Nullam non placerat nisl, vitae pulvinar arcu. Etiam rhoncus justo quis justo sagittis gravida. Donec vehicula vel magna in varius. Vestibulum bibendum non velit non tincidunt. Nam ornare magna magna, vulputate commodo sem pretium ut. Vivamus eu facilisis lorem. Suspendisse sagittis dolor dui, et lobortis mi ornare eget. Ut lacinia eros quis orci luctus, id dictum nulla cursus. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Suspendisse sit amet odio porttitor, tempus diam ut, ultricies dolor. Aenean pellentesque nunc ac nulla semper ornare. Nunc sodales suscipit arcu, quis scelerisque nisl. Cras pharetra erat quam, a lobortis lacus ullamcorper vel. Integer porttitor nisi varius, tristique metus in, posuere ex. In hac habitasse platea dictumst. Phasellus non imperdiet quam.</p>
+              <p>Vivamus eleifend varius sapien, vitae ornare lacus faucibus quis. Quisque efficitur ac elit dignissim tempus. Fusce pulvinar luctus nisl, non egestas eros semper sed. Maecenas rhoncus consequat massa. Curabitur nec egestas purus. Vivamus lorem justo, finibus vitae sem vel, vulputate malesuada dolor. Aenean fringilla tempus est, id tincidunt leo tristique at. Aliquam velit elit, sodales sit amet libero sit amet, fermentum condimentum ipsum. Aenean non finibus mi. Aliquam urna magna, dictum sed elementum eget, molestie vel mi. Pellentesque ultricies vitae enim eget lobortis. Donec eget mattis sem.</p>
+              <p>Morbi et urna vitae erat egestas elementum. Nullam vel semper lectus. Cras ultrices, justo in porttitor blandit, dui nisl finibus nunc, sodales rutrum turpis leo ac nisl. Nunc eget ullamcorper metus. Sed velit enim, eleifend nec vulputate quis, pulvinar in ipsum. Suspendisse ornare a tellus non dignissim. Nullam congue ante in turpis feugiat, ut pharetra magna dignissim. In eleifend laoreet lectus id efficitur. Vestibulum lacus urna, aliquam et rutrum sit amet, suscipit ac diam. Quisque ornare facilisis libero. Nam fermentum dolor et turpis consectetur convallis. Suspendisse sagittis ex metus, at elementum nisi tincidunt commodo.</p>
+              <p>Praesent suscipit elementum odio eu sodales. Sed sodales elit in dolor tristique eleifend. Etiam sapien nibh, iaculis nec auctor nec, laoreet in justo. Duis mi sem, mattis in tellus ac, semper aliquet turpis. Pellentesque eu mi a tellus accumsan molestie. Nunc vitae ligula nulla. Quisque ac urna vestibulum, luctus sem eget, molestie neque. Morbi lobortis nibh risus, sed sollicitudin neque consequat eget.</p>
+              <p>Nullam non placerat nisl, vitae pulvinar arcu. Etiam rhoncus justo quis justo sagittis gravida. Donec vehicula vel magna in varius. Vestibulum bibendum non velit non tincidunt. Nam ornare magna magna, vulputate commodo sem pretium ut. Vivamus eu facilisis lorem. Suspendisse sagittis dolor dui, et lobortis mi ornare eget. Ut lacinia eros quis orci luctus, id dictum nulla cursus. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Suspendisse sit amet odio porttitor, tempus diam ut, ultricies dolor. Aenean pellentesque nunc ac nulla semper ornare. Nunc sodales suscipit arcu, quis scelerisque nisl. Cras pharetra erat quam, a lobortis lacus ullamcorper vel. Integer porttitor nisi varius, tristique metus in, posuere ex. In hac habitasse platea dictumst. Phasellus non imperdiet quam.</p>
+              <p>Vivamus eleifend varius sapien, vitae ornare lacus faucibus quis. Quisque efficitur ac elit dignissim tempus. Fusce pulvinar luctus nisl, non egestas eros semper sed. Maecenas rhoncus consequat massa. Curabitur nec egestas purus. Vivamus lorem justo, finibus vitae sem vel, vulputate malesuada dolor. Aenean fringilla tempus est, id tincidunt leo tristique at. Aliquam velit elit, sodales sit amet libero sit amet, fermentum condimentum ipsum. Aenean non finibus mi. Aliquam urna magna, dictum sed elementum eget, molestie vel mi. Pellentesque ultricies vitae enim eget lobortis. Donec eget mattis sem.</p>
+              <p>Morbi et urna vitae erat egestas elementum. Nullam vel semper lectus. Cras ultrices, justo in porttitor blandit, dui nisl finibus nunc, sodales rutrum turpis leo ac nisl. Nunc eget ullamcorper metus. Sed velit enim, eleifend nec vulputate quis, pulvinar in ipsum. Suspendisse ornare a tellus non dignissim. Nullam congue ante in turpis feugiat, ut pharetra magna dignissim. In eleifend laoreet lectus id efficitur. Vestibulum lacus urna, aliquam et rutrum sit amet, suscipit ac diam. Quisque ornare facilisis libero. Nam fermentum dolor et turpis consectetur convallis. Suspendisse sagittis ex metus, at elementum nisi tincidunt commodo.</p>
+            </div>
+
+## Sub url for testing (Very long)
+- entity: "node"
+  type: "cgov_article"
+  langcode: en
+  status: 1
+  moderation_state:
+    value: 'published'
+  title: "Mock F30 Content"
+  field_browser_title:
+    value: "Mock F30 Content"
+  field_page_description:
+    value: "Mock content for F30"
+  field_site_section:
+    - '#process':
+        callback: 'reference'
+        args:
+          - 'taxonomy_term'
+          - vid: 'cgov_site_sections'
+            computed_path: '/grants-training/training/funding/f30'
+  field_article_body:
+    - entity: 'paragraph'
+      type: "body_section"
+      field_body_section_content:
+        - format: "full_html"
+          value: |
+            <div id="lipsum">
+              <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum viverra arcu a lectus rutrum facilisis. Quisque luctus sem a suscipit posuere. Proin bibendum imperdiet nisi, sed commodo libero varius non. Pellentesque magna erat, facilisis quis malesuada quis, ornare convallis felis. Mauris eu mi vitae dolor convallis vulputate. Aenean in ante id nunc blandit porttitor sed in nunc. Vestibulum rhoncus velit nec neque condimentum facilisis. Nulla sagittis placerat mi, vitae varius nunc auctor at. Proin sagittis vestibulum leo et laoreet. Aliquam volutpat arcu quam, eget iaculis odio facilisis ac.</p>
+              <p>Praesent suscipit elementum odio eu sodales. Sed sodales elit in dolor tristique eleifend. Etiam sapien nibh, iaculis nec auctor nec, laoreet in justo. Duis mi sem, mattis in tellus ac, semper aliquet turpis. Pellentesque eu mi a tellus accumsan molestie. Nunc vitae ligula nulla. Quisque ac urna vestibulum, luctus sem eget, molestie neque. Morbi lobortis nibh risus, sed sollicitudin neque consequat eget.</p>
+              <p>Nullam non placerat nisl, vitae pulvinar arcu. Etiam rhoncus justo quis justo sagittis gravida. Donec vehicula vel magna in varius. Vestibulum bibendum non velit non tincidunt. Nam ornare magna magna, vulputate commodo sem pretium ut. Vivamus eu facilisis lorem. Suspendisse sagittis dolor dui, et lobortis mi ornare eget. Ut lacinia eros quis orci luctus, id dictum nulla cursus. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Suspendisse sit amet odio porttitor, tempus diam ut, ultricies dolor. Aenean pellentesque nunc ac nulla semper ornare. Nunc sodales suscipit arcu, quis scelerisque nisl. Cras pharetra erat quam, a lobortis lacus ullamcorper vel. Integer porttitor nisi varius, tristique metus in, posuere ex. In hac habitasse platea dictumst. Phasellus non imperdiet quam.</p>
+              <p>Vivamus eleifend varius sapien, vitae ornare lacus faucibus quis. Quisque efficitur ac elit dignissim tempus. Fusce pulvinar luctus nisl, non egestas eros semper sed. Maecenas rhoncus consequat massa. Curabitur nec egestas purus. Vivamus lorem justo, finibus vitae sem vel, vulputate malesuada dolor. Aenean fringilla tempus est, id tincidunt leo tristique at. Aliquam velit elit, sodales sit amet libero sit amet, fermentum condimentum ipsum. Aenean non finibus mi. Aliquam urna magna, dictum sed elementum eget, molestie vel mi. Pellentesque ultricies vitae enim eget lobortis. Donec eget mattis sem.</p>
+              <p>Morbi et urna vitae erat egestas elementum. Nullam vel semper lectus. Cras ultrices, justo in porttitor blandit, dui nisl finibus nunc, sodales rutrum turpis leo ac nisl. Nunc eget ullamcorper metus. Sed velit enim, eleifend nec vulputate quis, pulvinar in ipsum. Suspendisse ornare a tellus non dignissim. Nullam congue ante in turpis feugiat, ut pharetra magna dignissim. In eleifend laoreet lectus id efficitur. Vestibulum lacus urna, aliquam et rutrum sit amet, suscipit ac diam. Quisque ornare facilisis libero. Nam fermentum dolor et turpis consectetur convallis. Suspendisse sagittis ex metus, at elementum nisi tincidunt commodo.</p>
+              <p>Praesent suscipit elementum odio eu sodales. Sed sodales elit in dolor tristique eleifend. Etiam sapien nibh, iaculis nec auctor nec, laoreet in justo. Duis mi sem, mattis in tellus ac, semper aliquet turpis. Pellentesque eu mi a tellus accumsan molestie. Nunc vitae ligula nulla. Quisque ac urna vestibulum, luctus sem eget, molestie neque. Morbi lobortis nibh risus, sed sollicitudin neque consequat eget.</p>
+              <p>Nullam non placerat nisl, vitae pulvinar arcu. Etiam rhoncus justo quis justo sagittis gravida. Donec vehicula vel magna in varius. Vestibulum bibendum non velit non tincidunt. Nam ornare magna magna, vulputate commodo sem pretium ut. Vivamus eu facilisis lorem. Suspendisse sagittis dolor dui, et lobortis mi ornare eget. Ut lacinia eros quis orci luctus, id dictum nulla cursus. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Suspendisse sit amet odio porttitor, tempus diam ut, ultricies dolor. Aenean pellentesque nunc ac nulla semper ornare. Nunc sodales suscipit arcu, quis scelerisque nisl. Cras pharetra erat quam, a lobortis lacus ullamcorper vel. Integer porttitor nisi varius, tristique metus in, posuere ex. In hac habitasse platea dictumst. Phasellus non imperdiet quam.</p>
+              <p>Vivamus eleifend varius sapien, vitae ornare lacus faucibus quis. Quisque efficitur ac elit dignissim tempus. Fusce pulvinar luctus nisl, non egestas eros semper sed. Maecenas rhoncus consequat massa. Curabitur nec egestas purus. Vivamus lorem justo, finibus vitae sem vel, vulputate malesuada dolor. Aenean fringilla tempus est, id tincidunt leo tristique at. Aliquam velit elit, sodales sit amet libero sit amet, fermentum condimentum ipsum. Aenean non finibus mi. Aliquam urna magna, dictum sed elementum eget, molestie vel mi. Pellentesque ultricies vitae enim eget lobortis. Donec eget mattis sem.</p>
+              <p>Morbi et urna vitae erat egestas elementum. Nullam vel semper lectus. Cras ultrices, justo in porttitor blandit, dui nisl finibus nunc, sodales rutrum turpis leo ac nisl. Nunc eget ullamcorper metus. Sed velit enim, eleifend nec vulputate quis, pulvinar in ipsum. Suspendisse ornare a tellus non dignissim. Nullam congue ante in turpis feugiat, ut pharetra magna dignissim. In eleifend laoreet lectus id efficitur. Vestibulum lacus urna, aliquam et rutrum sit amet, suscipit ac diam. Quisque ornare facilisis libero. Nam fermentum dolor et turpis consectetur convallis. Suspendisse sagittis ex metus, at elementum nisi tincidunt commodo.</p>
+              <p>Praesent suscipit elementum odio eu sodales. Sed sodales elit in dolor tristique eleifend. Etiam sapien nibh, iaculis nec auctor nec, laoreet in justo. Duis mi sem, mattis in tellus ac, semper aliquet turpis. Pellentesque eu mi a tellus accumsan molestie. Nunc vitae ligula nulla. Quisque ac urna vestibulum, luctus sem eget, molestie neque. Morbi lobortis nibh risus, sed sollicitudin neque consequat eget.</p>
+              <p>Nullam non placerat nisl, vitae pulvinar arcu. Etiam rhoncus justo quis justo sagittis gravida. Donec vehicula vel magna in varius. Vestibulum bibendum non velit non tincidunt. Nam ornare magna magna, vulputate commodo sem pretium ut. Vivamus eu facilisis lorem. Suspendisse sagittis dolor dui, et lobortis mi ornare eget. Ut lacinia eros quis orci luctus, id dictum nulla cursus. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Suspendisse sit amet odio porttitor, tempus diam ut, ultricies dolor. Aenean pellentesque nunc ac nulla semper ornare. Nunc sodales suscipit arcu, quis scelerisque nisl. Cras pharetra erat quam, a lobortis lacus ullamcorper vel. Integer porttitor nisi varius, tristique metus in, posuere ex. In hac habitasse platea dictumst. Phasellus non imperdiet quam.</p>
+              <p>Vivamus eleifend varius sapien, vitae ornare lacus faucibus quis. Quisque efficitur ac elit dignissim tempus. Fusce pulvinar luctus nisl, non egestas eros semper sed. Maecenas rhoncus consequat massa. Curabitur nec egestas purus. Vivamus lorem justo, finibus vitae sem vel, vulputate malesuada dolor. Aenean fringilla tempus est, id tincidunt leo tristique at. Aliquam velit elit, sodales sit amet libero sit amet, fermentum condimentum ipsum. Aenean non finibus mi. Aliquam urna magna, dictum sed elementum eget, molestie vel mi. Pellentesque ultricies vitae enim eget lobortis. Donec eget mattis sem.</p>
+              <p>Morbi et urna vitae erat egestas elementum. Nullam vel semper lectus. Cras ultrices, justo in porttitor blandit, dui nisl finibus nunc, sodales rutrum turpis leo ac nisl. Nunc eget ullamcorper metus. Sed velit enim, eleifend nec vulputate quis, pulvinar in ipsum. Suspendisse ornare a tellus non dignissim. Nullam congue ante in turpis feugiat, ut pharetra magna dignissim. In eleifend laoreet lectus id efficitur. Vestibulum lacus urna, aliquam et rutrum sit amet, suscipit ac diam. Quisque ornare facilisis libero. Nam fermentum dolor et turpis consectetur convallis. Suspendisse sagittis ex metus, at elementum nisi tincidunt commodo.</p>
+            </div>
+
+## Suburl for testing (Very Short)
+- entity: "node"
+  type: "cgov_article"
+  langcode: en
+  status: 1
+  moderation_state:
+    value: 'published'
+  title: "Mock F31 Content"
+  field_browser_title:
+    value: "Mock F31 Content"
+  field_page_description:
+    value: "Mock content for F31"
+  field_site_section:
+    - '#process':
+        callback: 'reference'
+        args:
+          - 'taxonomy_term'
+          - vid: 'cgov_site_sections'
+            computed_path: '/grants-training/training/funding/f31'
+  field_article_body:
+    - entity: 'paragraph'
+      type: "body_section"
+      field_body_section_content:
+        - format: "full_html"
+          value: |
+            <div id="lipsum">
+              <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum viverra arcu a lectus rutrum facilisis. </p>
+              <p>Quisque luctus sem a suscipit posuere. Proin bibendum imperdiet nisi, sed commodo libero varius non.</p>
+            </div>

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/src/libraries/deepLinkPatch/deepLinkPatch.js
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/src/libraries/deepLinkPatch/deepLinkPatch.js
@@ -50,6 +50,18 @@
    // Requirements changes over the years have only left us with the accordion requirement, so this file
    // is now just tailored to that use case.
 
+   // This is a bugfix for #3288 where some legacy #link/_57 links are still hanging around.
+   const linkRegex = /^([^#]+)#link\/(.*)$/;
+   document.querySelectorAll('a[href*="#link/"]').forEach((link) => {
+     // So yeah. The links are not just anchors, but they may also contain the rest of the URL, event
+     // for linking within the document. :( So this needs to be more complicated.
+     const oldHref = link.getAttribute('href');
+     const matches = oldHref.match(linkRegex);
+     if (matches) {
+       link.setAttribute('href', `${matches[1]}#${matches[2]}`);
+     }
+   });
+
    // When the accordion is drawn, expand either the section or the subsection of that accordion. This
    // will occur on a load, a resize, or clicking the back button.
    window.addEventListener('nci.accordion.create', function (event) {


### PR DESCRIPTION
This fix rewrites (via JS) any #link/_123 style links in content.
This hack should be removed once the PDQ content is no longer publishing anchors in this old format.

ODE: http://ncigovcdode453.prod.acquia-sites.com/AH_VIEW

Closes #3288