### PR TITLE
Bugfixes: safari print, focus rings and analytics

### DIFF
--- a/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/front-end/src/entrypoints/global/ncids-common.scss
+++ b/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/front-end/src/entrypoints/global/ncids-common.scss
@@ -21,6 +21,7 @@
 @import 'uswds/dist/scss/base/accessibility'; // header
 @import 'uswds/dist/scss/elements/typography/content'; // usa-prose, usa-intro(lede/lead)
 @import 'uswds/dist/scss/components/icon'; // page options icon sizes
+@import '@nciocpl/ncids-css/scss/utilities/no-print'; //print styling
 
 // The specific Component imports. Nothing in this list SHOULD reference
 // NCIDS or USWDS. It should come from ../../lib/components.

--- a/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/front-end/src/entrypoints/home-landing/home-landing-legacy.scss
+++ b/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/front-end/src/entrypoints/home-landing/home-landing-legacy.scss
@@ -2,24 +2,24 @@
 // file should generate markup.
 @import '../cgdp-required.scss';
 
-@import "~Core/styles/environments/percussion";
-@import "../../legacy/styles/variables";
-@import "~Core/styles/mixins";
+@import '~Core/styles/environments/percussion';
+@import '../../legacy/styles/variables';
+@import '~Core/styles/mixins';
 @import '../../legacy/styles/breakpoint-mixins';
-@import "~Core/styles/placeholders";
-@import "~Styles/sprites/svg-sprite";
-@import "~Core/styles/nci-foundation_mixins";
-@import "../../legacy/styles/nci-foundation_variables";
-@import "~Core/styles/thumbnailcards";
-@import "../../legacy/styles/hero";
-@import "~Core/styles/cards";
+@import '~Core/styles/placeholders';
+@import '~Styles/sprites/svg-sprite';
+@import '~Core/styles/nci-foundation_mixins';
+@import '../../legacy/styles/nci-foundation_variables';
+@import '~Core/styles/thumbnailcards';
+@import '../../legacy/styles/hero';
+@import '~Core/styles/cards';
 
 // We need to make sure that foundation does not generate any markup that would
 // be in Common.scss. This is for borderless cards.
 $include-html-classes: false;
 $include-html-button-classes: false;
-@import "~Core/styles/vendor/foundation/scss/foundation/components/global";
-@import "~Core/styles/vendor/foundation/scss/foundation/components/buttons";
+@import '~Core/styles/vendor/foundation/scss/foundation/components/global';
+@import '~Core/styles/vendor/foundation/scss/foundation/components/buttons';
 
 @import '~Core/styles/borderless-cards';
 @import '~Core/styles/alternating-lists';
@@ -31,322 +31,338 @@ $include-html-button-classes: false;
 // Cancer" for an example.
 // This came from the old common.scss
 @include bp(small) {
-  .guide-title h2 {
-    display: none;
-  }
+	.guide-title h2 {
+		display: none;
+	}
 }
 
 // This was moved in from common.scss.
 // This seems to be for the homepage carousel.
 // TODO: Move to home/landing?
