### PR TITLE
(#3398) Enable virus scanning for uploads

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,7 @@
         "drupal/address": "1.11.0",
         "drupal/admin_toolbar": "^3.0.3",
         "drupal/akamai": "3.x-dev@dev",
+        "drupal/clamav": "^2.0",
         "drupal/config_perms": "^2",
         "drupal/console": "^1.9.7",
         "drupal/core": "~9.4.7",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d6850a8cc706aa10a10432ba6334587e",
+    "content-hash": "0fc9aa225850f04194d6c7df19d7cb2f",
     "packages": [
         {
             "name": "acquia/acsf-tools",
@@ -4944,6 +4944,62 @@
             ],
             "support": {
                 "source": "https://git.drupalcode.org/project/akamai"
+            }
+        },
+        {
+            "name": "drupal/clamav",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/clamav.git",
+                "reference": "2.0.1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/clamav-2.0.1.zip",
+                "reference": "2.0.1",
+                "shasum": "e35f8240c3240b2dba20b49a321c89577f6d0719"
+            },
+            "require": {
+                "drupal/core": "^8 || ^9 || ^10"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "2.0.1",
+                    "datestamp": "1669299091",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "adammalone",
+                    "homepage": "https://www.drupal.org/user/1295980"
+                },
+                {
+                    "name": "James Andres",
+                    "homepage": "https://www.drupal.org/user/33827"
+                },
+                {
+                    "name": "manarth",
+                    "homepage": "https://www.drupal.org/user/321496"
+                },
+                {
+                    "name": "mcdruid",
+                    "homepage": "https://www.drupal.org/user/255969"
+                }
+            ],
+            "description": "Integration with the ClamAV anti-virus scanner.",
+            "homepage": "https://www.drupal.org/project/clamav",
+            "support": {
+                "source": "https://git.drupalcode.org/project/clamav"
             }
         },
         {
@@ -20461,5 +20517,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.2.0"
 }

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -60,12 +60,16 @@ RUN DEBIAN_FRONTEND=noninteractive \
   php7.4-xml \
   mysql-client-5.7 \
   git \
+  clamav \
   imagemagick \
   vim \
   zip \
   autoconf libtool m4 pkg-config nasm \
   libpng-dev \
   chromium-chromedriver
+
+# Update ClamAV
+RUN freshclam
 
 # Copy up the available sites config. The startup script
 # manipulates this file based on env vars.

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.info.yml
@@ -4,6 +4,7 @@ package: 'CGov Digital Platform'
 description: 'CGov Core Components (used by the CGov Site install profile)'
 core_version_requirement: '^8.9 || ^9'
 dependencies:
+  - 'clamav:clamav'
   - 'config_perms:config_perms'
   - 'drupal:block'
   - 'drupal:block_content'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/config/install/clamav.settings.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/config/install/clamav.settings.yml
@@ -1,0 +1,13 @@
+enabled: true
+outage_action: 1
+overridden_schemes: {  }
+scan_mode: 1
+verbosity: 0
+mode_executable:
+  executable_path: /usr/bin/clamscan
+  executable_parameters: ''
+mode_daemon_tcpip:
+  hostname: localhost
+  port: 3310
+mode_daemon_unixsocket:
+  unixsocket: /var/clamav/clamd


### PR DESCRIPTION
- Add clam AV to dockerfile
- Install and enable ClamAV drupal module
- Configure ClamAV module to point to executable
- Set outage action to allow
- Removed clamav settings from features yml file

Closes https://github.com/NCIOCPL/cgov-digital-platform/issues/3398

See https://github.com/NCIOCPL/cgov-digital-platform/pull/3476 for previous notes