### PR TITLE
(#3856) image carousel next/prev label fix

### DIFF
--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/src/libraries/imageCarousel/jquery.ui.imagecarousel.js
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/src/libraries/imageCarousel/jquery.ui.imagecarousel.js
@@ -78,6 +78,7 @@
             // Draw Controls
             this.controls.$prevButton = $('<button>', {
                 "class": 'previous',
+                "aria-label": this.options.previousText,
                 type: 'button'
             }).append('<span>', {
                 "class": "ic-arrow-button",
@@ -85,7 +86,9 @@
             })
 
             this.controls.$nextButton = $('<button>', {
-                "class": 'next'
+                "class": 'next',
+                "aria-label": this.options.nextText,
+                type: 'button'
             }).append('<span>', {
                 "class": "ic-arrow-button",
                 text: this.options.nextText


### PR DESCRIPTION
Closes #3856 .

Added aria label to next/prev buttons for image carousel.  
Confirmed that labels are in place for yt-video carousels as well.