-@import "~Core/libraries/carousel/carousel";
+@import '~Core/libraries/carousel/carousel';
 
 /********************* BEGIN Home Page Styles ******************************************/
 h1 {
-  margin-top: .58em;
+	margin-top: 0.58em;
 }
 
 // overriding default spacing for p tags for the home/landing pages
 // The top margin for the p-tag causes extra spacing above the carousel
 // and has been excluded from this rule (VE, WCMSFEQ-390)
 p:not(.site-name):not(.site-link) {
-  margin: 0.5em 0;
+	margin: 0.5em 0;
 }
 
 .ui-accordion .ui-accordion-header,
 .ui-accordion div.ui-accordion-content {
-  margin-left: -32px;
-  margin-right: -32px;
+	margin-left: -32px;
+	margin-right: -32px;
 }
 
 .ui-accordion div.ui-accordion-content {
-  padding: 10px 10px 10px 21px;
+	padding: 10px 10px 10px 21px;
 }
 /* BEGIN FEATURE AND SECONDARY PRIMARY CARDS ROW */
 .feature-primary .rawHtml,
 .feature-primary .rawHtml .featured-text {
-  height: 100%;
+	height: 100%;
 }
 .feature-primary {
-  margin-bottom: 1em;
+	margin-bottom: 1em;
 
-  a {
-    &,
-    h3 {
-      color: $white;
-    }
-  }
-  h3 {
-    font-weight: normal;
-    color: $white;
-    font-size: 1.375em;
-    line-height: 1.272;
-  }
-  p {
-    margin-bottom: 0;
-    font-size: em-calc(18px);
-    line-height: 1.167em;
-  }
-  .card {
-    background: $dteal;
-  }
-  .featured-text {
-    // featured-text is used for the funding opportunities box
-    padding: 15px;
-    background: $white;
-    color: $color-link !important;
-    // this is needed to overcome padding that was put in cards anchor tag
-    a {
-      padding: 0 !important; //needed to overcome specificity
-      color: $color-link;
-      @extend %card-link-hover;
-    }
-    h3 {
-      color: $header-font-color;
-    }
-    p {
-      margin-top: 1em;
-      margin-bottom: 0.5em;
-    }
-  }
-  @include card-clickable;
+	a {
+		&,
+		h3 {
+			color: $white;
+		}
+		// focus ring is handled on slot-item below
+		&:focus {
+			outline: none;
+		}
+	}
+	.slot-item:focus-within {
+		outline: 2px solid black;
+		outline-offset: -2px;
+	}
+	.icon-exit-notification:focus-within {
+		outline: 2px solid black;
+		outline-offset: -2px;
+	}
+	h3 {
+		font-weight: normal;
+		color: $white;
+		font-size: 1.375em;
+		line-height: 1.272;
+	}
+	p {
+		margin-bottom: 0;
+		font-size: em-calc(18px);
+		line-height: 1.167em;
+	}
+	.card {
+		background: $dteal;
+	}
+	.featured-text {
+		// featured-text is used for the funding opportunities box
+		padding: 15px;
+		background: $white;
+		color: $color-link !important;
+		// this is needed to overcome padding that was put in cards anchor tag
+		a {
+			padding: 0 !important; //needed to overcome specificity
+			color: $color-link;
+			@extend %card-link-hover;
+		}
+		h3 {
+			color: $header-font-color;
+		}
+		p {
+			margin-top: 1em;
+			margin-bottom: 0.5em;
+		}
+	}
+	@include card-clickable;
 }
 
 @include bp(medium-down) {
-  .feature-primary-title {
-    background: $dteal;
-  }
-  /* fix for white space appearing on feature card row in tablet view mtn 6-22-17 */
-  .row.feature-primary {
-    max-width: 64.5em;
-    background: $dteal;
-  }
-  .feature-primary-title h3 {
-    font-size: 1.375em;
-    color: white;
-    padding: 0.625em 30px;
-    margin: 0em;
-  }
+	.feature-primary-title {
+		background: $dteal;
+	}
+	/* fix for white space appearing on feature card row in tablet view mtn 6-22-17 */
+	.row.feature-primary {
+		max-width: 64.5em;
+		background: $dteal;
+	}
+	.feature-primary-title h3 {
+		font-size: 1.375em;
+		color: white;
+		padding: 0.625em 30px;
+		margin: 0em;
+	}
 }
 @include bp(large-up) {
-  .feature-primary a:hover h3 {
-    color: white;
-  }
-  .feature-primary-title {
-    display: none;
-  }
+	.feature-primary a:hover h3 {
+		color: white;
+	}
+	.feature-primary-title {
+		display: none;
+	}
+	.feature-primary .slot-item:focus-within {
+		outline: 2px solid black;
+		outline-offset: 5px;
+	}
 }
 
 .feature-secondary {
-  margin-bottom: 1em;
+	margin-bottom: 1em;
 
-  .card {
-    background: $white;
-  }
-  h3 {
-    font-size: 1.375em;
-    line-height: 1.272;
-  }
-  a {
-    h3 {
-      font-weight: normal;
-      color: $color-link;
-    }
-    &:hover,
-    &:focus {
-      h3 {
-        color: $lcranberry;
-      }
-    }
-    @extend %card-link-hover;
-  }
-  p {
-    margin-bottom: 0;
-    color: $body-font-color;
-    font-size: em-calc(18px);
-    line-height: 1.167em;
-  }
-  @include card-clickable;
+	.card {
+		background: $white;
+	}
+	h3 {
+		font-size: 1.375em;
+		line-height: 1.272;
+	}
+	a {
+		h3 {
+			font-weight: normal;
+			color: $color-link;
+		}
+		&:hover,
+		&:focus {
+			h3 {
+				color: $lcranberry;
+			}
+		}
+		@extend %card-link-hover;
+	}
+	p {
+		margin-bottom: 0;
+		color: $body-font-color;
+		font-size: em-calc(18px);
+		line-height: 1.167em;
+	}
+	@include card-clickable;
 }
 
 @include bp(small) {
-  .feature-primary {
-    margin-bottom: 0;
-  }
-  .feature-primary .card {
-    background: $dteal;
-  }
-  .feature-primary .columns a,
-  .feature-secondary .columns a {
-    padding-bottom: 15px;
-    padding-top: 15px;
-    overflow: auto;
-  }
-  .feature-primary .image-hover,
-  .feature-secondary .image-hover {
-    float: left;
-    width: 30%;
-  }
-  .feature-primary h3,
-  .feature-secondary h3 {
-    margin-top: 0;
-    float: right;
-    width: 70%;
-    font-size: 1.13em;
-    line-height: 1.111em;
-  }
+	.feature-primary {
+		margin-bottom: 0;
+	}
+	.feature-primary .card {
+		background: $dteal;
+	}
+	.feature-primary .columns a,
+	.feature-secondary .columns a {
+		padding-bottom: 15px;
+		padding-top: 15px;
+		overflow: auto;
+	}
+	.feature-primary .image-hover,
+	.feature-secondary .image-hover {
+		float: left;
+		width: 30%;
+	}
+	.feature-primary h3,
+	.feature-secondary h3 {
+		margin-top: 0;
+		float: right;
+		width: 70%;
+		font-size: 1.13em;
+		line-height: 1.111em;
+	}
 
-  .feature-primary a:hover h3,
-  .feature-primary a:hover h3 {
-    color: white;
-  }
-  .feature-primary p,
-  .feature-secondary p,
-  .card-thumbnail img {
-    display: none;
-  }
-  /* the portal pages needed these items to not hit the edge of screen on mobile only */
-  .feature-primary h3,
-  .feature-primary p,
-  .feature-secondary h3,
-  .feature-secondary p,
-  .other-sites-carousel h3,
-  .row.card-thumbnail h4,
-  .row.card-thumbnail h3,
-  .row.card-thumbnail p {
-    padding-left: 15px;
-  }
-  .feature-primary .featured-text {
-    display: none;
-  }
+	.feature-primary a:hover h3,
+	.feature-primary a:hover h3 {
+		color: white;
+	}
+	.feature-primary p,
+	.feature-secondary p,
+	.card-thumbnail img {
+		display: none;
+	}
+	/* the portal pages needed these items to not hit the edge of screen on mobile only */
+	.feature-primary h3,
+	.feature-primary p,
+	.feature-secondary h3,
+	.feature-secondary p,
+	.other-sites-carousel h3,
+	.row.card-thumbnail h4,
+	.row.card-thumbnail h3,
+	.row.card-thumbnail p {
+		padding-left: 15px;
+	}
+	.feature-primary .featured-text {
+		display: none;
+	}
 }
 /* END FEATURE AND SECONDARY PRIMARY CARDS ROW */
 
 /* BEGIN SLOTTED AND INLINE FEATURE CARDS */
 
