### PR TITLE
(#3513) Add CTHP card title field

### DIFF
--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/pdq_cis_hp_acupuncture.content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/pdq_cis_hp_acupuncture.content.yml
@@ -21,6 +21,8 @@
   field_date_updated:
     value: '2021-06-23'
   field_browser_title:
+    value: 'Acupuncture (PDQ®)'
+  field_cthp_card_title:
     value: 'Acupuncture'
   field_page_description:
     value: 'Acupuncture is a complementary therapy used by cancer patients to manage symptoms related to cancer and its treatment. Get detailed information about acupuncture and its use as a complementary therapy in cancer in this summary for clinicians.'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/pdq_cis_hp_adult_treatment.content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/pdq_cis_hp_adult_treatment.content.yml
@@ -21,6 +21,8 @@
   field_date_updated:
     value: '2018-11-02'
   field_browser_title:
+    value: 'Breast Cancer Treatment (PDQ®)'
+  field_cthp_card_title:
     value: 'Breast Cancer Treatment'
   field_page_description:
     value: 'Breast cancer treatment commonly includes various combinations of surgery, radiation therapy, chemotherapy, and hormone therapy. Prognosis and selection of therapy is influenced by clinical and pathology features. Get detailed information about breast cancer in this summary for clinicians.'
@@ -893,6 +895,8 @@
   field_date_updated__ES:
     value: '2018-06-15'
   field_browser_title__ES:
+    value: 'Tratamiento del cáncer de seno (mama) (PDQ®)'
+  field_cthp_card_title__ES:
     value: 'Tratamiento del cáncer de seno (mama)'
   field_page_description__ES:
     value: 'Resumen de información revisada por expertos acerca del tratamiento del cáncer de seno (mama).'
@@ -1441,6 +1445,8 @@
   field_date_updated:
     value: '2018-08-17'
   field_browser_title:
+    value: 'Gastric Cancer Treatment (PDQ®)'
+  field_cthp_card_title:
     value: 'Gastric Cancer Treatment'
   field_page_description:
     value: 'Gastric cancer treatment options depend on extent of disease and may include radical surgery, chemotherapy, radiation, and immunotherapy. Get detailed information about the diagnosis, treatment, and prognosis of newly diagnosed and recurrent gastric cancer in this clinician summary. '
@@ -1721,6 +1727,8 @@
   field_date_updated__ES:
     value: '2018-11-08'
   field_browser_title__ES:
+    value: 'Tratamiento del cáncer de estómago (PDQ®)'
+  field_cthp_card_title__ES:
     value: 'Tratamiento del cáncer de estómago'
   field_page_description__ES:
     value: 'Resumen de información revisada por expertos acerca del tratamiento del cáncer de estómago. '
@@ -2353,6 +2361,8 @@
   field_date_updated:
     value: '2018-09-12'
   field_browser_title:
+    value: 'Merkel Cell Carcinoma Treatment (PDQ®)'
+  field_cthp_card_title:
     value: 'Merkel Cell Carcinoma Treatment'
   field_page_description:
     value: 'Merkel cell carcinoma treatment options include surgery, radiation therapy, and chemotherapy. Get detailed information about the diagnosis and treatment of newly diagnosed and recurrent Merkel cell carcinoma in this summary for clinicians. '
@@ -2502,6 +2512,8 @@
   field_date_updated__ES:
     value: '2018-11-15'
   field_browser_title__ES:
+    value: 'Tratamiento del carcinoma de células de Merkel (PDQ®)'
+  field_cthp_card_title__ES:
     value: 'Tratamiento del carcinoma de células de Merkel'
   field_page_description__ES:
     value: 'Resumen de información revisada por expertos acerca del tratamiento del carcinoma de células de Merkel.'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/pdq_cis_hp_genetics.content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/pdq_cis_hp_genetics.content.yml
@@ -21,6 +21,8 @@
   field_date_updated:
     value: '2018-07-20'
   field_browser_title:
+    value: 'Genetics of Breast and Gynecologic Cancers (PDQ®)'
+  field_cthp_card_title:
     value: 'Genetics of Breast and Gynecologic Cancers'
   field_page_description:
     value: 'Genetics of Breast and Gynecologic Cancers includes information on BRCA1 and BRCA2 variants (breast and ovarian cancer) and Lynch syndrome (endometrial cancer). Get more information about hereditary breast and gynecologic cancer syndromes in this clinician summary.'
@@ -848,6 +850,8 @@
   field_date_updated:
     value: '2018-06-13'
   field_browser_title:
+    value: 'Genetics of Prostate Cancer (PDQ®)'
+  field_cthp_card_title:
     value: 'Genetics of Prostate Cancer'
   field_page_description:
     value: 'Familial prostate cancer is associated with certain inherited gene mutations (variants). Learn about the hereditary prostate cancer genes, genetic testing, clinical management, and psychosocial issues in this expert-reviewed summary.'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/pdq_cis_hp_iact.content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/pdq_cis_hp_iact.content.yml
@@ -21,6 +21,8 @@
   field_date_updated:
     value: '2017-12-13'
   field_browser_title:
+    value: 'High-Dose Vitamin C (PDQ®)'
+  field_cthp_card_title:
     value: 'High-Dose Vitamin C'
   field_page_description:
     value: 'High-dose vitamin C, with and without conventional cancer therapies, appeared promising in early studies and was well tolerated. However, these studies have several limitations due to lack of rigor in trial design. Get detailed information about high-dose vitamin C in cancer in this clinician summary.'
@@ -142,6 +144,8 @@
   field_date_updated__ES:
     value: '2018-01-18'
   field_browser_title__ES:
+    value: 'Dosis altas de vitamina C (PDQ®)'
+  field_cthp_card_title__ES:
     value: 'Dosis altas de vitamina C'
   field_page_description__ES:
     value: 'Resumen de información revisada por expertos sobre el uso de dosis altas de vitamina C como tratamiento para personas con cáncer.'
@@ -262,6 +266,8 @@
   field_date_updated:
     value: '2018-10-05'
   field_browser_title:
+    value: 'Mistletoe Extracts (PDQ®)'
+  field_cthp_card_title:
     value: 'Mistletoe Extracts'
   field_page_description:
     value: 'Mistletoe, a semiparasitic plant that grows on several types of trees such as apple, oak, pine and elm, is commonly used in cancer patients in Europe. Read about laboratory and human studies of extracts, such as Iscador and Eurixor, and their effects on quality of life, survival and symptom relief in this expert-review'
@@ -422,6 +428,8 @@
   field_date_updated__ES:
     value: '2018-11-14'
   field_browser_title__ES:
+    value: 'Extractos de muérdago (PDQ®)'
+  field_cthp_card_title__ES:
     value: 'Extractos de muérdago'
   field_page_description__ES:
     value: 'Resumen de información revisada por expertos sobre el uso de los extractos de muérdago como tratamiento para personas con cáncer.'
@@ -893,6 +901,8 @@
   field_date_updated:
     value: '2018-08-23'
   field_browser_title:
+    value: 'Cartilage (Bovine and Shark) (PDQ®)'
+  field_cthp_card_title:
     value: 'Cartilage (Bovine and Shark)'
   field_page_description:
     value: 'Cartilage (bovine and shark) has been studied as a treatment for people with cancer and other conditions for more than 30 years. Few human studies of cartilage in cancer have been reported to date, and the results are inconclusive. Get detailed information in this clinician summary.'
@@ -1395,6 +1405,8 @@
   field_date_updated__ES:
     value: '2017-07-10'
   field_browser_title__ES:
+    value: 'Cartílago (bovino y de tiburón) (PDQ®)'
+  field_cthp_card_title__ES:
     value: 'Cartílago (bovino y de tiburón)'
   field_page_description__ES:
     value: 'Resumen de información revisada por expertos sobre el uso de cartílago bovino y de tiburón como tratamiento para personas con cáncer. Nota: la información contenida en este sumario ya no se actualiza y se ofrece solo con fines de consulta.'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/pdq_cis_hp_ped_treatment.content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/pdq_cis_hp_ped_treatment.content.yml
@@ -21,6 +21,8 @@
   field_date_updated:
     value: '2018-09-28'
   field_browser_title:
+    value: 'Childhood Brain Stem Glioma Treatment (PDQ®)'
+  field_cthp_card_title:
     value: 'Childhood Brain Stem Glioma Treatment'
   field_page_description:
     value: 'Childhood brain stem glioma presents as a diffuse intrinsic pontine glioma (DIPG; a fast-growing tumor that is difficult to treat and has a poor prognosis) or a focal glioma (grows more slowly, is easier to treat, and has a better prognosis). Learn about the diagnosis, cellular classification, staging, treatment, and c'
@@ -182,6 +184,8 @@
   field_date_updated__ES:
     value: '2017-08-15'
   field_browser_title__ES:
+    value: 'Tumores de encéfalo y de médula espinal infantiles (PDQ®)'
+  field_cthp_card_title__ES:
     value: 'Tumores de encéfalo y de médula espinal infantiles'
   field_page_description__ES:
     value: 'Resumen de información revisada por expertos acerca del tratamiento de varios tumores de encéfalo infantiles.'
@@ -308,6 +312,8 @@
   field_date_updated:
     value: '2018-08-22'
   field_browser_title:
+    value: 'Retinoblastoma Treatment (PDQ®)'
+  field_cthp_card_title:
     value: 'Retinoblastoma Treatment'
   field_page_description:
     value: 'Retinoblastoma treatment is tailored and uses treatment options including enucleation, local treatments, chemotherapy, and radiation therapy. Get detailed treatment information for newly diagnosed and recurrent retinoblastoma in this summary for clinicians.'
@@ -509,6 +515,8 @@
   field_date_updated__ES:
     value: '2018-09-26'
   field_browser_title__ES:
+    value: 'Tratamiento del retinoblastoma (PDQ®)'
+  field_cthp_card_title__ES:
     value: 'Tratamiento del retinoblastoma'
   field_page_description__ES:
     value: 'Resumen de información revisada por expertos acerca del tratamiento del retinoblastoma en niños.'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/pdq_cis_hp_prevention.content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/pdq_cis_hp_prevention.content.yml
@@ -21,6 +21,8 @@
   field_date_updated:
     value: '2018-09-14'
   field_browser_title:
+    value: 'Breast Cancer Prevention (PDQ®)'
+  field_cthp_card_title:
     value: 'Breast Cancer Prevention'
   field_page_description:
     value: 'Risk factors for breast cancer are female sex and advancing age, inherited risk, breast density, obesity, alcohol consumption, and exposure to ionizing radiation. Interventions to prevent breast cancer include chemoprevention (e.g. SERMs, AIs), risk-reducing surgery (e.g. mastectomy, oophorectomy). Review the evidenc'
@@ -180,6 +182,8 @@
   field_date_updated__ES:
     value: '2018-08-24'
   field_browser_title__ES:
+    value: 'Prevención del cáncer de seno (mama) (PDQ®)'
+  field_cthp_card_title__ES:
     value: 'Prevención del cáncer de seno (mama)'
   field_page_description__ES:
     value: 'Sumario de información revisada por expertos sobre factores que influyen en el riesgo de presentar cáncer de mama y sobre las investigaciones dirigidas a la prevención de esta enfermedad.'
@@ -367,6 +371,8 @@
   field_date_updated:
     value: '2018-03-02'
   field_browser_title:
+    value: 'Lung Cancer Prevention (PDQ®)'
+  field_cthp_card_title:
     value: 'Lung Cancer Prevention'
   field_page_description:
     value: 'Lung cancer prevention strategies include quitting or avoiding exposure to smoking, occupational carcinogens, and radon. Get detailed information about risk factors and lung cancer prevention in this summary for clinicians. '
@@ -528,6 +534,8 @@
   field_date_updated__ES:
     value: '2018-03-19'
   field_browser_title__ES:
+    value: 'Prevención del cáncer de pulmón (PDQ®)'
+  field_cthp_card_title__ES:
     value: 'Prevención del cáncer de pulmón'
   field_page_description__ES:
     value: 'Sumario de información revisada por expertos sobre factores que influyen en el riesgo de presentar cáncer de pulmón y sobre las investigaciones dirigidas a la prevención de esta enfermedad.'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/pdq_cis_hp_screening.content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/pdq_cis_hp_screening.content.yml
@@ -21,6 +21,8 @@
   field_date_updated:
     value: '2018-10-08'
   field_browser_title:
+    value: 'Breast Cancer Screening (PDQ®)'
+  field_cthp_card_title:
     value: 'Breast Cancer Screening'
   field_page_description:
     value: 'Breast cancer screening most often includes mammography but can also include ultrasound, MRI, and other tests. Get detailed information about the potential benefits and harms of the tests used to screen for breast cancer in this summary for clinicians.'
@@ -323,6 +325,8 @@
   field_date_updated__ES:
     value: '2018-06-19'
   field_browser_title__ES:
+    value: 'Exámenes de detección del cáncer de seno (mama) (PDQ®)'
+  field_cthp_card_title__ES:
     value: 'Exámenes de detección del cáncer de seno (mama)'
   field_page_description__ES:
     value: 'Sumario de información revisada por expertos sobre pruebas que se usan para detectar el cáncer de mama.'
@@ -541,6 +545,8 @@
   field_date_updated:
     value: '2018-02-02'
   field_browser_title:
+    value: 'Lung Cancer Screening (PDQ®)'
+  field_cthp_card_title:
     value: 'Lung Cancer Screening'
   field_page_description:
     value: 'Lung cancer screening with low-dose spiral CT scans has been shown to decrease the risk of dying from lung cancer in heavy smokers. Screening with chest x-ray or sputum cytology does not reduce lung cancer mortality. Get detailed information about lung cancer screening in this clinician summary.'
@@ -658,6 +664,8 @@
   field_date_updated__ES:
     value: '2018-02-16'
   field_browser_title__ES:
+    value: 'Exámenes de detección del cáncer de pulmón (PDQ®)'
+  field_cthp_card_title__ES:
     value: 'Exámenes de detección del cáncer de pulmón'
   field_page_description__ES:
     value: 'Resumen de información revisada por expertos acerca de las pruebas utilizadas para detectar o vigilar el cáncer de pulmón.'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/pdq_cis_hp_supportive.content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/pdq_cis_hp_supportive.content.yml
@@ -21,6 +21,8 @@
   field_date_updated:
     value: '2017-06-29'
   field_browser_title:
+    value: 'Fatigue (PDQ®)'
+  field_cthp_card_title:
     value: 'Fatigue'
   field_page_description:
     value: 'Fatigue is the most common side effect of cancer treatment, but it can also be a presenting symptom. Fatigue has a negative impact on all areas of function and can last well beyond treatment. Get comprehensive information about fatigue and interventions in this summary for clinicians.'
@@ -416,6 +418,8 @@
   field_date_updated__ES:
     value: '2017-07-20'
   field_browser_title__ES:
+    value: 'Fatiga (PDQ®)'
+  field_cthp_card_title__ES:
     value: 'Fatiga'
   field_page_description__ES:
     value: 'Resumen de información revisada por expertos acerca de la fatiga, una afección caracterizada por extremo cansancio e incapacidad para funcionar por la falta de energía, que a menudo se observa como una complicación del cáncer y su tratamiento. '
@@ -843,6 +847,8 @@
   field_date_updated:
     value: '2016-05-05'
   field_browser_title:
+    value: 'Pruritus (PDQ®)'
+  field_cthp_card_title:
     value: 'Pruritus'
   field_page_description:
     value: 'Pruritus (itching of the skin) can be a complication of cancer or its treatment. Get detailed information about the etiology, assessment, and interventions for pruritus in this summary for clinicians.'
@@ -1065,6 +1071,8 @@
   field_date_updated__ES:
     value: '2016-07-21'
   field_browser_title__ES:
+    value: 'Prurito (PDQ®)'
+  field_cthp_card_title__ES:
     value: 'Prurito'
   field_page_description__ES:
     value: 'Resumen de información revisada por expertos acerca del prurito (picazón de la piel) como complicación del cáncer y su tratamiento. Se consideran los abordajes de manejo y tratamiento del prurito.'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/pdq_cis_patient_adult_treatment.content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/pdq_cis_patient_adult_treatment.content.yml
@@ -22,6 +22,8 @@
     value: '2018-10-19'
   field_browser_title:
     value: 'Breast Cancer Treatment'
+  field_cthp_card_title:
+    value: 'Breast Cancer Treatment'
   field_page_description:
     value: 'Breast cancer treatment depends on several factors and can include combinations of surgery, chemotherapy, radiation, hormone, and targeted therapy. Learn more about how breast cancer is diagnosed and treated in this expert-reviewed summary.'
   field_public_use:
@@ -285,6 +287,8 @@
     value: '2018-11-02'
   field_browser_title__ES:
     value: 'Tratamiento del cáncer de seno (mama)'
+  field_cthp_card_title__ES:
+    value: 'Tratamiento del cáncer de seno (mama)'
   field_page_description__ES:
     value: 'Resumen de información revisada por expertos acerca del tratamiento del cáncer de seno (mama).'
   field_public_use__ES:
@@ -486,6 +490,8 @@
     value: '2018-10-25'
   field_browser_title:
     value: 'Gastric Cancer Treatment'
+  field_cthp_card_title:
+    value: 'Gastric Cancer Treatment'
   field_page_description:
     value: 'Gastric (stomach) cancer treatment can include surgery, chemotherapy, radiation therapy, chemoradiation, and targeted therapy. Learn more about the diagnosis, treatment, and prognosis of newly diagnosed and recurrent gastric cancer in this expert-reviewed summary.'
   field_public_use:
@@ -619,6 +625,8 @@
     value: '2018-11-08'
   field_browser_title__ES:
     value: 'Tratamiento del cáncer de estómago'
+  field_cthp_card_title__ES:
+    value: 'Tratamiento del cáncer de estómago'
   field_page_description__ES:
     value: 'Resumen de información revisada por expertos acerca del tratamiento del cáncer de estómago.'
   field_public_use__ES:
@@ -751,6 +759,8 @@
     value: '2018-10-18'
   field_browser_title:
     value: 'Merkel Cell Carcinoma Treatment'
+  field_cthp_card_title:
+    value: 'Merkel Cell Carcinoma Treatment'
   field_page_description:
     value: 'Merkel cell carcinoma is a rare type of skin cancer that usually starts in areas of skin exposed to the sun. Sun exposure and having a weak immune system can affect the risk of Merkel cell carcinoma. Merkel cell carcinoma usually appears as a single painless lump on sun-exposed skin. Find out more about risk factors,'
   field_public_use:
@@ -878,6 +888,8 @@
   field_date_updated__ES:
     value: '2018-05-04'
   field_browser_title__ES:
+    value: 'Carcinoma de células de Merkel'
+  field_cthp_card_title__ES:
     value: 'Carcinoma de células de Merkel'
   field_page_description__ES:
     value: 'Resumen de información revisada por expertos acerca del tratamiento del carcinoma de células de Merkel.'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/pdq_cis_patient_hydrazine-sulfate.content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/pdq_cis_patient_hydrazine-sulfate.content.yml
@@ -22,6 +22,8 @@
     value: '2015-12-11'
   field_browser_title:
     value: 'Hydrazine Sulfate'
+  field_cthp_card_title:
+    value: 'Hydrazine Sulfate'
   field_page_description:
     value: 'Hydrazine sulfate has shown no anticancer activity in randomized clinical trials. It was reported in some clinical trials to be helpful in treating poor appetite and weight loss due to cancer. Learn more about hydrazine sulfate as a treatment for people with cancer in this expert-reviewed summary. '
   field_public_use:

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/pdq_cis_patient_iact.content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/pdq_cis_patient_iact.content.yml
@@ -22,6 +22,8 @@
     value: '2018-06-21'
   field_browser_title:
     value: 'High-Dose Vitamin C'
+  field_cthp_card_title:
+    value: 'High-Dose Vitamin C'
   field_page_description:
     value: 'High-dose vitamin C, in some studies, has shown improved quality of life and fewer side effects in some cancer patients. The U.S. Food and Drug Administration has not approved its use as a treatment for cancer. Learn more in this expert-reviewed summary. '
   field_public_use:
@@ -136,6 +138,8 @@
   field_date_updated__ES:
     value: '2018-07-18'
   field_browser_title__ES:
+    value: 'Dosis altas de vitamina C'
+  field_cthp_card_title__ES:
     value: 'Dosis altas de vitamina C'
   field_page_description__ES:
     value: 'Resumen de información revisada por expertos sobre el uso de dosis altas de vitamina C como tratamiento para personas con cáncer.'
@@ -266,6 +270,8 @@
   field_date_updated:
     value: '2018-04-12'
   field_browser_title:
+    value: 'Mistletoe Extracts'
+  field_cthp_card_title:
     value: 'Mistletoe Extracts'
   field_page_description:
     value: 'Mistletoe extracts have been studied as a complementary and alternative medicine for many illnesses including cancer. Read about the use of mistletoe therapy in cancer patients and the results of clinical trials in this expert-reviewed summary.'
@@ -401,6 +407,8 @@
   field_date_updated__ES:
     value: '2018-09-21'
   field_browser_title__ES:
+    value: 'Extractos de muérdago'
+  field_cthp_card_title__ES:
     value: 'Extractos de muérdago'
   field_page_description__ES:
     value: 'Resumen de información revisada por expertos sobre el uso de los extractos de muérdago como tratamiento para personas con cáncer.'
@@ -545,6 +553,8 @@
     value: '2017-09-07'
   field_browser_title:
     value: 'Cartilage (Bovine and Shark)'
+  field_cthp_card_title:
+    value: 'Cartilage (Bovine and Shark)'
   field_page_description:
     value: 'Cartilage (bovine and shark) has been studied as a treatment for people with cancer and other conditions for more than 30 years. Results of human studies have been mixed. Learn more in this expert-reviewed summary.'
   field_public_use:
@@ -661,6 +671,8 @@
   field_date_updated__ES:
     value: '2017-09-15'
   field_browser_title__ES:
+    value: 'Cartílago (bovino y de tiburón)'
+  field_cthp_card_title__ES:
     value: 'Cartílago (bovino y de tiburón)'
   field_page_description__ES:
     value: 'Resumen de información revisada por expertos sobre el uso de cartílago bovino y de tiburón como tratamiento para personas con cáncer. Nota: la información contenida en este sumario ya no se actualiza y se ofrece solo con fines de consulta.'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/pdq_cis_patient_ped_treatment.content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/pdq_cis_patient_ped_treatment.content.yml
@@ -22,6 +22,8 @@
     value: '2018-07-05'
   field_browser_title:
     value: 'Childhood Brain Stem Glioma Treatment'
+  field_cthp_card_title:
+    value: 'Childhood Brain Stem Glioma Treatment'
   field_page_description:
     value: 'Childhood brain stem glioma treatment options can include surgery, radiation therapy, chemotherapy, cerebral spinal fluid diversion, observation, and targeted therapy. Learn more about newly diagnosed and recurrent childhood brain stem glioma in this expert-reviewed summary. '
   field_public_use:
@@ -213,6 +215,8 @@
     value: '2018-07-12'
   field_browser_title__ES:
     value: 'Tratamiento de tumores de encéfalo y médula espinal infantiles'
+  field_cthp_card_title__ES:
+    value: 'Tratamiento de tumores de encéfalo y médula espinal infantiles'
   field_page_description__ES:
     value: 'Resumen de información revisada por expertos acerca del tratamiento de tumores de encéfalo infantiles. '
   field_public_use__ES:
@@ -384,6 +388,8 @@
     value: '2018-01-29'
   field_browser_title:
     value: 'Retinoblastoma Treatment'
+  field_cthp_card_title:
+    value: 'Retinoblastoma Treatment'
   field_page_description:
     value: 'Retinoblastoma treatment may include cryosurgery, laser therapy (thermotherapy), chemotherapy, radiation therapy, high-dose chemotherapy with stem cell rescue, and sometimes surgery. Learn more about newly diagnosed and recurrent retinoblastoma in this expert-reviewed summary.'
   field_public_use:
@@ -548,6 +554,8 @@
   field_date_updated__ES:
     value: '2018-02-08'
   field_browser_title__ES:
+    value: 'Tratamiento del retinoblastoma'
+  field_cthp_card_title__ES:
     value: 'Tratamiento del retinoblastoma'
   field_page_description__ES:
     value: 'Resumen de información revisada por expertos acerca del tratamiento del retinoblastoma en niños.'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/pdq_cis_patient_prevention.content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/pdq_cis_patient_prevention.content.yml
@@ -22,6 +22,8 @@
     value: '2018-10-19'
   field_browser_title:
     value: 'Breast Cancer Prevention'
+  field_cthp_card_title:
+    value: 'Breast Cancer Prevention'
   field_page_description:
     value: 'Breast cancer prevention strategies include avoiding known risks, having a healthy lifestyle, and medications or surgery for those at high risk. Learn more about breast cancer prevention, risks and protective factors, and how to estimate risk in this expert-reviewed summary.'
   field_public_use:
@@ -144,6 +146,8 @@
     value: '2018-11-09'
   field_browser_title__ES:
     value: 'Prevención del cáncer de seno (mama)'
+  field_cthp_card_title__ES:
+    value: 'Prevención del cáncer de seno (mama)'
   field_page_description__ES:
     value: 'Sumario de información revisada por expertos sobre factores que influyen en el riesgo de presentar cáncer de mama y sobre las investigaciones dirigidas a la prevención de esta enfermedad.'
   field_public_use__ES:
@@ -230,6 +234,8 @@
   field_date_updated:
     value: '2017-12-06'
   field_browser_title:
+    value: 'Lung Cancer Prevention'
+  field_cthp_card_title:
     value: 'Lung Cancer Prevention'
   field_page_description:
     value: 'Lung cancer prevention approaches include avoiding exposure to risk factors like tobacco smoke, radon, radiation, asbestos, and other substances. Learn more about preventing lung cancer in this expert-reviewed summary.'
@@ -370,6 +376,8 @@
   field_date_updated__ES:
     value: '2018-07-20'
   field_browser_title__ES:
+    value: 'Prevención del cáncer de pulmón'
+  field_cthp_card_title__ES:
     value: 'Prevención del cáncer de pulmón'
   field_page_description__ES:
     value: 'Sumario de información revisada por expertos sobre factores que influyen en el riesgo de presentar cáncer de pulmón y sobre las investigaciones dirigidas a la prevención de esta enfermedad.'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/pdq_cis_patient_screening.content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/pdq_cis_patient_screening.content.yml
@@ -22,6 +22,8 @@
     value: '2018-10-26'
   field_browser_title:
     value: 'Breast Cancer Screening'
+  field_cthp_card_title:
+    value: 'Breast Cancer Screening'
   field_page_description:
     value: 'Breast cancer screening is performed using mammogram, clinical breast exam (CBE), and MRI (magnetic resonance imaging) tests. Learn about these and other tests that have been studied to detect or screen for breast cancer in this expert-reviewed and evidence-based summary. '
   field_public_use:
@@ -147,6 +149,8 @@
     value: '2018-11-15'
   field_browser_title__ES:
     value: 'Exámenes de detección del cáncer de seno (mama)'
+  field_cthp_card_title__ES:
+    value: 'Exámenes de detección del cáncer de seno (mama)'
   field_page_description__ES:
     value: 'Sumario de información revisada por expertos sobre exámenes que se usan para detectar el cáncer de mama.'
   field_public_use__ES:
@@ -236,6 +240,8 @@
   field_date_updated:
     value: '2017-06-16'
   field_browser_title:
+    value: 'Lung Cancer Screening'
+  field_cthp_card_title:
     value: 'Lung Cancer Screening'
   field_page_description:
     value: 'Lung cancer screening with low-dose spiral CT scans has been shown to decrease the risk of dying from lung cancer in heavy smokers. Learn more about tests to detect lung cancer and their potential benefits and harms in this expert-reviewed summary.'
@@ -365,6 +371,8 @@
   field_date_updated__ES:
     value: '2018-07-13'
   field_browser_title__ES:
+    value: 'Exámenes de detección del cáncer de pulmón'
+  field_cthp_card_title__ES:
     value: 'Exámenes de detección del cáncer de pulmón'
   field_page_description__ES:
     value: 'Resumen de información revisada por expertos acerca de las pruebas utilizadas para detectar o vigilar el cáncer de pulmón.'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/pdq_cis_patient_supportive.content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/pdq_cis_patient_supportive.content.yml
@@ -22,6 +22,8 @@
     value: '2017-06-30'
   field_browser_title:
     value: 'Fatigue'
+  field_cthp_card_title:
+    value: 'Fatigue'
   field_page_description:
     value: 'Fatigue (extreme tiredness or lack of energy) is a common side effect of cancer or its treatment. Fatigue can decrease a patient''s quality of life, and continue long after treatment. Learn more about fatigue and ways to manage it in this expert-reviewed information summary.'
   field_public_use:
@@ -175,6 +177,8 @@
     value: '2017-09-28'
   field_browser_title__ES:
     value: 'Fatiga'
+  field_cthp_card_title__ES:
+    value: 'Fatiga'
   field_page_description__ES:
     value: 'Resumen de información revisada por expertos acerca de la fatiga, una afección caracterizada por extremo cansancio e incapacidad para funcionar por la falta de energía, que a menudo se observa como una complicación del cáncer y su tratamiento.'
   field_public_use__ES:
@@ -311,6 +315,8 @@
     value: '2016-06-15'
   field_browser_title:
     value: 'Pruritus'
+  field_cthp_card_title:
+    value: 'Pruritus'
   field_page_description:
     value: 'Pruritus (itching of the skin) can be caused by certain cancers or cancer treatment. Learn more about causes and treatment of pruritus in this expert-reviewed summary.'
   field_public_use:
@@ -410,6 +416,8 @@
   field_date_updated__ES:
     value: '2016-05-19'
   field_browser_title__ES:
+    value: 'Prurito'
+  field_cthp_card_title__ES:
     value: 'Prurito'
   field_page_description__ES:
     value: 'Resumen de información revisada por expertos acerca del prurito (picazón en la piel) como complicación del cáncer o su tratamiento. Se consideran los abordajes de manejo y tratamiento del prurito.'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/svpc_liver-cancer-causes-risk-factors-and-prevention.content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/svpc_liver-cancer-causes-risk-factors-and-prevention.content.yml
@@ -22,6 +22,8 @@
     value: '2021-11-17'
   field_browser_title:
     value: 'Liver Cancer Causes, Risk Factors, and Prevention'
+  field_cthp_card_title:
+    value: 'Liver Cancer Causes, Risk Factors, and Prevention'
   field_page_description:
     value: 'Placeholder'
   field_public_use:
@@ -106,6 +108,8 @@
   field_date_updated__ES:
     value: '2022-02-14'
   field_browser_title__ES:
+    value: 'Causas, factores de riesgo y prevención del cáncer de hígado'
+  field_cthp_card_title__ES:
     value: 'Causas, factores de riesgo y prevención del cáncer de hígado'
   field_page_description__ES:
     value: 'Marcador de posición'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/svpc_liver-cancer-diagnosis.content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/svpc_liver-cancer-diagnosis.content.yml
@@ -22,6 +22,8 @@
     value: '2022-01-12'
   field_browser_title:
     value: 'Liver Cancer Diagnosis'
+  field_cthp_card_title:
+    value: 'Liver Cancer Diagnosis'
   field_page_description:
     value: 'Medical tests that examine the liver and the blood are used to detect and diagnose liver cancer. Learn about liver cancer diagnosis from the nation’s top health experts.'
   field_public_use:
@@ -65,6 +67,8 @@
   field_date_updated__ES:
     value: '2022-02-14'
   field_browser_title__ES:
+    value: 'Diagnóstico de cáncer de hígado'
+  field_cthp_card_title__ES:
     value: 'Diagnóstico de cáncer de hígado'
   field_page_description__ES:
     value: 'Las pruebas médicas que examinan el hígado y la sangre se utilizan para detectar y diagnosticar el cáncer de hígado. Obtenga información sobre el diagnóstico de cáncer de hígado de parte de los principales expertos en salud del país.'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/svpc_liver-cancer-treatment.content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/svpc_liver-cancer-treatment.content.yml
@@ -22,6 +22,8 @@
     value: '2021-11-15'
   field_browser_title:
     value: 'Liver Cancer Treatment'
+  field_cthp_card_title:
+    value: 'Liver Cancer Treatment'
   field_page_description:
     value: 'Treatment of liver cancer in adults depends on the stage. Treatment options include hepatectomy, liver transplant, ablation, electroporation therapy (EPT), embolization therapy, targeted therapy, and/or radiation therapy. Learn more about treatment for the different stages of liver cancer.'
   field_public_use:
@@ -177,6 +179,8 @@
   field_date_updated__ES:
     value: '2022-02-14'
   field_browser_title__ES:
+    value: 'Tratamiento del cáncer de hígado'
+  field_cthp_card_title__ES:
     value: 'Tratamiento del cáncer de hígado'
   field_page_description__ES:
     value: 'El tratamiento del cáncer de hígado en adultos depende del estadio. Las opciones de tratamiento incluyen hepatectomía, trasplante de hígado, ablación, terapia de electroporación (EPT), terapia de embolización, terapia dirigida y/o radioterapia. Obtenga más información sobre el tratamiento para las diferentes etapas del cáncer de hígado.'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/svpc_what-is-liver-cancer.content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/svpc_what-is-liver-cancer.content.yml
@@ -22,6 +22,8 @@
     value: '2022-01-13'
   field_browser_title:
     value: 'What is Liver Cancer?'
+  field_cthp_card_title:
+    value: 'What is Liver Cancer?'
   field_page_description:
     value: 'Primary liver cancer is a disease that forms in the liver. The most common type is hepatocellular carcinoma. Learn about liver cancer, signs, and symptoms from the nation’s top health experts.'
   field_public_use:
@@ -80,6 +82,8 @@
   field_date_updated__ES:
     value: '2022-02-14'
   field_browser_title__ES:
+    value: '¿Qué es el cáncer de hígado?'
+  field_cthp_card_title__ES:
     value: '¿Qué es el cáncer de hígado?'
   field_page_description__ES:
     value: 'El cáncer de hígado primario es una enfermedad que se forma en el hígado. El tipo más común es el carcinoma hepatocelular. Obtenga información sobre el cáncer de hígado, los signos y los síntomas de los principales expertos en salud del país.'

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/README.md
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/README.md
@@ -24,4 +24,4 @@ Loads the editing user interface through a web browser (using `Drupal\Tests\Brow
 
 New fields should be added to [PDQCancerSummaryTest.php](tests/src/Functional/PDQSummaryTest.php) with their existence tested in `testSummaryFieldsExist()`.
 
-Field presence tests require the ID of the UI element from the editing page. These names are based on the field's machine name, the exact rules for generating the filed name varies according to the field type (e.g. the "Short Title" input field has the ID `edit-field-short-title-0-value`. The "Posted Date" date selector has the ID `edit-field-date-posted-0-value-date`). The field names can most easily be found by loading the page and inspecting the HTML.
+Field presence tests require the ID of the UI element from the editing page. These names are based on the field's machine name, the exact rules for generating the filed name varies according to the field type (e.g. the "Browser Title" input field has the ID `edit-field-browser-title-0-value`. The "Posted Date" date selector has the ID `edit-field-date-posted-0-value-date`). The field names can most easily be found by loading the page and inspecting the HTML.

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_form_display.node.pdq_cancer_information_summary.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_form_display.node.pdq_cancer_information_summary.default.yml
@@ -3,6 +3,7 @@ status: true
 dependencies:
   config:
     - field.field.node.pdq_cancer_information_summary.field_browser_title
+    - field.field.node.pdq_cancer_information_summary.field_cthp_card_title
     - field.field.node.pdq_cancer_information_summary.field_date_posted
     - field.field.node.pdq_cancer_information_summary.field_date_updated
     - field.field.node.pdq_cancer_information_summary.field_hhs_syndication
@@ -41,6 +42,14 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_browser_title:
+    type: string_textfield
+    weight: 10
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_cthp_card_title:
     type: string_textfield
     weight: 10
     region: content
@@ -124,11 +133,10 @@ content:
       placeholder: ''
     third_party_settings: {  }
   field_public_use:
-    type: boolean_checkbox
+    type: options_select
     weight: 17
     region: content
-    settings:
-      display_label: true
+    settings: { }
     third_party_settings: {  }
   field_summary_sections:
     type: paragraphs_classic_asymmetric

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_view_display.node.pdq_cancer_information_summary.cthp_guide_card_list_item.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_view_display.node.pdq_cancer_information_summary.cthp_guide_card_list_item.yml
@@ -4,6 +4,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.cthp_guide_card_list_item
     - field.field.node.pdq_cancer_information_summary.field_browser_title
+    - field.field.node.pdq_cancer_information_summary.field_cthp_card_title
     - field.field.node.pdq_cancer_information_summary.field_date_posted
     - field.field.node.pdq_cancer_information_summary.field_date_updated
     - field.field.node.pdq_cancer_information_summary.field_hhs_syndication
@@ -32,6 +33,14 @@ content:
     weight: -20
     region: content
   field_browser_title:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  field_cthp_card_title:
     type: string
     label: hidden
     settings:

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_view_display.node.pdq_cancer_information_summary.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_view_display.node.pdq_cancer_information_summary.default.yml
@@ -3,6 +3,7 @@ status: true
 dependencies:
   config:
     - field.field.node.pdq_cancer_information_summary.field_browser_title
+    - field.field.node.pdq_cancer_information_summary.field_cthp_card_title
     - field.field.node.pdq_cancer_information_summary.field_date_posted
     - field.field.node.pdq_cancer_information_summary.field_date_updated
     - field.field.node.pdq_cancer_information_summary.field_hhs_syndication
@@ -38,6 +39,14 @@ content:
     weight: 0
     region: content
   field_browser_title:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  field_cthp_card_title:
     type: string
     label: above
     settings:

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_view_display.node.pdq_cancer_information_summary.full.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_view_display.node.pdq_cancer_information_summary.full.yml
@@ -4,6 +4,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.full
     - field.field.node.pdq_cancer_information_summary.field_browser_title
+    - field.field.node.pdq_cancer_information_summary.field_cthp_card_title
     - field.field.node.pdq_cancer_information_summary.field_date_posted
     - field.field.node.pdq_cancer_information_summary.field_date_updated
     - field.field.node.pdq_cancer_information_summary.field_hhs_syndication
@@ -45,6 +46,14 @@ content:
       link_to_entity: false
     third_party_settings: {  }
     weight: 101
+    region: content
+  field_cthp_card_title:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 102
     region: content
   field_date_updated:
     type: datetime_default

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_view_display.node.pdq_cancer_information_summary.teaser.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_view_display.node.pdq_cancer_information_summary.teaser.yml
@@ -4,6 +4,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.teaser
     - field.field.node.pdq_cancer_information_summary.field_browser_title
+    - field.field.node.pdq_cancer_information_summary.field_cthp_card_title
     - field.field.node.pdq_cancer_information_summary.field_date_posted
     - field.field.node.pdq_cancer_information_summary.field_date_updated
     - field.field.node.pdq_cancer_information_summary.field_hhs_syndication
@@ -41,6 +42,7 @@ content:
     region: content
 hidden:
   field_browser_title: true
+  field_cthp_card_title: true
   field_date_posted: true
   field_date_updated: true
   field_hhs_syndication: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/field.field.node.pdq_cancer_information_summary.field_cthp_card_title.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/field.field.node.pdq_cancer_information_summary.field_cthp_card_title.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_cthp_card_title
+    - node.type.pdq_cancer_information_summary
+id: node.pdq_cancer_information_summary.field_cthp_card_title
+field_name: field_cthp_card_title
+entity_type: node
+bundle: pdq_cancer_information_summary
+label: 'CTHP Card Title'
+description: 'Title for the Cancer Type Home Page card for this summary.'
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/field.storage.node.field_cthp_card_title.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/field.storage.node.field_cthp_card_title.yml
@@ -1,0 +1,23 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+  enforced:
+    module:
+      - pdq_cancer_information_summary
+id: node.field_cthp_card_title
+field_name: field_cthp_card_title
+entity_type: node
+type: string
+settings:
+  max_length: 100
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/metatag.metatag_defaults.node__pdq_cancer_information_summary.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/metatag.metatag_defaults.node__pdq_cancer_information_summary.yml
@@ -7,7 +7,7 @@ tags:
   canonical_url: '[node:url]'
   content_language: '[node:langcode]'
   description: '[node:field_page_description:value]'
-  title: '[node:title] - [cgov_tokens:cgov-trans-org-name]'
+  title: '[cgov_tokens:cgov-title] - [cgov_tokens:cgov-trans-org-name]'
   dcterms_audience: '[node:field_pdq_audience:value]'
   dcterms_coverage: 'nciglobal,ncienterprise'
   dcterms_issued: '[node:field_date_posted:date:short]'
@@ -18,7 +18,7 @@ tags:
   og_description: '[node:field_page_description:value]'
   og_image: '[cgov_tokens:cgov-og-image]'
   og_site_name: '[cgov_tokens:cgov-og-site-name]'
-  og_title: '[node:title]'
+  og_title: '[node:field_browser_title:value]'
   og_type: Website
   og_url: '[current-page:url]'
   twitter_cards_type: summary

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/pdq_cancer_information_summary.install
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/pdq_cancer_information_summary.install
@@ -294,3 +294,31 @@ function pdq_cancer_information_summary_update_9003(&$sandbox) {
   $config->save();
   \Drupal::logger('pdq_cancer_information_summary')->notice('Installed field_pdq_intro_text on the edit form.');
 }
+
+/**
+ * Add new field for cancer-type home page card titles.
+ */
+function pdq_cancer_information_summary_update_9004(&$sandbox) {
+
+  // Make sure the field is installed.
+  _pdq_cancer_information_summary_install_node_field('field_cthp_card_title');
+
+  // Make sure it shows up on the form.
+  $name = 'core.entity_form_display.node.pdq_cancer_information_summary.default';
+  $config = \Drupal::getContainer()->get('config.factory')->getEditable($name);
+  $content = $config->get('content');
+  $hidden = $config->get('hidden');
+  $weight = $content['field_browser_title']['weight'] ?? 10;
+  $content['field_cthp_card_title'] = [
+    'weight' => $weight,
+    'settings' => ['display_label' => TRUE],
+    'third_party_settings' => [],
+    'type' => 'string_textfield',
+    'region' => 'content',
+  ];
+  unset($hidden['field_cthp_card_title']);
+  $config->set('content', $content);
+  $config->set('hidden', $hidden);
+  $config->save();
+  \Drupal::logger('pdq_cancer_information_summary')->notice('Installed field_cthp_card_title on the edit form.');
+}

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/pdq_cancer_information_summary.module
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/pdq_cancer_information_summary.module
@@ -70,10 +70,10 @@ function _pdq_cis_needs_site_sections(EntityInterface $entity) {
     ->execute();
 
   // If so, and the label used for navigation is unchanged, we're done.
-  $short_title = $entity->get('field_browser_title')->value;
+  $browser_title = $entity->get('field_browser_title')->value;
   foreach ($tids as $tid) {
     $term = Term::load($tid);
-    if ($term->getName() === $short_title) {
+    if ($term->getName() === $browser_title) {
       return FALSE;
     }
   }

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/src/Plugin/rest/resource/PDQResource.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/src/Plugin/rest/resource/PDQResource.php
@@ -165,7 +165,8 @@ class PDQResource extends ResourceBase {
           'summary_type' => $translation->field_pdq_summary_type->value,
           'posted_date' => $translation->field_date_posted->value,
           'updated_date' => $translation->field_date_updated->value,
-          'short_title' => $translation->field_browser_title->value,
+          'browser_title' => $translation->field_browser_title->value,
+          'cthp_card_title' => $translation->field_cthp_card_title->value,
           'description' => $translation->field_page_description->value,
           'public_use' => $translation->field_public_use->value,
           'url' => $translation->field_pdq_url->value,
@@ -284,7 +285,8 @@ class PDQResource extends ResourceBase {
     $node->set('field_pdq_summary_type', $summary['summary_type']);
     $node->set('field_date_posted', $summary['posted_date'] ?? $today);
     $node->set('field_date_updated', $summary['updated_date'] ?? $today);
-    $node->set('field_browser_title', $summary['short_title']);
+    $node->set('field_browser_title', $summary['browser_title']);
+    $node->set('field_cthp_card_title', $summary['cthp_card_title']) ?? $summary['browser_title'];
     $node->set('field_page_description', $summary['description']);
     $node->set('field_summary_sections', $sections);
     $node->set('field_public_use', 1);

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/tests/src/Functional/ApiTest.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/tests/src/Functional/ApiTest.php
@@ -41,16 +41,14 @@ class ApiTest extends BrowserTestBase {
   protected $english = [
     'nid' => NULL,
     'title' => 'Test English Summary',
-    'short_title' => 'Test Short Title',
+    'browser_title' => 'Test Browser Title',
+    'cthp_card_title' => 'Test Card Title',
     'description' => 'Test description',
     'language' => 'en',
     'url' => '/types/lymphoma/hp/adult-hodgkin-treatment-pdq',
     'cdr_id' => 5001,
     'audience' => 'Patients',
     'summary_type' => 'Treatment',
-    // Begin suppressed field.
-    // 'keywords' => 'cancer, treatment',
-    // End suppressed field.
     'posted_date' => '2020-01-01',
     'updated_date' => '2020-01-02',
     'sections' => [
@@ -70,16 +68,14 @@ class ApiTest extends BrowserTestBase {
   protected $spanish = [
     'nid' => NULL,
     'title' => "Resumen en espa\u{f1}ol",
-    'short_title' => "T\u{ed}tulo corto",
+    'browser_title' => "T\u{ed}tulo corto",
+    'cthp_card_title' => 'Hakuna matata',
     'description' => "Descripci\u{f3}n",
     'language' => 'es',
     'url' => '/tipos/linfoma/pro/tratamiento-hodgkin-adultos-pdq',
     'cdr_id' => 5002,
     'audience' => 'Patients',
     'summary_type' => 'Treatment',
-    // Begin suppressed field.
-    // 'keywords' => 'cancer, treatment',
-    // End suppressed field.
     'posted_date' => '2020-01-04',
     'updated_date' => '2020-01-05',
     'sections' => [
@@ -100,13 +96,11 @@ class ApiTest extends BrowserTestBase {
     'audience',
     'cdr_id',
     'description',
-    // Begin suppressed field.
-    // 'keywords',
-    // End suppressed field.
     'posted_date',
     'title',
     'sections',
-    'short_title',
+    'browser_title',
+    'cthp_card_title',
     'summary_type',
     'updated_date',
     'url',
@@ -180,6 +174,7 @@ class ApiTest extends BrowserTestBase {
     $this->english['svpc'] = 1;
     $this->english['suppress_otp'] = 1;
     $this->english['intro_text'] = '<p>Oh, look!</p>';
+    $this->english['cthp_card_title'] = 'No worries!';
     $payload = $this->store($this->english, 200);
     $summary_sections_created += count($this->english['sections']);
     $this->assertEquals($payload['nid'], $nid, 'Uses same node');
@@ -236,12 +231,12 @@ class ApiTest extends BrowserTestBase {
     $this->checkPathauto($this->spanish);
 
     // Make sure changes don't affect the site sections until published.
-    $old_short_title = $this->english['short_title'];
-    $this->english['short_title'] = 'New Short Title';
+    $old_browser_title = $this->english['browser_title'];
+    $this->english['browser_title'] = 'New Browser Title';
     $payload = $this->store($this->english, 200);
     $summary_sections_created += count($this->english['sections']);
     $this->assertEquals($payload['nid'], $nid, 'Uses same node');
-    $this->checkSiteSections($this->english, $old_short_title);
+    $this->checkSiteSections($this->english, $old_browser_title);
     $this->publish([[$nid, 'en']]);
     $this->checkSiteSections($this->english);
 
@@ -557,7 +552,7 @@ class ApiTest extends BrowserTestBase {
       $name = $section->getName();
       if ($tail) {
         if (empty($nav_label)) {
-          $nav_label = $summary['short_title'];
+          $nav_label = $summary['browser_title'];
         }
 
         // For the last token in the URL, fields have different assignments.

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_drug_information_summary/README.md
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_drug_information_summary/README.md
@@ -21,4 +21,4 @@ Loads the editing user interface through a web browser (using `Drupal\Tests\Brow
 
 New fields should be added to [PDQDrugSummaryTest.php](tests/src/Functional/PDQSummaryTest.php) with their existence tested in `testSummaryFieldsExist()`.
 
-Field presence tests require the ID of the UI element from the editing page. These names are based on the field's machine name, the exact rules for generating the filed name varies according to the field type (e.g. the "Short Title" input field has the ID `edit-field-short-title-0-value`. The "Posted Date" date selector has the ID `edit-field-date-posted-0-value-date`). The field names can most easily be found by loading the page and inspecting the HTML.
+Field presence tests require the ID of the UI element from the editing page. These names are based on the field's machine name, the exact rules for generating the filed name varies according to the field type (e.g. the "Browser Title" input field has the ID `edit-field-browser-title-0-value`. The "Posted Date" date selector has the ID `edit-field-date-posted-0-value-date`). The field names can most easily be found by loading the page and inspecting the HTML.

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/cthp/node--cthp-guide-card-list-item.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/cthp/node--cthp-guide-card-list-item.html.twig
@@ -1,3 +1,9 @@
 <li>
-  <a href="{{ url }}">{{ content.field_browser_title }}</a>
+  <a href="{{ url }}">
+    {%- if content.field_cthp_card_title -%}
+      {{- content.field_cthp_card_title -}}
+    {%- else -%}
+      {{- content.field_browser_title -}}
+    {%- endif -%}
+  </a>
 </li>

--- a/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/templates/content/cthp/node--cthp-guide-card-list-item.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/templates/content/cthp/node--cthp-guide-card-list-item.html.twig
@@ -1,3 +1,9 @@
 <li>
-  <a href="{{ url }}">{{ content.field_browser_title }}</a>
+  <a href="{{ url }}">
+    {%- if content.field_cthp_card_title -%}
+      {{- content.field_cthp_card_title -}}
+    {%- else -%}
+      {{- content.field_browser_title -}}
+    {%- endif -%}
+  </a>
 </li>


### PR DESCRIPTION
This will allow the field_browser_title value, populated from the CDR, to be used as for the browser title, as was originally intended.

Tasks include:
- create new field_ctrp_card_title field, 100 characters max
- modify the RESTful services to handle the new field
- modify the tests to include the new field
- adjust the YAML sample content to include the new field
- add the new field to the CTHP: Guide Card List view
- modify the cthp guide card list item template to use new field
- use the field_browser_title value for the head/title element

Deployment will be coupled with a full load of the CIS summaries, to populate the new field with appropriate values, and to adjust the values in the browser title field so that they are unique.

Closes #3513.