### PR TITLE
Add a generator tag to indicate that a 404 response comes from fast 404

### DIFF
--- a/docroot/sites/settings/cgov_fast_404.settings.php
+++ b/docroot/sites/settings/cgov_fast_404.settings.php
@@ -8,4 +8,4 @@
 $config['system.performance']['fast_404']['enabled'] = TRUE;
 $config['system.performance']['fast_404']['paths'] = '/.*/';
 $config['system.performance']['fast_404']['exclude_paths'] = '/\/ErrorPages\/.*/i';
-$config['system.performance']['fast_404']['html'] = '<!DOCTYPE html><html><head><title>404 Not Found</title></head><body><h1>Not Found</h1><p>The requested URL "@path" was not found on this server.</p></body></html>';
+$config['system.performance']['fast_404']['html'] = '<!DOCTYPE html><html><head><title>404 Not Found</title><meta name="Generator" content="CGOV Fast 404" /></head><body><h1>Not Found</h1><p>The requested URL "@path" was not found on this server.</p></body></html>';


### PR DESCRIPTION
Change for #3450 to support https://github.com/NCIOCPL/cgov-digital-platform-maintenance-scripts/issues/1. Simply adds a meta tag for generator to the fast 404 template HTML.

Closes #3450.