-@import "~Core/styles/topicFeature";
+@import '~Core/styles/topicFeature';
 
 .blog-feature {
-  a {
-    &:hover,
-    &:focus {
-      h3 {
-        color: $lcranberry;
-      }
-    }
-  }
+	a {
+		&:hover,
+		&:focus {
+			h3 {
+				color: $lcranberry;
+			}
+		}
+	}
 }
 /* END SLOTTED AND INLINE FEATURE CARDS */
 
 /* BEGIN GUIDE CARDS ROW */
 .guide-card {
-  margin-bottom: 1em;
-  .card {
-    padding: em-calc(38px 32px);
+	margin-bottom: 1em;
+	.card {
+		padding: em-calc(38px 32px);
 
-    ul {
-      margin-bottom: 0;
-    }
-    h2 {
-      margin-top: 0;
-      font-size: 1.5em;
-    }
-    a {
-      font-size: em-calc(18px);
-      line-height: em-calc(22px, 18px);
-    }
-    li {
-      margin-top: 0.25em;
-      margin-bottom: 0.25em;
-    }
+		ul {
+			margin-bottom: 0;
+		}
+		h2 {
+			margin-top: 0;
+			font-size: 1.5em;
+		}
+		a {
+			font-size: em-calc(18px);
+			line-height: em-calc(22px, 18px);
+		}
+		li {
+			margin-top: 0.25em;
+			margin-bottom: 0.25em;
+		}
 
-    ul.cancer-types li {
-      background: none;
-      float: left;
-      width: 2.5em;
-      padding-right: 0;
-      margin: 0;
+		ul.cancer-types li {
+			background: none;
+			float: left;
+			width: 2.5em;
+			padding-right: 0;
+			margin: 0;
 
-      a {
-        @extend %card-link-hover;
-      }
-      a,
-      span {
-        line-height: 2.046; // line height needs to be 45px
-        font-size: 22px; // for browsers that don't know 'rem'
-        font-size: 1.375rem;
-      }
-    }
-    // this was done because the columns were becoming too narrow in tablet and had to stack before they reached mobile.
-    @include bp("(max-width: 765px)") {
-      width: 100%;
-    }
-  }
+			a {
+				@extend %card-link-hover;
+			}
+			a,
+			span {
+				line-height: 2.046; // line height needs to be 45px
+				font-size: 22px; // for browsers that don't know 'rem'
+				font-size: 1.375rem;
+			}
+		}
+		// this was done because the columns were becoming too narrow in tablet and had to stack before they reached mobile.
+		@include bp('(max-width: 765px)') {
+			width: 100%;
+		}
+	}
 }
 @include bp(small) {
-  .guide-card {
-    margin-bottom: 0;
-    margin-top: 0;
-    padding: 0;
+	.guide-card {
+		margin-bottom: 0;
+		margin-top: 0;
+		padding: 0;
 
-    .card {
-      background: #1d5e86;
-      padding-top: 0;
-      padding-bottom: 0;
-      margin: 0;
+		.card {
+			background: #1d5e86;
+			padding-top: 0;
+			padding-bottom: 0;
+			margin: 0;
 
-      h2 {
-        line-height: 1.111em;
-        font-size: 1.125em;
-      }
-    }
-  }
+			h2 {
+				line-height: 1.111em;
+				font-size: 1.125em;
+			}
+		}
+	}
 }
 
