### PR TITLE
(#3702) (Bugfix) pronunciation block wrapping fix

### DIFF
--- a/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/front-end/src/entrypoints/app-module/app-module-legacy.scss
+++ b/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/front-end/src/entrypoints/app-module/app-module-legacy.scss
@@ -17,8 +17,11 @@
 		height: initial;
 		width: 30px;
 	}
+
 	.pronunciation {
-		height: 42px;
+    .pronunciation__audio {
+      padding-top: 4px;
+    }
 		.pronunciation__term {
 			margin-right: 5px;
 		}
@@ -26,8 +29,10 @@
 		.pronunciation__key {
 			margin-left: 10px;
 			padding-top: 4px;
+      padding-bottom: 4px;
 		}
 	}
+
 
 	.dictionary-list-container {
 		.dictionary-list{


### PR DESCRIPTION
Closes #3702 
- the height applied to pronunciation was causing overflow issues; removed explicit height
- applied similar padding to term to audio icon

**Bug:**
set viewport such that the term pronunciation wraps to 3 lines
https://www-test-acsf.cancer.gov/publications/dictionaries/cancer-terms/def/atypical-glandular-cells-of-undetermined-significance

**Expected result of fix:**
term wrapping to three lines no longer overflows the container 
<img width="344" alt="Screen Shot 2022-12-12 at 12 35 28 PM" src="https://user-images.githubusercontent.com/45469809/207137719-29844698-dab4-4755-8447-4781c3de8cbb.png">
