### PR TITLE
(#2343) Automated OTP section headings - letters with accents excluded from anchor link

### DIFF
--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/article/field--field-article-body.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/article/field--field-article-body.html.twig
@@ -18,8 +18,9 @@
     <ul>
       {% for item in items %}
         {% if item.content['#paragraph'].field_body_section_heading.value %}
+        {% set field_body_section_heading_eng =  item.content['#paragraph'].field_body_section_heading.value|replace({'Š':'S', 'š':'s', 'Ž':'Z', 'ž':'z', 'À':'A', 'Á':'A', 'Â':'A', 'Ã':'A', 'Ä':'A', 'Å':'A', 'Æ':'A', 'Ç':'C', 'È':'E', 'É':'E','Ê':'E', 'Ë':'E', 'Ì':'I', 'Í':'I', 'Î':'I', 'Ï':'I', 'Ñ':'N', 'Ò':'O', 'Ó':'O', 'Ô':'O', 'Õ':'O', 'Ö':'O', 'Ø':'O', 'Ù':'U','Ú':'U', 'Û':'U', 'Ü':'U', 'Ý':'Y', 'Þ':'B', 'ß':'Ss', 'à':'a', 'á':'a', 'â':'a', 'ã':'a', 'ä':'a', 'å':'a', 'æ':'a', 'ç':'c','è':'e', 'é':'e', 'ê':'e', 'ë':'e', 'ì':'i', 'í':'i', 'î':'i', 'ï':'i', 'ð':'o', 'ñ':'n', 'ò':'o', 'ó':'o', 'ô':'o', 'õ':'o','ö':'o', 'ø':'o', 'ù':'u', 'ú':'u', 'û':'u', 'ý':'y', 'þ':'b', 'ÿ':'y' }) %}
         <li>
-          <a href="#{{ item.content['#paragraph'].field_body_section_heading.value | striptags | clean_id }}">
+          <a href="#{{ field_body_section_heading_eng | striptags | clean_id }}">
             {# We have to apply the raw filter in order to render what is a simple format field as actual markup #}
             {{- item.content['#paragraph'].field_body_section_heading.value|raw -}}</a>
         </li>

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/article/paragraph--body-section.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/article/paragraph--body-section.html.twig
@@ -8,13 +8,15 @@
  * nav displays - based on the wrapping container.
  */
 #}
+{% set field_body_section_heading_eng =  content.field_body_section_heading['#items'][0].value|replace({'Š':'S', 'š':'s', 'Ž':'Z', 'ž':'z', 'À':'A', 'Á':'A', 'Â':'A', 'Ã':'A', 'Ä':'A', 'Å':'A', 'Æ':'A', 'Ç':'C', 'È':'E', 'É':'E','Ê':'E', 'Ë':'E', 'Ì':'I', 'Í':'I', 'Î':'I', 'Ï':'I', 'Ñ':'N', 'Ò':'O', 'Ó':'O', 'Ô':'O', 'Õ':'O', 'Ö':'O', 'Ø':'O', 'Ù':'U','Ú':'U', 'Û':'U', 'Ü':'U', 'Ý':'Y', 'Þ':'B', 'ß':'Ss', 'à':'a', 'á':'a', 'â':'a', 'ã':'a', 'ä':'a', 'å':'a', 'æ':'a', 'ç':'c','è':'e', 'é':'e', 'ê':'e', 'ë':'e', 'ì':'i', 'í':'i', 'î':'i', 'ï':'i', 'ð':'o', 'ñ':'n', 'ò':'o', 'ó':'o', 'ô':'o', 'õ':'o','ö':'o', 'ø':'o', 'ù':'u', 'ú':'u', 'û':'u', 'ý':'y', 'þ':'b', 'ÿ':'y' })%}
+
 {% if content.field_body_section_heading['#items'].getValue() %}
   {# TODO: Determine how to deal with headings that are H3s #}
   {# Set the id to a clean version of the section heading for OTP links. #}
   {% if schema_org_type %}
-    <h2 id="{{ content.field_body_section_heading['#items'][0].value | striptags | clean_id }}" itemprop="name">
+    <h2 id="{{ field_body_section_heading_eng | striptags | clean_id }}" itemprop="name">
   {% else %}
-    <h2 id="{{ content.field_body_section_heading['#items'][0].value | striptags | clean_id }}">
+    <h2 id="{{ field_body_section_heading_eng | striptags | clean_id }}">
   {% endif %}
     {{- content.field_body_section_heading -}}
   </h2>


### PR DESCRIPTION
 - Replaced the new anchor link characters with accent marks with their english character equivalent