-@import "~Core/styles/arrowLinks";
+@import '~Core/styles/arrowLinks';
 
 a.learn-more {
-  margin-top: 1em;
-  /* adding padding per #OCECREATIV-783 --sjc */
+	margin-top: 1em;
+	/* adding padding per #OCECREATIV-783 --sjc */
 }
 
 /* Class previously used to target homepage only with blue tint on 'Resources for' */
 .guide-card--home {
-  .card {
-    display: flex;
-    flex-direction: column;
-  }
-  ul {
-    margin-bottom: 0;
-    display: flex;
-    flex-direction: column;
-    flex-grow: 1;
-    justify-content: flex-start;
+	.card {
+		display: flex;
+		flex-direction: column;
+	}
+	ul {
+		margin-bottom: 0;
+		display: flex;
+		flex-direction: column;
+		flex-grow: 1;
+		justify-content: flex-start;
 
-    .card__view-more {
-      /* targets last li to separate list from 'learn/view more' links  */
+		.card__view-more {
+			/* targets last li to separate list from 'learn/view more' links  */
 
-      padding: 3em 0 0.5em;
-      margin-bottom: 0;
+			padding: 3em 0 0.5em;
+			margin-bottom: 0;
 
-      a.arrow-link {
-        /* targets last li item and adds dk blue chevron */
-        &::before {
-          @include svg-sprite(chevron-circle-dk-blue, $rotate: right);
-        }
-        &:hover::before {
-          @include svg-sprite(chevron-circle-red, $rotate: right);
-        }
-      }
-      @include break(medium) {
-        padding: 2em 0 0;
-        margin-top: auto; /* align links to bottom */
-      }
-      @include break(tablet-ls) {
-        margin-top: auto;
-      }
-    }
-  }
+			a.arrow-link {
+				/* targets last li item and adds dk blue chevron */
+				&::before {
+					@include svg-sprite(chevron-circle-dk-blue, $rotate: right);
+				}
+				&:hover::before {
+					@include svg-sprite(chevron-circle-red, $rotate: right);
+				}
+			}
+			@include break(medium) {
+				padding: 2em 0 0;
+				margin-top: auto; /* align links to bottom */
+			}
+			@include break(tablet-ls) {
+				margin-top: auto;
+			}
+		}
+	}
 }
 
 /* Upon resizing the browser window up from the mobile (accordion) view,
@@ -354,11 +370,11 @@ a div with a clearfix class is added that wraps around the ul of each card.
 A height of 100% is added to force this clearfix div to be same height as
 parent accordion in all breakpoints. */
 .guide-card--home .clearfix {
-  flex-grow: 1;
-  height: 100%; /* forces entire clearfix div to be 100%  */
-  ul {
-    height: 100%; /* forces ul to be same height as parent clearfix inserted by jquery-ui accordion  */
-  }
+	flex-grow: 1;
+	height: 100%; /* forces entire clearfix div to be 100%  */
+	ul {
+		height: 100%; /* forces ul to be same height as parent clearfix inserted by jquery-ui accordion  */
+	}
 }
 /* END GUIDE CARDS ROW */
 
@@ -370,336 +386,335 @@ parent accordion in all breakpoints. */
 .nvcgSlBodyLayout > div:last-of-type .multimedia-slot:last-child,
 .nvcgSlBodyLayout > div:last-of-type .guide-card //targets same issue on nci connect guide card row
 {
-  margin-bottom: 0;
+	margin-bottom: 0;
 }
