### PR TITLE
(#3266) Upgrade to PHP 8.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,10 +78,10 @@ jobs:
       - name: Setup PHP with tools
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4'
+          php-version: '8.0'
           ## This list of extensions matches those we install with our docker file, then I removed
           ## cli, common, fpm cause they would not install, then I removed xdebug cause why?
-          extensions: bz2, curl, gd, json, mbstring, memcached, mysql, oauth, opcache, readline, sqlite3, soap, xml
+          extensions: bz2, curl, gd, mbstring, memcached, mysql, oauth, opcache, readline, sqlite3, soap, xml
           tools: composer:v2
       - name: Get Composer Cache Directory
         id: composer-cache
@@ -99,8 +99,8 @@ jobs:
       ## Install BLT and Drush Launchers
       - name: Install BLT and Drush Launchers
         run: |
-          curl -sL -o /usr/local/bin/drush https://github.com/drush-ops/drush-launcher/releases/download/0.6.0/drush.phar && chmod +x /usr/local/bin/drush
-          curl -sL -o /usr/local/bin/blt https://github.com/acquia/blt-launcher/releases/download/v1.0.3/blt.phar && chmod +x /usr/local/bin/blt
+          curl -sL -o /usr/local/bin/drush https://github.com/drush-ops/drush-launcher/releases/download/0.10.1/drush.phar && chmod +x /usr/local/bin/drush
+          curl -sL -o /usr/local/bin/blt https://github.com/acquia/blt-launcher/releases/download/v1.1.0/blt.phar && chmod +x /usr/local/bin/blt
       - name: Setup Env
         run: |
           ## The mynci service creates the drupal DB, we need to make the

--- a/acquia-pipelines.yml
+++ b/acquia-pipelines.yml
@@ -4,7 +4,7 @@ services:
       version: 2
   - mysql
   - php:
-      version: 7.4
+      version: 8.0
 
 variables:
   global:

--- a/composer.json
+++ b/composer.json
@@ -85,7 +85,7 @@
         "kint-php/kint": "^3.3",
         "nciocpl/clinical-trial-search-client.php": "dev-master",
         "robrichards/xmlseclibs": "^3.1",
-        "scotteh/php-dom-wrapper": "^1.0",
+        "scotteh/php-dom-wrapper": "^2.0.3",
         "simplesamlphp/simplesamlphp": "^1.18.6",
         "vlucas/phpdotenv": "^2.4",
         "webflo/drupal-finder": "^1.0.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0fc9aa225850f04194d6c7df19d7cb2f",
+    "content-hash": "f33acc1fa91fe6b8bbc3f8bd3aa7a1ea",
     "packages": [
         {
             "name": "acquia/acsf-tools",
@@ -12850,16 +12850,16 @@
         },
         {
             "name": "scotteh/php-dom-wrapper",
-            "version": "1.2.1",
+            "version": "2.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/scotteh/php-dom-wrapper.git",
-                "reference": "54b064eb88e25887945a179b07097452b2f7af2e"
+                "reference": "edf37231a9ee609ea947ffaa5ac342a372f18b29"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/scotteh/php-dom-wrapper/zipball/54b064eb88e25887945a179b07097452b2f7af2e",
-                "reference": "54b064eb88e25887945a179b07097452b2f7af2e",
+                "url": "https://api.github.com/repos/scotteh/php-dom-wrapper/zipball/edf37231a9ee609ea947ffaa5ac342a372f18b29",
+                "reference": "edf37231a9ee609ea947ffaa5ac342a372f18b29",
                 "shasum": ""
             },
             "require": {
@@ -12867,16 +12867,15 @@
                 "ext-mbstring": "*",
                 "lib-libxml": ">=2.7.7",
                 "php": ">=7.1.0",
-                "symfony/css-selector": "^4.0 || ^5.0"
+                "symfony/css-selector": "^4.0 || ^5.0 || ^6.0"
             },
             "require-dev": {
-                "phpdocumentor/phpdocumentor": "^2.9",
-                "phpunit/phpunit": "^7.0"
+                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -12905,9 +12904,9 @@
             ],
             "support": {
                 "issues": "https://github.com/scotteh/php-dom-wrapper/issues",
-                "source": "https://github.com/scotteh/php-dom-wrapper/tree/1.2.1"
+                "source": "https://github.com/scotteh/php-dom-wrapper/tree/2.0.3"
             },
-            "time": "2020-02-22T00:53:56+00:00"
+            "time": "2022-05-14T06:10:52+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/docker/README.md
+++ b/docker/README.md
@@ -31,7 +31,7 @@ At some point in time there will be multiple websites within our project. (e.g. 
   * MySQL
 * web
   * OS: Ubuntu Bionic
-  * PHP 7.4
+  * PHP 8.0
     * bz2
     * cli
     * common

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -13,8 +13,8 @@ services:
       - ../:/var/www:cached
       ## Configs
       - ./web/runtime/apache2.conf:/etc/apache2/apache2.conf
-      - ./web/runtime/php_apache2.ini:/etc/php/7.4/apache2/php.ini
-      - ./web/runtime/php_cli.ini:/etc/php/7.4/cli/php.ini
+      - ./web/runtime/php_apache2.ini:/etc/php/8.0/apache2/php.ini
+      - ./web/runtime/php_cli.ini:/etc/php/8.0/cli/php.ini
       ## Block git repo management within the container
       - ./web/runtime/container-hooks:/var/www/scripts/hooks
       ## Npmrc for package installation.

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -28,7 +28,7 @@ RUN mkdir /usr/local/share/ca-certificates/nih \
 RUN DEBIAN_FRONTEND=noninteractive \
   apt-get install -yq software-properties-common
 
-# Add the PHP 7.3 repository
+# Add the PHP repository
 RUN DEBIAN_FRONTEND=noninteractive \
   add-apt-repository ppa:ondrej/php; \
   DEBIAN_FRONTEND=noninteractive \
@@ -39,25 +39,24 @@ RUN DEBIAN_FRONTEND=noninteractive \
   apt-get install -yq \
   apache2 \
   build-essential \
-  php7.4 \
-  libapache2-mod-php7.4 \
-  php7.4-bz2 \
-  php7.4-cli \
-  php7.4-common \
-  php7.4-curl \
-  php7.4-fpm \
-  php7.4-gd \
-  php7.4-json \
-  php7.4-mbstring \
-  php7.4-memcached \
-  php7.4-mysql \
-  php7.4-oauth \
-  php7.4-opcache \
-  php7.4-readline \
-  php7.4-sqlite3 \
-  php7.4-soap \
-  php7.4-xdebug \
-  php7.4-xml \
+  php8.0 \
+  libapache2-mod-php8.0 \
+  php8.0-bz2 \
+  php8.0-cli \
+  php8.0-common \
+  php8.0-curl \
+  php8.0-fpm \
+  php8.0-gd \
+  php8.0-mbstring \
+  php8.0-memcached \
+  php8.0-mysql \
+  php8.0-oauth \
+  php8.0-opcache \
+  php8.0-readline \
+  php8.0-sqlite3 \
+  php8.0-soap \
+  php8.0-xdebug \
+  php8.0-xml \
   mysql-client-5.7 \
   git \
   clamav \
@@ -78,7 +77,7 @@ COPY ./build/000-default.conf /etc/apache2/sites-available/000-default.conf
 ## These are the PHP modules that are available to be
 ## loaded by the CLI & apache. This should be inline with
 ## the modules installed above.
-COPY ./build/php-conf /etc/php/7.4/mods-available
+COPY ./build/php-conf /etc/php/8.0/mods-available
 
 # Enable mod_rewrite 'cause we needs it.
 RUN a2enmod rewrite
@@ -119,7 +118,7 @@ RUN npm install -g npm@8.1.0
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer --2
 
 ## Install Drush Launcher (runs local drush instances)
-RUN curl -sL -o /usr/local/bin/drush https://github.com/drush-ops/drush-launcher/releases/download/0.6.0/drush.phar \
+RUN curl -sL -o /usr/local/bin/drush https://github.com/drush-ops/drush-launcher/releases/download/0.10.1/drush.phar \
   && chmod +x /usr/local/bin/drush
 
 ## Install Drupal console
@@ -129,7 +128,7 @@ RUN curl https://drupalconsole.com/installer -L -o /usr/local/bin/drupal \
 RUN php --version; composer --version; drupal --version; drush --drush-launcher-version
 
 ## Enable BLT function
-RUN curl -sL -o /usr/local/bin/blt https://github.com/acquia/blt-launcher/releases/download/v1.0.3/blt.phar \
+RUN curl -sL -o /usr/local/bin/blt https://github.com/acquia/blt-launcher/releases/download/v1.1.0/blt.phar \
   && chmod +x /usr/local/bin/blt
 
 ## Turn off xdebug as it uses resources that could be best used

--- a/docker/web/build/php-conf/json.ini
+++ b/docker/web/build/php-conf/json.ini
@@ -1,3 +1,0 @@
-; configuration for php json module
-; priority=20
-extension=json.so

--- a/docker/web/runtime/php_apache2.ini
+++ b/docker/web/runtime/php_apache2.ini
@@ -88,6 +88,7 @@
 ;;;;;;;;;;;;;;;;;;;
 ; Quick Reference ;
 ;;;;;;;;;;;;;;;;;;;
+
 ; The following are all the settings which are different in either the production
 ; or development versions of the INIs with respect to PHP's default behavior.
 ; Please see the actual settings later in the document for more details as to why
@@ -99,12 +100,12 @@
 ;   Production Value: Off
 
 ; display_startup_errors
-;   Default Value: Off
+;   Default Value: On
 ;   Development Value: On
 ;   Production Value: Off
 
 ; error_reporting
-;   Default Value: E_ALL & ~E_NOTICE & ~E_STRICT & ~E_DEPRECATED
+;   Default Value: E_ALL
 ;   Development Value: E_ALL
 ;   Production Value: E_ALL & ~E_DEPRECATED & ~E_STRICT
 
@@ -152,6 +153,16 @@
 ;   Default Value: "EGPCS"
 ;   Development Value: "GPCS"
 ;   Production Value: "GPCS"
+
+; zend.exception_ignore_args
+;   Default Value: Off
+;   Development Value: Off
+;   Production Value: On
+
+; zend.exception_string_param_max_len
+;   Default Value: 15
+;   Development Value: 15
+;   Production Value: 0
 
 ;;;;;;;;;;;;;;;;;;;;
 ; php.ini Options  ;
@@ -352,20 +363,30 @@ zend.enable_gc = On
 ; If enabled, scripts may be written in encodings that are incompatible with
 ; the scanner.  CP936, Big5, CP949 and Shift_JIS are the examples of such
 ; encodings.  To use this feature, mbstring extension must be enabled.
-; Default: Off
 ;zend.multibyte = Off
 
 ; Allows to set the default encoding for the scripts.  This value will be used
 ; unless "declare(encoding=...)" directive appears at the top of the script.
 ; Only affects if zend.multibyte is set.
-; Default: ""
 ;zend.script_encoding =
 
 ; Allows to include or exclude arguments from stack traces generated for exceptions.
 ; In production, it is recommended to turn this setting on to prohibit the output
 ; of sensitive information in stack traces
-; Default: Off
+; Default Value: Off
+; Development Value: Off
+; Production Value: On
 zend.exception_ignore_args = On
+
+; Allows setting the maximum string length in an argument of a stringified stack trace
+; to a value between 0 and 1000000.
+; This has no effect when zend.exception_ignore_args is enabled.
+; Default Value: 15
+; Development Value: 15
+; Production Value: 0
+; In production, it is recommended to set this to 0 to reduce the output
+; of sensitive information in stack traces.
+zend.exception_string_param_max_len = 0
 
 ;;;;;;;;;;;;;;;;;
 ; Miscellaneous ;
@@ -458,7 +479,7 @@ memory_limit = 256M
 ;   E_ALL & ~E_NOTICE  (Show all errors, except for notices)
 ;   E_ALL & ~E_NOTICE & ~E_STRICT  (Show all errors, except for notices and coding standards warnings.)
 ;   E_COMPILE_ERROR|E_RECOVERABLE_ERROR|E_ERROR|E_CORE_ERROR  (Show only errors)
-; Default Value: E_ALL & ~E_NOTICE & ~E_STRICT & ~E_DEPRECATED
+; Default Value: E_ALL
 ; Development Value: E_ALL
 ; Production Value: E_ALL & ~E_DEPRECATED & ~E_STRICT
 ; http://php.net/error-reporting
@@ -482,11 +503,9 @@ error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT
 display_errors = Off
 
 ; The display of errors which occur during PHP's startup sequence are handled
-; separately from display_errors. PHP's default behavior is to suppress those
-; errors from clients. Turning the display of startup errors on can be useful in
-; debugging configuration problems. We strongly recommend you
-; set this to 'off' for production servers.
-; Default Value: Off
+; separately from display_errors. We strongly recommend you set this to 'off'
+; for production servers to avoid leaking configuration details.
+; Default Value: On
 ; Development Value: On
 ; Production Value: Off
 ; http://php.net/display-startup-errors
@@ -524,18 +543,8 @@ ignore_repeated_source = Off
 ; http://php.net/report-memleaks
 report_memleaks = On
 
-; This setting is on by default.
+; This setting is off by default.
 ;report_zend_debug = 0
-
-; Store the last error/warning message in $php_errormsg (boolean). Setting this value
-; to On can assist in debugging and is appropriate for development servers. It should
-; however be disabled on production servers.
-; This directive is DEPRECATED.
-; Default Value: Off
-; Development Value: Off
-; Production Value: Off
-; http://php.net/track-errors
-;track_errors = Off
 
 ; Turn off normal error reporting and emit XML-RPC error XML
 ; http://php.net/xmlrpc-errors
@@ -915,7 +924,7 @@ default_socket_timeout = 60
 ;extension=ffi
 ;extension=ftp
 ;extension=fileinfo
-;extension=gd2
+;extension=gd
 ;extension=gettext
 ;extension=gmp
 ;extension=intl
@@ -925,6 +934,7 @@ default_socket_timeout = 60
 ;extension=exif      ; Must be after mbstring as it depends on it
 ;extension=mysqli
 ;extension=oci8_12c  ; Use with Oracle Database 12c Instant Client
+;extension=oci8_19  ; Use with Oracle Database 19 Instant Client
 ;extension=odbc
 ;extension=openssl
 ;extension=pdo_firebird
@@ -945,8 +955,9 @@ default_socket_timeout = 60
 ;extension=sodium
 ;extension=sqlite3
 ;extension=tidy
-;extension=xmlrpc
 ;extension=xsl
+
+;zend_extension=opcache
 
 ;;;;;;;;;;;;;;;;;;;
 ; Module Settings ;
@@ -968,10 +979,10 @@ date.timezone = "UTC"
 ;date.default_longitude = 35.2333
 
 ; http://php.net/date.sunrise-zenith
-;date.sunrise_zenith = 90.583333
+;date.sunrise_zenith = 90.833333
 
 ; http://php.net/date.sunset-zenith
-;date.sunset_zenith = 90.583333
+;date.sunset_zenith = 90.833333
 
 [filter]
 ; http://php.net/filter.default
@@ -1047,8 +1058,6 @@ date.timezone = "UTC"
 ; Whether to pool ODBC connections. Can be one of "strict", "relaxed" or "off"
 ; http://php.net/pdo-odbc.connection-pooling
 ;pdo_odbc.connection_pooling=strict
-
-;pdo_odbc.db2_instance_name
 
 [Pdo_mysql]
 ; Default socket name for local MySQL connects.  If empty, uses the built-in
@@ -1389,6 +1398,12 @@ session.cookie_domain =
 ; http://php.net/session.cookie-httponly
 session.cookie_httponly =
 
+; Add SameSite attribute to cookie to help mitigate Cross-Site Request Forgery (CSRF/XSRF)
+; Current valid values are "Strict", "Lax" or "None". When using "None",
+; make sure to include the quotes, as `none` is interpreted like `false` in ini files.
+; https://tools.ietf.org/html/draft-west-first-party-cookies-07
+session.cookie_samesite =
+
 ; Handler used to serialize data. php is the standard serializer of PHP.
 ; http://php.net/session.serialize-handler
 session.serialize_handler = php
@@ -1579,11 +1594,6 @@ zend.assertions = -1
 ; http://php.net/assert.callback
 ;assert.callback = 0
 
-; Eval the expression with current error_reporting().  Set to true if you want
-; error_reporting(0) around the eval().
-; http://php.net/assert.quiet-eval
-;assert.quiet_eval = 0
-
 [COM]
 ; path to a file containing GUIDs, IIDs or filenames of files with TypeLibs
 ; http://php.net/com.typelib-file
@@ -1608,6 +1618,10 @@ zend.assertions = -1
 ; The default character set code-page to use when passing strings to and from COM objects.
 ; Default: system ANSI code page
 ;com.code_page=
+
+; The version of the .NET framework to use. The value of the setting are the first three parts
+; of the framework's version number, separated by dots, and prefixed with "v", e.g. "v4.0.30319".
+;com.dotnet_version=
 
 [mbstring]
 ; language for internal character representation.
@@ -1658,34 +1672,20 @@ zend.assertions = -1
 ; http://php.net/mbstring.substitute-character
 ;mbstring.substitute_character = none
 
-; overload(replace) single byte functions by mbstring functions.
-; mail(), ereg(), etc are overloaded by mb_send_mail(), mb_ereg(),
-; etc. Possible values are 0,1,2,4 or combination of them.
-; For example, 7 for overload everything.
-; 0: No overload
-; 1: Overload mail() function
-; 2: Overload str*() functions
-; 4: Overload ereg*() functions
-; http://php.net/mbstring.func-overload
-;mbstring.func_overload = 0
-
-; enable strict encoding detection.
-; Default: Off
-;mbstring.strict_detection = On
+; Enable strict encoding detection.
+;mbstring.strict_detection = Off
 
 ; This directive specifies the regex pattern of content types for which mb_output_handler()
 ; is activated.
-; Default: mbstring.http_output_conv_mimetype=^(text/|application/xhtml\+xml)
-;mbstring.http_output_conv_mimetype=
+; Default: mbstring.http_output_conv_mimetypes=^(text/|application/xhtml\+xml)
+;mbstring.http_output_conv_mimetypes=
 
 ; This directive specifies maximum stack depth for mbstring regular expressions. It is similar
 ; to the pcre.recursion_limit for PCRE.
-; Default: 100000
 ;mbstring.regex_stack_limit=100000
 
 ; This directive specifies maximum retry count for mbstring regular expressions. It is similar
 ; to the pcre.backtrack_limit for PCRE.
-; Default: 1000000
 ;mbstring.regex_retry_limit=1000000
 
 [gd]
@@ -1799,6 +1799,11 @@ ldap.max_links = -1
 ; If disabled, all PHPDoc comments are dropped from the code to reduce the
 ; size of the optimized code.
 ;opcache.save_comments=1
+
+; If enabled, compilation warnings (including notices and deprecations) will
+; be recorded and replayed each time a file is included. Otherwise, compilation
+; warnings will only be emitted when the file is first cached.
+;opcache.record_warnings=0
 
 ; Allow file existence override (file_exists, etc.) performance feature.
 ;opcache.enable_file_override=0

--- a/docker/web/runtime/php_cli.ini
+++ b/docker/web/runtime/php_cli.ini
@@ -88,6 +88,7 @@
 ;;;;;;;;;;;;;;;;;;;
 ; Quick Reference ;
 ;;;;;;;;;;;;;;;;;;;
+
 ; The following are all the settings which are different in either the production
 ; or development versions of the INIs with respect to PHP's default behavior.
 ; Please see the actual settings later in the document for more details as to why
@@ -99,12 +100,12 @@
 ;   Production Value: Off
 
 ; display_startup_errors
-;   Default Value: Off
+;   Default Value: On
 ;   Development Value: On
 ;   Production Value: Off
 
 ; error_reporting
-;   Default Value: E_ALL & ~E_NOTICE & ~E_STRICT & ~E_DEPRECATED
+;   Default Value: E_ALL
 ;   Development Value: E_ALL
 ;   Production Value: E_ALL & ~E_DEPRECATED & ~E_STRICT
 
@@ -152,6 +153,16 @@
 ;   Default Value: "EGPCS"
 ;   Development Value: "GPCS"
 ;   Production Value: "GPCS"
+
+; zend.exception_ignore_args
+;   Default Value: Off
+;   Development Value: Off
+;   Production Value: On
+
+; zend.exception_string_param_max_len
+;   Default Value: 15
+;   Development Value: 15
+;   Production Value: 0
 
 ;;;;;;;;;;;;;;;;;;;;
 ; php.ini Options  ;
@@ -352,20 +363,30 @@ zend.enable_gc = On
 ; If enabled, scripts may be written in encodings that are incompatible with
 ; the scanner.  CP936, Big5, CP949 and Shift_JIS are the examples of such
 ; encodings.  To use this feature, mbstring extension must be enabled.
-; Default: Off
 ;zend.multibyte = Off
 
 ; Allows to set the default encoding for the scripts.  This value will be used
 ; unless "declare(encoding=...)" directive appears at the top of the script.
 ; Only affects if zend.multibyte is set.
-; Default: ""
 ;zend.script_encoding =
 
 ; Allows to include or exclude arguments from stack traces generated for exceptions.
 ; In production, it is recommended to turn this setting on to prohibit the output
 ; of sensitive information in stack traces
-; Default: Off
+; Default Value: Off
+; Development Value: Off
+; Production Value: On
 zend.exception_ignore_args = On
+
+; Allows setting the maximum string length in an argument of a stringified stack trace
+; to a value between 0 and 1000000.
+; This has no effect when zend.exception_ignore_args is enabled.
+; Default Value: 15
+; Development Value: 15
+; Production Value: 0
+; In production, it is recommended to set this to 0 to reduce the output
+; of sensitive information in stack traces.
+zend.exception_string_param_max_len = 0
 
 ;;;;;;;;;;;;;;;;;
 ; Miscellaneous ;
@@ -458,7 +479,7 @@ memory_limit = -1
 ;   E_ALL & ~E_NOTICE  (Show all errors, except for notices)
 ;   E_ALL & ~E_NOTICE & ~E_STRICT  (Show all errors, except for notices and coding standards warnings.)
 ;   E_COMPILE_ERROR|E_RECOVERABLE_ERROR|E_ERROR|E_CORE_ERROR  (Show only errors)
-; Default Value: E_ALL & ~E_NOTICE & ~E_STRICT & ~E_DEPRECATED
+; Default Value: E_ALL
 ; Development Value: E_ALL
 ; Production Value: E_ALL & ~E_DEPRECATED & ~E_STRICT
 ; http://php.net/error-reporting
@@ -482,11 +503,9 @@ error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT
 display_errors = Off
 
 ; The display of errors which occur during PHP's startup sequence are handled
-; separately from display_errors. PHP's default behavior is to suppress those
-; errors from clients. Turning the display of startup errors on can be useful in
-; debugging configuration problems. We strongly recommend you
-; set this to 'off' for production servers.
-; Default Value: Off
+; separately from display_errors. We strongly recommend you set this to 'off'
+; for production servers to avoid leaking configuration details.
+; Default Value: On
 ; Development Value: On
 ; Production Value: Off
 ; http://php.net/display-startup-errors
@@ -524,18 +543,8 @@ ignore_repeated_source = Off
 ; http://php.net/report-memleaks
 report_memleaks = On
 
-; This setting is on by default.
+; This setting is off by default.
 ;report_zend_debug = 0
-
-; Store the last error/warning message in $php_errormsg (boolean). Setting this value
-; to On can assist in debugging and is appropriate for development servers. It should
-; however be disabled on production servers.
-; This directive is DEPRECATED.
-; Default Value: Off
-; Development Value: Off
-; Production Value: Off
-; http://php.net/track-errors
-;track_errors = Off
 
 ; Turn off normal error reporting and emit XML-RPC error XML
 ; http://php.net/xmlrpc-errors
@@ -915,7 +924,7 @@ default_socket_timeout = 60
 ;extension=ffi
 ;extension=ftp
 ;extension=fileinfo
-;extension=gd2
+;extension=gd
 ;extension=gettext
 ;extension=gmp
 ;extension=intl
@@ -925,6 +934,7 @@ default_socket_timeout = 60
 ;extension=exif      ; Must be after mbstring as it depends on it
 ;extension=mysqli
 ;extension=oci8_12c  ; Use with Oracle Database 12c Instant Client
+;extension=oci8_19  ; Use with Oracle Database 19 Instant Client
 ;extension=odbc
 ;extension=openssl
 ;extension=pdo_firebird
@@ -945,8 +955,9 @@ default_socket_timeout = 60
 ;extension=sodium
 ;extension=sqlite3
 ;extension=tidy
-;extension=xmlrpc
 ;extension=xsl
+
+;zend_extension=opcache
 
 ;;;;;;;;;;;;;;;;;;;
 ; Module Settings ;
@@ -968,10 +979,10 @@ date.timezone = "UTC"
 ;date.default_longitude = 35.2333
 
 ; http://php.net/date.sunrise-zenith
-;date.sunrise_zenith = 90.583333
+;date.sunrise_zenith = 90.833333
 
 ; http://php.net/date.sunset-zenith
-;date.sunset_zenith = 90.583333
+;date.sunset_zenith = 90.833333
 
 [filter]
 ; http://php.net/filter.default
@@ -1047,8 +1058,6 @@ date.timezone = "UTC"
 ; Whether to pool ODBC connections. Can be one of "strict", "relaxed" or "off"
 ; http://php.net/pdo-odbc.connection-pooling
 ;pdo_odbc.connection_pooling=strict
-
-;pdo_odbc.db2_instance_name
 
 [Pdo_mysql]
 ; Default socket name for local MySQL connects.  If empty, uses the built-in
@@ -1585,11 +1594,6 @@ zend.assertions = -1
 ; http://php.net/assert.callback
 ;assert.callback = 0
 
-; Eval the expression with current error_reporting().  Set to true if you want
-; error_reporting(0) around the eval().
-; http://php.net/assert.quiet-eval
-;assert.quiet_eval = 0
-
 [COM]
 ; path to a file containing GUIDs, IIDs or filenames of files with TypeLibs
 ; http://php.net/com.typelib-file
@@ -1614,6 +1618,10 @@ zend.assertions = -1
 ; The default character set code-page to use when passing strings to and from COM objects.
 ; Default: system ANSI code page
 ;com.code_page=
+
+; The version of the .NET framework to use. The value of the setting are the first three parts
+; of the framework's version number, separated by dots, and prefixed with "v", e.g. "v4.0.30319".
+;com.dotnet_version=
 
 [mbstring]
 ; language for internal character representation.
@@ -1664,34 +1672,20 @@ zend.assertions = -1
 ; http://php.net/mbstring.substitute-character
 ;mbstring.substitute_character = none
 
-; overload(replace) single byte functions by mbstring functions.
-; mail(), ereg(), etc are overloaded by mb_send_mail(), mb_ereg(),
-; etc. Possible values are 0,1,2,4 or combination of them.
-; For example, 7 for overload everything.
-; 0: No overload
-; 1: Overload mail() function
-; 2: Overload str*() functions
-; 4: Overload ereg*() functions
-; http://php.net/mbstring.func-overload
-;mbstring.func_overload = 0
-
-; enable strict encoding detection.
-; Default: Off
-;mbstring.strict_detection = On
+; Enable strict encoding detection.
+;mbstring.strict_detection = Off
 
 ; This directive specifies the regex pattern of content types for which mb_output_handler()
 ; is activated.
-; Default: mbstring.http_output_conv_mimetype=^(text/|application/xhtml\+xml)
-;mbstring.http_output_conv_mimetype=
+; Default: mbstring.http_output_conv_mimetypes=^(text/|application/xhtml\+xml)
+;mbstring.http_output_conv_mimetypes=
 
 ; This directive specifies maximum stack depth for mbstring regular expressions. It is similar
 ; to the pcre.recursion_limit for PCRE.
-; Default: 100000
 ;mbstring.regex_stack_limit=100000
 
 ; This directive specifies maximum retry count for mbstring regular expressions. It is similar
 ; to the pcre.backtrack_limit for PCRE.
-; Default: 1000000
 ;mbstring.regex_retry_limit=1000000
 
 [gd]
@@ -1805,6 +1799,11 @@ ldap.max_links = -1
 ; If disabled, all PHPDoc comments are dropped from the code to reduce the
 ; size of the optimized code.
 ;opcache.save_comments=1
+
+; If enabled, compilation warnings (including notices and deprecations) will
+; be recorded and replayed each time a file is included. Otherwise, compilation
+; warnings will only be emitted when the file is first cached.
+;opcache.record_warnings=0
 
 ; Allow file existence override (file_exists, etc.) performance feature.
 ;opcache.enable_file_override=0

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/007_file.content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/007_file.content.yml
@@ -15,7 +15,8 @@
             computed_path: '/research/progress/discovery'
   field_list_description: "File description. O, for a muse of fire that would ascend the brightest heaven of invention, a kingdom for a stage, princes to act, and monarchs to behold the swelling scene."
   field_browser_title: "File Browser title"
-  field_search_engine_restrictions: 0
+  field_search_engine_restrictions:
+    value: IncludeSearch
   field_image_promotional:
     - target_type: 'media'
       '#process':
@@ -52,7 +53,8 @@
     value: "Unpublished File list description"
   field_browser_title:
     value: "Unpublished File Browser title"
-  field_search_engine_restrictions: 0
+  field_search_engine_restrictions:
+    value: IncludeSearch
   field_image_promotional:
     - target_type: 'media'
       '#process':
@@ -86,7 +88,8 @@
             computed_path: '/'
   field_list_description: "File description."
   field_browser_title: "File Browser title"
-  field_search_engine_restrictions: 0
+  field_search_engine_restrictions:
+    value: IncludeSearch
   field_media_file:
     - '#process':
         callback: 'file'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/016_biography-jen.content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/016_biography-jen.content.yml
@@ -95,7 +95,8 @@
           - 'media'
           - bundle: 'cgov_image'
             name: 'Jennifer Bio'
-  field_search_engine_restrictions: 0
+  field_search_engine_restrictions:
+    value: IncludeSearch
   field_related_resources:
     - entity: 'paragraph'
       type: "cgov_internal_link"

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/016_biography-no-date.content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/016_biography-no-date.content.yml
@@ -95,4 +95,5 @@
           - 'media'
           - bundle: 'cgov_image'
             name: 'Jennifer Bio'
-  field_search_engine_restrictions: 0
+  field_search_engine_restrictions:
+    value: IncludeSearch

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/020_infographic_NCI_at_a_glance.content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/020_infographic_NCI_at_a_glance.content.yml
@@ -75,7 +75,8 @@
   field_date_updated: '2014-12-15'
   field_date_reviewed: '2015-12-15'
   field_public_use: 1
-  field_search_engine_restrictions: 0
+  field_search_engine_restrictions:
+    value: IncludeSearch
   field_pretty_url: 'nci-at-a-glance'
   field_pretty_url__ES: 'infografia-nci'
   field_site_section:

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/020_infographic_cancer_and_the_human_tumor_atlas_network.content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/020_infographic_cancer_and_the_human_tumor_atlas_network.content.yml
@@ -43,7 +43,8 @@
   field_date_updated: '2018-10-23'
   field_date_reviewed: '2018-10-23'
   field_public_use: 1
-  field_search_engine_restrictions: 0
+  field_search_engine_restrictions:
+    value: IncludeSearch
   field_pretty_url: 'screen-to-save-infographic'
   field_pretty_url__ES:
   field_site_section:

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/020_infographic_pediatric_match.content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/020_infographic_pediatric_match.content.yml
@@ -77,7 +77,8 @@
   field_date_updated: '2017-07-24'
   field_date_reviewed: '2017-07-24'
   field_public_use: 1
-  field_search_engine_restrictions: 0
+  field_search_engine_restrictions:
+    value: IncludeSearch
   field_pretty_url: 'pediatric-match-infographic'
   field_pretty_url__ES: 'match-infantil-infografia'
   field_site_section:

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/020_infographic_screen_to_save.content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/020_infographic_screen_to_save.content.yml
@@ -38,7 +38,8 @@
   field_date_updated: '2017-02-27'
   field_date_reviewed: '2017-02-27'
   field_public_use: 1
-  field_search_engine_restrictions: 0
+  field_search_engine_restrictions:
+    value: IncludeSearch
   field_pretty_url: 'screen-to-save-infographic'
   field_pretty_url__ES:
   field_site_section:

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/021_infographic_pediatric_nci.content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/021_infographic_pediatric_nci.content.yml
@@ -58,7 +58,8 @@
   field_date_display_mode:
     value: 'reviewed'
   field_public_use: 1
-  field_search_engine_restrictions: 0
+  field_search_engine_restrictions:
+    value: IncludeSearch
   field_pretty_url: 'infographic-nci'
   field_pretty_url__ES: 'esp-infografia-nci'
   field_site_section:

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/200_blog-series.content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/200_blog-series.content.yml
@@ -15,7 +15,8 @@
   field_feature_card_description:
     value: 'Cancer Currents Blog'
   field_public_use: 1
-  field_search_engine_restrictions: 0
+  field_search_engine_restrictions:
+    value: IncludeSearch
   field_about_blog:
     value: 'A blog featuring news and research updates from the National Cancer Institute.'
   field_site_section:
@@ -99,7 +100,8 @@
   field_page_description:
     value: 'ras, research, dialogue, blog'
   field_public_use: 1
-  field_search_engine_restrictions: 0
+  field_search_engine_restrictions:
+    value: IncludeSearch
   field_site_section:
     - '#process':
         callback: 'reference'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/202_blog-post-cc.content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/202_blog-post-cc.content.yml
@@ -109,7 +109,8 @@
   field_pretty_url:
     value: "my-blog-post"
   field_public_use: 1
-  field_search_engine_restrictions: 0
+  field_search_engine_restrictions:
+    value: IncludeSearch
 
 - entity: "node"
   type: "cgov_blog_post"
@@ -232,7 +233,8 @@
   field_pretty_url:
     value: 'human-tumor-atlas-network-cancer-maps'
   field_public_use: 1
-  field_search_engine_restrictions: 0
+  field_search_engine_restrictions:
+    value: IncludeSearch
 
 ## Rebuild the series with Featured Posts now that posts exist.
 - entity: "node"
@@ -251,7 +253,8 @@
   field_feature_card_description:
     value: 'Cancer Currents Blog'
   field_public_use: 1
-  field_search_engine_restrictions: 0
+  field_search_engine_restrictions:
+    value: IncludeSearch
   field_about_blog:
     value: 'A blog featuring news and research updates from the National Cancer Institute.'
   field_site_section:

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/202_blog-post-ras.content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/202_blog-post-ras.content.yml
@@ -71,7 +71,8 @@
   field_pretty_url:
     value: "jaffee-immunotherapy"
   field_public_use: 1
-  field_search_engine_restrictions: 0
+  field_search_engine_restrictions:
+    value: IncludeSearch
   field_blog_topics:
     - '#process':
         callback: 'reference'
@@ -171,7 +172,8 @@
   field_pretty_url:
     value: "shiva-malek"
   field_public_use: 1
-  field_search_engine_restrictions: 0
+  field_search_engine_restrictions:
+    value: IncludeSearch
   field_blog_topics:
     - '#process':
         callback: 'reference'
@@ -242,7 +244,8 @@
   field_pretty_url:
     value: "ras-dependent"
   field_public_use: 1
-  field_search_engine_restrictions: 0
+  field_search_engine_restrictions:
+    value: IncludeSearch
   field_blog_topics:
     - '#process':
         callback: 'reference'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/203_blog-post-pagingation.content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/203_blog-post-pagingation.content.yml
@@ -402,7 +402,8 @@
   field_pretty_url:
     value: "cancer-drugs-natural-products-nci-program"
   field_public_use: 1
-  field_search_engine_restrictions: 0
+  field_search_engine_restrictions:
+    value: IncludeSearch
   field_date_posted:
     value: "2019-03-22"
   field_image_article:
@@ -515,7 +516,8 @@
   field_pretty_url:
     value: "nci-sbir-working-with-small-business"
   field_public_use: 1
-  field_search_engine_restrictions: 0
+  field_search_engine_restrictions:
+    value: IncludeSearch
   field_date_posted:
     value: "2019-02-21"
   field_image_article:
@@ -607,7 +609,8 @@
   field_pretty_url:
     value: "darolutamide-delays-prostate-cancer-spread"
   field_public_use: 1
-  field_search_engine_restrictions: 0
+  field_search_engine_restrictions:
+    value: IncludeSearch
   field_date_posted:
     value: "2019-03-15"
   field_image_article:
@@ -704,7 +707,8 @@
   field_pretty_url__ES:
     value: "tobacco-corrective-es"
   field_public_use: 1
-  field_search_engine_restrictions: 0
+  field_search_engine_restrictions:
+    value: IncludeSearch
   field_date_posted:
     value: "2017-11-28"
   field_image_promotional:
@@ -784,7 +788,8 @@
   field_pretty_url__ES:
     value: "fda-combo-es"
   field_public_use: 1
-  field_search_engine_restrictions: 0
+  field_search_engine_restrictions:
+    value: IncludeSearch
   field_date_posted:
     value: "2018-05-25"
   field_image_article:
@@ -842,7 +847,8 @@
   field_pretty_url:
     value: "immunotherapy-biomarkers-research-network"
   field_public_use: 1
-  field_search_engine_restrictions: 0
+  field_search_engine_restrictions:
+    value: IncludeSearch
   field_date_posted:
     value: "2018-07-27"
   field_image_article:
@@ -901,7 +907,8 @@
   field_pretty_url:
     value: "global-cancer-symposium"
   field_public_use: 1
-  field_search_engine_restrictions: 0
+  field_search_engine_restrictions:
+    value: IncludeSearch
   field_date_posted:
     value: "2016-11-09"
   field_image_article:
@@ -975,7 +982,8 @@
   field_pretty_url:
     value: "cancer-immunotherapy-targeted-therapy-combination"
   field_public_use: 1
-  field_search_engine_restrictions: 0
+  field_search_engine_restrictions:
+    value: IncludeSearch
   field_date_posted:
     value: "2019-03-19"
   field_image_promotional:
@@ -1040,7 +1048,8 @@
   field_pretty_url:
     value: "expanding-clinical-trial-eligibility-criteria"
   field_public_use: 1
-  field_search_engine_restrictions: 0
+  field_search_engine_restrictions:
+    value: IncludeSearch
   field_date_posted:
     value: "2019-03-07"
   field_image_article:
@@ -1114,7 +1123,8 @@
   field_pretty_url:
     value: "nci-seer-enhancements-creating-opportunities"
   field_public_use: 1
-  field_search_engine_restrictions: 0
+  field_search_engine_restrictions:
+    value: IncludeSearch
   field_date_posted:
     value: "2018-08-23"
   field_image_article:
@@ -1170,7 +1180,8 @@
   field_pretty_url:
     value: "endometrial-cancer-bleeding-common-symptom"
   field_public_use: 1
-  field_search_engine_restrictions: 0
+  field_search_engine_restrictions:
+    value: IncludeSearch
   field_date_posted:
     value: "2018-08-29"
   field_image_article:
@@ -1217,7 +1228,8 @@
   field_pretty_url:
     value: "fda-osimertinib-necitumumab"
   field_public_use: 1
-  field_search_engine_restrictions: 0
+  field_search_engine_restrictions:
+    value: IncludeSearch
   field_date_posted:
     value: "2018-12-28"
   field_image_article:
@@ -1288,7 +1300,8 @@
   field_pretty_url:
     value: "hpv-vaccines-lowy"
   field_public_use: 1
-  field_search_engine_restrictions: 0
+  field_search_engine_restrictions:
+    value: IncludeSearch
   field_date_posted:
     value: "2014-11-20"
   field_image_article:
@@ -1347,7 +1360,8 @@
   field_pretty_url:
     value: "lymphoma-sd-101-in-situ-vaccine"
   field_public_use: 1
-  field_search_engine_restrictions: 0
+  field_search_engine_restrictions:
+    value: IncludeSearch
   field_date_posted:
     value: "2018-09-26"
   field_image_article:
@@ -1399,7 +1413,8 @@
   field_pretty_url:
     value: "interferon"
   field_public_use: 1
-  field_search_engine_restrictions: 0
+  field_search_engine_restrictions:
+    value: IncludeSearch
   field_date_posted:
     value: "2018-04-01"
   field_image_article:
@@ -1456,7 +1471,8 @@
   field_pretty_url:
     value: "precision-prevention-chanock"
   field_public_use: 1
-  field_search_engine_restrictions: 0
+  field_search_engine_restrictions:
+    value: IncludeSearch
   field_date_posted:
     value: "2016-05-26"
   field_image_article:
@@ -1531,7 +1547,8 @@
   field_pretty_url:
     value: "early-stage-lung-cancer-biomarker"
   field_public_use: 1
-  field_search_engine_restrictions: 0
+  field_search_engine_restrictions:
+    value: IncludeSearch
   field_date_posted:
     value: "2019-01-03"
   field_image_article:
@@ -1610,7 +1627,8 @@
   field_pretty_url:
     value: "new-december-2018"
   field_public_use: 1
-  field_search_engine_restrictions: 0
+  field_search_engine_restrictions:
+    value: IncludeSearch
   field_date_posted:
     value: "2018-12-28"
   field_image_article:
@@ -1670,7 +1688,8 @@
   field_pretty_url:
     value: "cancer-risk-total-diet"
   field_public_use: 1
-  field_search_engine_restrictions: 0
+  field_search_engine_restrictions:
+    value: IncludeSearch
   field_date_posted:
     value: "2019-01-01"
   field_image_article:
@@ -1734,7 +1753,8 @@
   field_pretty_url:
     value: "fda-lenvatinib"
   field_public_use: 1
-  field_search_engine_restrictions: 0
+  field_search_engine_restrictions:
+    value: IncludeSearch
   field_date_posted:
     value: "2015-03-02"
   field_image_article:
@@ -1792,7 +1812,8 @@
   field_pretty_url:
     value: "pancreatic-cancer-targeting-kras-indirectly"
   field_public_use: 1
-  field_search_engine_restrictions: 0
+  field_search_engine_restrictions:
+    value: IncludeSearch
   field_date_posted:
     value: "2019-06-05"
   field_image_article:

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/204_blog_post_hpv_vaccine.content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/204_blog_post_hpv_vaccine.content.yml
@@ -114,7 +114,8 @@
   field_pretty_url:
     value: "hpv-vaccine-presidents-cancer-panel-improving-uptake"
   field_public_use: 1
-  field_search_engine_restrictions: 0
+  field_search_engine_restrictions:
+    value: IncludeSearch
   field_related_resources:
 
     - entity: 'paragraph'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/205_blog_post_vitamin_d.content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/205_blog_post_vitamin_d.content.yml
@@ -104,7 +104,8 @@
   field_pretty_url__ES:
     value: "vitamina-d-complemento-cancer-prevencion"
   field_public_use: 1
-  field_search_engine_restrictions: 0
+  field_search_engine_restrictions:
+    value: IncludeSearch
   field_related_resources:
     - entity: 'paragraph'
       type: "cgov_internal_link"

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/206_blog_post_NCI_director_d.content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/206_blog_post_NCI_director_d.content.yml
@@ -74,7 +74,8 @@
   field_pretty_url:
     value: "transition-lowy-nci-acting-director"
   field_public_use: 1
-  field_search_engine_restrictions: 0
+  field_search_engine_restrictions:
+    value: IncludeSearch
   field_citation:
     - entity: 'paragraph'
       type: "cgov_citation"

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/300_press_release.content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/300_press_release.content.yml
@@ -188,6 +188,7 @@
         crop_wrapper:
           freeform:
             crop_container:
+              values:
                 crop_applied: 1
                 x: 0
                 y: 0

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/biography-jennifer-loukissas.content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/biography-jennifer-loukissas.content.yml
@@ -95,4 +95,5 @@
           - 'media'
           - bundle: 'cgov_image'
             name: 'Jennifer K. Loukissas, M.P.P.'
-  field_search_engine_restrictions: 0
+  field_search_engine_restrictions:
+    value: IncludeSearch

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/biography-stephen-chanock.content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/biography-stephen-chanock.content.yml
@@ -77,8 +77,6 @@
     value: "NCIChanock"
   field_scientific_publications:
     value: "https://dceg2.cancer.gov/cgi-bin-pubsearch/pubsearch/index.pl?EntryLimit=0&branch=ALL&searchTxtAuth=chanock%20s&authorOption=exact&pi=0010114442"
-  field_display_bio_press_info:
-    value: 1
   field_date_posted:
     value: "2019-02-07"
   field_date_reviewed:
@@ -102,4 +100,5 @@
           - 'media'
           - bundle: 'cgov_image'
             name: 'Stephen J. Chanock, M.D.'
-  field_search_engine_restrictions: 0
+  field_search_engine_restrictions:
+    value: IncludeSearch

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/src/Service/CgovYamlContentEventSubscriber.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/src/Service/CgovYamlContentEventSubscriber.php
@@ -165,7 +165,7 @@ class CgovYamlContentEventSubscriber implements EventSubscriberInterface {
       $fields[$key] = $this->translateParagraphs($value);
     }
 
-    $isParagraph = $fields['entity'] === 'paragraph';
+    $isParagraph = array_key_exists('entity', $fields) && $fields['entity'] === 'paragraph';
     if ($isParagraph) {
       $fields = $this->createParagraph($fields);
     }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,17 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!-- TODO set checkForUnintentionallyCoveredCode="true" once https://www.drupal.org/node/2626832 is resolved. -->
 <!-- PHPUnit expects functional tests to be run with either a privileged user
  or your current system user. See core/tests/README.md and
  https://www.drupal.org/node/2116263 for details.
 -->
-<phpunit bootstrap="docroot/core/tests/bootstrap.php" colors="true"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         bootstrap="docroot/core/tests/bootstrap.php"
+         colors="true"
          beStrictAboutTestsThatDoNotTestAnything="true"
          beStrictAboutOutputDuringTests="true"
          beStrictAboutChangesToGlobalState="true"
          failOnWarning="true"
          printerClass="\Drupal\Tests\Listeners\HtmlOutputPrinter"
-         cacheResult="false">
+         cacheResult="false"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory>./includes</directory>
+      <directory>./lib</directory>
+      <directory>./modules</directory>
+      <directory>../modules</directory>
+      <directory>../sites</directory>
+    </include>
+    <exclude>
+      <directory>*/tests/*</directory>
+      <directory>*/Tests/*</directory>
+    </exclude>
+  </coverage>
   <php>
     <!-- Set error reporting to E_ALL. -->
     <ini name="error_reporting" value="32767"/>
@@ -53,18 +68,4 @@
     </listener>
   </listeners -->
   <!-- Filter for coverage reports. -->
-  <filter>
-    <whitelist>
-      <directory>./includes</directory>
-      <directory>./lib</directory>
-      <directory>./modules</directory>
-      <directory>../modules</directory>
-      <directory>../sites</directory>
-      <!-- Exclude all test modules, tests etc -->
-      <exclude>
-        <directory>*/tests/*</directory>
-        <directory>*/Tests/*</directory>
-      </exclude>
-     </whitelist>
-  </filter>
 </phpunit>


### PR DESCRIPTION
- Updates Acquia Pipelines
- Updates Docker
- Removes json PHP module which is now core
- Updated php-dom-wrapper to work with PHP 8.0
- Fixed an error in our YAML Content subscriber that was incorrectly trying to access a key of an array without checking first.
- Update press release content to add values key to object that is required to be there. The underlying module code expects the key to be there. This was most likely just quietly not working before.
- Bad YAML content failed to set field_search_engine_restrictions correctly. It is unknown why cgov_metatag.module worked with the 0 value with PHP 7 vs PHP 8 failing. This would most likely be something with the Field loading or entity interface that is behaving differently with PHP 8.
- Updates phpunit.xml schema