### PR TITLE
(#3768) Add translation to workaround issue

### DIFF
--- a/docroot/profiles/custom/cgov_site/translations/cgov_site.es.po
+++ b/docroot/profiles/custom/cgov_site/translations/cgov_site.es.po
@@ -229,3 +229,6 @@ msgstr "Enviar por correo electrónico"
 msgctxt "CGDP Page Options"
 msgid "Print"
 msgstr "Imprimir"
+
+msgid "Version 2.6.0"
+msgstr "Versión 2.6.0"


### PR DESCRIPTION
- We updated Drupal translations and this causes issues for our
  translations being overwritten unless we have a newer file.