-
 
 .multimedia-slot {
-  background: #099;
-  margin-bottom: 1em;
-  padding: 1em 0;
+	background: #099;
+	margin-bottom: 1em;
+	padding: 1em 0;
 
-  a {
-    &:hover,
-    &:focus {
-      h3 {
-        color: $lcranberry;
-      }
-    }
-  }
-  .feature-card {
-    background: $white;
-    padding-bottom: 1em;
+	a {
+		&:hover,
+		&:focus {
+			h3 {
+				color: $lcranberry;
+			}
+		}
+	}
+	.feature-card {
+		background: $white;
+		padding-bottom: 1em;
 
-    h3,
-    p,
-    ul {
-      padding: 0 15px;
-    }
-    h3 {
-      font-size: 1.375em;
-      font-weight: normal;
-      line-height: 1.272;
-      color: $color-link;
-    }
+		h3,
+		p,
+		ul {
+			padding: 0 15px;
+		}
+		h3 {
+			font-size: 1.375em;
+			font-weight: normal;
+			line-height: 1.272;
+			color: $color-link;
+		}
 
-    @extend %card-link-hover;
-  }
+		@extend %card-link-hover;
+	}
 }
 @include bp(small) {
-  .multimedia-slot {
-    p,
-    ul {
-      display: none;
-    }
-    .equalheight {
-      .slot-item {
-        margin-right: 15px;
-      }
-      &:last-child .slot-item {
-        margin-right: 0;
-      }
-    }
-  }
+	.multimedia-slot {
+		p,
+		ul {
+			display: none;
+		}
+		.equalheight {
+			.slot-item {
+				margin-right: 15px;
+			}
+			&:last-child .slot-item {
+				margin-right: 0;
+			}
+		}
+	}
 }
 @include bp(medium-down) {
-  .multimedia-slot {
-    padding: 1em;
-  }
+	.multimedia-slot {
+		padding: 1em;
+	}
 }
 
 @include bp(large-up) {
-  /* equal height cards for desktop, visually push a div to the bottom of it's container */
-  .equalheight {
-    overflow: hidden;
-  }
-  .equalheight .push-to-bottom-desktop {
-    height: 100%;
-  }
+	/* equal height cards for desktop, visually push a div to the bottom of it's container */
+	.equalheight {
+		overflow: hidden;
+	}
+	.equalheight .push-to-bottom-desktop {
+		height: 100%;
+	}
 
-  // Pushing the last element to the bottom of the card using margin-top: auto in a flex container
-  // had a bug in Firefox only when overflow was hidden. This fixes it.
-  .guide-card--home {
-    .equalheight {
-      overflow: inherit;
-    }
-  }
+	// Pushing the last element to the bottom of the card using margin-top: auto in a flex container
+	// had a bug in Firefox only when overflow was hidden. This fixes it.
+	.guide-card--home {
+		.equalheight {
+			overflow: inherit;
+		}
+	}
 }
 
 .multimedia {
-  .card {
-    background: none;
-    opacity: 1;
-    padding-left: 0;
+	.card {
+		background: none;
+		opacity: 1;
+		padding-left: 0;
 
-    a {
-      color: $body-font-color;
-    }
-    &:hover {
-      h3 {
-        color: $lcranberry;
-      }
-    }
-  }
+		a {
+			color: $body-font-color;
+		}
+		&:hover {
+			h3 {
+				color: $lcranberry;
+			}
+		}
+	}
 
-  // The last of the feature guide cards needs to right align to the edge of the container, mirroring the
-  // left side.
-  .card:last-of-type {
-    padding-right: 0;
-  }
+	// The last of the feature guide cards needs to right align to the edge of the container, mirroring the
+	// left side.
+	.card:last-of-type {
+		padding-right: 0;
+	}
 
-  h3 a {
-    @extend %card-link-hover;
-  }
+	h3 a {
+		@extend %card-link-hover;
+	}
 }
 
 @include bp(medium-down) {
-  /* Multimedia row does need padding in tablet */
-  .multimedia h3,
-  .multimedia p {
-    padding-left: 15px;
-  }
+	/* Multimedia row does need padding in tablet */
+	.multimedia h3,
+	.multimedia p {
+		padding-left: 15px;
+	}
 }
 
 .multimedia-feature-card {
-  background: $white;
-  padding-bottom: 1em;
-  position: relative;
+	background: $white;
+	padding-bottom: 1em;
+	position: relative;
 
-  a {
-    color: $body-font-color;
+	a {
+		color: $body-font-color;
 
-    &:before {
-      @include call-to-action-corner();
-    }
-  }
-  h3 {
-    font-size: 1.375em;
-    font-weight: normal;
-    line-height: 1.272;
-    color: $color-link;
-  }
-  h3,
-  p,
-  ul {
-    padding: 0 15px;
-  }
+		&:before {
+			@include call-to-action-corner();
+		}
+	}
+	h3 {
+		font-size: 1.375em;
+		font-weight: normal;
+		line-height: 1.272;
+		color: $color-link;
+	}
+	h3,
+	p,
+	ul {
+		padding: 0 15px;
+	}
 
-  &.cgvInfographic.non-playable {
-    a:before {
-      content: "Infographic";
-      html[lang="es"] & {
-        content: "Infograf\00ed a";
-      }
-    }
-  }
-  &.gloVideo.non-playable {
-    a:before {
-      content: "Video";
-      html[lang="es"] & {
-        content: "Video";
-      }
-    }
-  }
+	&.cgvInfographic.non-playable {
+		a:before {
+			content: 'Infographic';
+			html[lang='es'] & {
+				content: 'Infograf\00ed a';
+			}
+		}
+	}
+	&.gloVideo.non-playable {
+		a:before {
+			content: 'Video';
+			html[lang='es'] & {
+				content: 'Video';
+			}
+		}
+	}
 
-  &.gloVideoCarousel.non-playable {
-    a:before {
-      content: "Video Playlist";
-      html[lang="es"] & {
-        content: "Lista de reproducci\00f3 n de videos";
-      }
-    }
-  }
-  &.non-playable {
-    a.mm-additional-info:before {
-      content: none;
-      html[lang="es"] & {
-        content: none;
-      }
-    }
-  }
+	&.gloVideoCarousel.non-playable {
+		a:before {
+			content: 'Video Playlist';
+			html[lang='es'] & {
+				content: 'Lista de reproducci\00f3 n de videos';
+			}
+		}
+	}
+	&.non-playable {
+		a.mm-additional-info:before {
+			content: none;
+			html[lang='es'] & {
+				content: none;
+			}
+		}
+	}
 }
 @include bp(small) {
-  .multimedia-feature-card h3,
-  .multimedia-slot .feature-card h3 {
-    font-size: 1em;
-    line-height: 1.125em;
-    word-wrap: break-word;
-  }
+	.multimedia-feature-card h3,
+	.multimedia-slot .feature-card h3 {
+		font-size: 1em;
+		line-height: 1.125em;
+		word-wrap: break-word;
+	}
 }
 // these rules are to fix the autoheight problems in multimedia row
 %autoheight-fix {
-  height: 100%;
+	height: 100%;
 }
 .multimedia-feature-card,
 .multimedia .feature-card {
-  //@extend %autoheight-fix;
-  a {
-    display: block;
-    //height: 100%;
-  }
+	//@extend %autoheight-fix;
+	a {
+		display: block;
+		//height: 100%;
+	}
 }
 
 .card > .slot-item {
-  @extend %autoheight-fix;
+	@extend %autoheight-fix;
 }
 .multimedia-slot .equalheight .slot-item {
-  background-color: $white;
+	background-color: $white;
 }
 /* END MULIMEDIA ROW */
 
 /* BEGIN Director's Row */
 
 .directors-row {
-  h3 {
-    color: $white;
-  }
+	h3 {
+		color: $white;
+	}
 }
 .infographic {
-  position: relative;
-  /* allows for appearance of equal height cards on home page */
-  background: $white;
-  figcaption {
-    padding: 0.5em 1em;
-  }
+	position: relative;
+	/* allows for appearance of equal height cards on home page */
+	background: $white;
+	figcaption {
+		padding: 0.5em 1em;
+	}
 }
 .infographic-enlarge {
-  position: absolute;
-  top: 0;
-  right: 0;
-  color: $white;
+	position: absolute;
+	top: 0;
+	right: 0;
+	color: $white;
 
-  a {
-    position: relative;
-    color: $white;
-    padding: 1em 2em 1em 1em;
-    display: block;
-    /* TODO: add this image to the sprite */
-    background-color: #403f3f;
-    @extend %card-link-hover;
+	a {
+		position: relative;
+		color: $white;
+		padding: 1em 2em 1em 1em;
+		display: block;
+		/* TODO: add this image to the sprite */
+		background-color: #403f3f;
+		@extend %card-link-hover;
 
-    &::before {
-      @include svg-sprite(chevron-white);
-      content: "";
-      position: absolute;
-      top: 50%;
-      right: 0.6em;
-      transform: translateY(-50%) rotate(90deg);
-    }
-  }
+		&::before {
+			@include svg-sprite(chevron-white);
+			content: '';
+			position: absolute;
+			top: 50%;
+			right: 0.6em;
+			transform: translateY(-50%) rotate(90deg);
+		}
+	}
 }
 .home-director-stories {
-  background: $white;
-  padding: 0.5em 1em 0.2em;
-  margin-top: -10px;
+	background: $white;
+	padding: 0.5em 1em 0.2em;
+	margin-top: -10px;
 }
 @include bp(medium-down) {
-  .home-director-stories,
-  .infographic {
-    background: none;
-  }
+	.home-director-stories,
+	.infographic {
+		background: none;
+	}
 }
 /* END Director's Row */
 // adding a position relative to feature card images so exit disclaimer notification icon can be positioned to its bottom right
 .feature-card {
-  .image-hover {
-    position: relative;
-  }
+	.image-hover {
+		position: relative;
+	}
 }
 
 /* News & events Item list */
 .press-releases-list {
-  .list-item {
-    margin: 2.5em 0;
+	.list-item {
+		margin: 2.5em 0;
 
-    &:first-child {
-      margin-top: 1.875em;
-    }
-  }
+		&:first-child {
+			margin-top: 1.875em;
+		}
+	}
 
-  .container {
-    .body {
-      margin: 0.5em 0;
-    }
-  }
+	.container {
+		.body {
+			margin: 0.5em 0;
+		}
+	}
 }
 
 .list {
-  // News & Events press releases listing
-  &.dynamic {
-    li {
-      &.has-media {
-        .list-item-image {
-          @include break(medium) {
-            padding-right: 0;
+	// News & Events press releases listing
+	&.dynamic {
+		li {
+			&.has-media {
+				.list-item-image {
+					@include break(medium) {
+						padding-right: 0;
 
-            + .title-and-desc {
-              padding-left: 20px;
-              padding-right: 0;
-            }
-          }
-        }
-      }
-    }
-  }
+						+ .title-and-desc {
+							padding-left: 20px;
+							padding-right: 0;
+						}
+					}
+				}
+			}
+		}
+	}
 
-  &.managed {
-    @extend .row;
-    max-width: 62.5em;
-    margin: 0 auto;
+	&.managed {
+		@extend .row;
+		max-width: 62.5em;
+		margin: 0 auto;
 
-    h2 {
-      margin-left: 15px;
-    }
+		h2 {
+			margin-left: 15px;
+		}
 
-    ul {
-      @extend .card-thumbnail;
-      padding: 1em 0;
+		ul {
+			@extend .card-thumbnail;
+			padding: 1em 0;
 
-      li {
-        &.has-media {
-          > .container {
-            padding: 0 mq-px2em(15px);
-          }
+			li {
+				&.has-media {
+					> .container {
+						padding: 0 mq-px2em(15px);
+					}
 
-          .list-item-image {
-            @include break(medium) {
-              width: 16.7%;
-            }
-          }
+					.list-item-image {
+						@include break(medium) {
+							width: 16.7%;
+						}
+					}
 
-          .title-and-desc {
-            margin-left: 0;
-            padding-left: 15px;
+					.title-and-desc {
+						margin-left: 0;
+						padding-left: 15px;
 
-            @include break(medium) {
-              margin-left: 16.7%;
-            }
-          }
-        }
-      }
-    }
-  }
+						@include break(medium) {
+							margin-left: 16.7%;
+						}
+					}
+				}
+			}
+		}
+	}
 }
 
 /********************* END Home Page Styles ******************************************/
@@ -712,8 +727,9 @@ parent accordion in all breakpoints. */
 .social-media-row {
 	display: flex;
 	margin-bottom: 2em;
-	&:before, &after {
-		display:none;
+	&:before,
+	&after {
+		display: none;
 	}
 }
 .social-media-card {
@@ -728,7 +744,6 @@ parent accordion in all breakpoints. */
 	.social-media-text h3 {
 		text-align: center;
 	}
-
 }
 .social-media-card:last-child {
 	margin-right: 0;
@@ -748,7 +763,6 @@ parent accordion in all breakpoints. */
 	display: block;
 	margin: 0 auto;
 }
-
 
 .social-media-row .icon-exit-notification {
 	font-size: 15px;
@@ -798,7 +812,6 @@ parent accordion in all breakpoints. */
 			width: 104px;
 			height: auto;
 		}
-
 	}
 	.social-media-card .social-media-text {
 		margin-bottom: 0;
@@ -876,7 +889,6 @@ parent accordion in all breakpoints. */
 		text-align: center;
 		margin: 0;
 	}
-
 }
 
 @media only screen and (min-width: 461px) and (max-width: 900px) {

--- a/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/front-end/src/lib/components/usa-footer/__tests__/usa-footer.test.ts
+++ b/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/front-end/src/lib/components/usa-footer/__tests__/usa-footer.test.ts
@@ -146,11 +146,15 @@ describe('usa-footer', () => {
 		fireEvent.click(input);
 
 		// Analytics sent for clicking into input field
-		expect(spy).toHaveBeenCalledWith('Form:Start', 'Form:Start', {
-			formType: 'EmailSignUp',
-			status: 'Start',
-			location: 'Footer',
-		});
+		expect(spy).toHaveBeenCalledWith(
+			'Footer:EmailForm:Start',
+			'Footer:EmailForm:Start',
+			{
+				formType: 'EmailSignUp',
+				status: 'Start',
+				location: 'Footer',
+			}
+		);
 
 		// Should have only been called once
 		expect(spy).toHaveBeenCalledTimes(1);
@@ -178,11 +182,15 @@ describe('usa-footer', () => {
 		fireEvent.click(button);
 
 		// Invalid form submission
-		expect(spy).toHaveBeenCalledWith('Form:Error', 'Form:Error', {
-			formType: 'EmailSignUp',
-			status: 'Error',
-			location: 'Footer',
-		});
+		expect(spy).toHaveBeenCalledWith(
+			'Footer:EmailForm:Error',
+			'Footer:EmailForm:Error',
+			{
+				formType: 'EmailSignUp',
+				status: 'Error',
+				location: 'Footer',
+			}
+		);
 	});
 
 	it('sends the correct analytics for form submission', () => {
@@ -209,11 +217,15 @@ describe('usa-footer', () => {
 
 		// Valid form submission
 		expect(spy).toHaveBeenCalledTimes(1);
-		expect(spy).toHaveBeenCalledWith('Form:Complete', 'Form:Complete', {
-			formType: 'EmailSignUp',
-			status: 'Complete',
-			location: 'Footer',
-		});
+		expect(spy).toHaveBeenCalledWith(
+			'Footer:EmailForm:Complete',
+			'Footer:EmailForm:Complete',
+			{
+				formType: 'EmailSignUp',
+				status: 'Complete',
+				location: 'Footer',
+			}
+		);
 	});
 
 	it('sends the correct analytics for a bad html', () => {

--- a/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/front-end/src/lib/components/usa-footer/__tests__/usa-footer.test.ts
+++ b/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/front-end/src/lib/components/usa-footer/__tests__/usa-footer.test.ts
@@ -50,11 +50,15 @@ describe('usa-footer', () => {
 
 		// Click Return to top
 		fireEvent.click(link[0]);
-		expect(spy).toHaveBeenCalledWith('Footer:LinkClick', 'Footer:LinkClick', {
-			linkText: 'Back To Top',
-			location: 'Footer',
-			section: 'Back To Top',
-		});
+		expect(spy).toHaveBeenCalledWith(
+			'RightEdge:LinkClick',
+			'RightEdge:LinkClick',
+			{
+				linkText: 'Back To Top',
+				location: 'Right Edge',
+				section: 'Back To Top',
+			}
+		);
 
 		// Click secondary link
 		fireEvent.click(link[1]);

--- a/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/front-end/src/lib/components/usa-footer/usa-footer.ts
+++ b/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/front-end/src/lib/components/usa-footer/usa-footer.ts
@@ -130,17 +130,17 @@ let trackSubscribeStart = true;
 const footerSubscribeStartHandler = () => () => {
 	if (!trackSubscribeStart) return;
 	trackSubscribeStart = false;
-	trackForm('Form:Start', 'Start');
+	trackForm('Footer:EmailForm:Start', 'Start');
 };
 
 /** Onsubmit handler for subscribe form. */
 const footerSubscribeCompleteHandler = () => () => {
-	trackForm('Form:Complete', 'Complete');
+	trackForm('Footer:EmailForm:Complete', 'Complete');
 };
 
 /** On error handler for subscribe form. */
 const footerSubscribeErrorHandler = () => () => {
-	trackForm('Form:Error', 'Error');
+	trackForm('Footer:EmailForm:Error', 'Error');
 };
 
 /**

--- a/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/front-end/src/lib/components/usa-footer/usa-footer.ts
+++ b/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/front-end/src/lib/components/usa-footer/usa-footer.ts
@@ -98,6 +98,17 @@ const footerLinkAnalyticsHandler = () => (event: Event) => {
 };
 
 /**
+ * Click handler for back to top click.
+ */
+const backToTopAnalyticsHandler = () => () => {
+	trackOther('RightEdge:LinkClick', 'RightEdge:LinkClick', {
+		linkText: 'Back To Top',
+		location: 'Right Edge',
+		section: 'Back To Top',
+	});
+};
+
+/**
  * Click handler for collapse events.
  */
 const footerCollapseAnalyticsHandler = () => (event: Event) => {
@@ -147,8 +158,16 @@ const initialize = (): void => {
 		NCIBigFooter.create(footerElement);
 	}
 
-	// All link clicks in the footer
-	const navLinks = footerElement.querySelectorAll('a');
+	// set up listener for backToTop
+	const backToTopLink = footerElement.querySelector(
+		'.usa-footer__nci-return-to-top a'
+	) as HTMLAnchorElement;
+	backToTopLink.addEventListener('click', backToTopAnalyticsHandler());
+
+	// All link clicks in the footer(primary and secondary sections)
+	const navLinks = footerElement.querySelectorAll(
+		'.usa-footer__primary-section a, .usa-footer__secondary-section a'
+	);
 	navLinks.forEach((link) => {
 		link.addEventListener('click', footerLinkAnalyticsHandler());
 	});

--- a/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/templates/layout/regions/ncids/region--ncids-sidenav.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/templates/layout/regions/ncids/region--ncids-sidenav.html.twig
@@ -1,6 +1,6 @@
 {% if content %}
   <!-- SECTION NAVIGATION -->
-  <div class="desktop:grid-col-3">
+  <div class="desktop:grid-col-3 nci-no-print">
     {{ content }}
   </div>
 {% endif %}


### PR DESCRIPTION
Closes #3608 .
Closes #3594 .
Closes #3528 .
Closes #3603 .

- added class `nci-no-print` to sidenav container; added no-print partial to ncids-common
- updated analytics naming for back-to-top button in footer and added corresponding test
- modified outline surrounding cards on focus for keyboard navigation
- updated analytics for footer email signup

<img width="829" alt="Screen Shot 2022-11-21 at 1 29 47 PM" src="https://user-images.githubusercontent.com/45469809/203157334-4387c88e-a5e0-4647-b095-0fc5269d2c50.png">
