### PR TITLE
(#4002) phpstan quick fixes for twig extension files

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8147,26 +8147,26 @@
         },
         {
             "name": "drupal/twig_field_value",
-            "version": "2.0.0",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/twig_field_value.git",
-                "reference": "2.0.0"
+                "reference": "2.0.2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/twig_field_value-2.0.0.zip",
-                "reference": "2.0.0",
-                "shasum": "d2d0db6249493542bf9d568970f67d10ce143f90"
+                "url": "https://ftp.drupal.org/files/projects/twig_field_value-2.0.2.zip",
+                "reference": "2.0.2",
+                "shasum": "7d1267c6ed5ef0e5d6ab82732e42bc505bb2dec8"
             },
             "require": {
-                "drupal/core": "^8 || ^9"
+                "drupal/core": "^9 || ^10"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "2.0.0",
-                    "datestamp": "1587069998",
+                    "version": "2.0.2",
+                    "datestamp": "1671703066",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -20748,5 +20748,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.services.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.services.yml
@@ -26,7 +26,7 @@ services:
       - '@entity.repository'
   cgov_core.twig_extensions:
     class: Drupal\cgov_core\CgovCoreTwigExtensions
-    arguments: ['@entity_type.manager', '@language_manager', '@renderer', '@request_stack']
+    arguments: ['@entity_type.manager', '@language_manager', '@renderer', '@request_stack', '@file_url_generator']
     tags:
       - { name: twig.extension }
   cgov_core.translation_available:

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/CgovCoreTwigExtensions.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/CgovCoreTwigExtensions.php
@@ -9,15 +9,16 @@ use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\Core\Render\RendererInterface;
 use Drupal\file\Entity\File;
 use Drupal\views\ViewExecutable;
-use Drupal\image\Entity\ImageStyle;
 use Drupal\Component\Utility\Html;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Twig\TwigFunction;
+use Twig\Extension\AbstractExtension;
+use Drupal\Core\File\FileUrlGeneratorInterface;
 
 /**
- * Extend Drupal's Twig_Extension class.
+ * Extend Drupal's AbstractExtension class.
  */
-class CgovCoreTwigExtensions extends \Twig_Extension {
+class CgovCoreTwigExtensions extends AbstractExtension {
 
   /**
    * Entity Type Manager.
@@ -41,9 +42,9 @@ class CgovCoreTwigExtensions extends \Twig_Extension {
   protected $renderer;
 
   /**
-   * The current Request object.
+   * The request stack.
    *
-   * @var \Symfony\Component\HttpFoundation\Request
+   * @var \Symfony\Component\HttpFoundation\RequestStack
    */
   protected $requestStack;
 
@@ -55,15 +56,23 @@ class CgovCoreTwigExtensions extends \Twig_Extension {
   protected $langid;
 
   /**
+   * The file URL generator.
+   *
+   * @var \Drupal\Core\File\FileUrlGeneratorInterface
+   */
+  protected $fileUrlGenerator;
+
+  /**
    * Constructs a new CgovNavigationManager class.
    */
-  public function __construct(EntityTypeManagerInterface $entityTypeManager, LanguageManagerInterface $languageManager, RendererInterface $renderer, RequestStack $requestStack) {
+  public function __construct(EntityTypeManagerInterface $entityTypeManager, LanguageManagerInterface $languageManager, RendererInterface $renderer, RequestStack $requestStack, FileUrlGeneratorInterface $file_url_generator) {
     $this->entityTypeManager = $entityTypeManager;
     $this->languageManager = $languageManager;
     $this->renderer = $renderer;
     $this->requestStack = $requestStack;
     // Get current language.
     $this->langid = $this->languageManager->getCurrentLanguage()->getID();
+    $this->fileUrlGenerator = $file_url_generator;
   }
 
   /**
@@ -78,12 +87,20 @@ class CgovCoreTwigExtensions extends \Twig_Extension {
    */
   public function getFunctions() {
     return [
-      new \Twig_SimpleFunction('get_blog_info', [$this, 'getBlogInfo'], ['is_safe' => ['html']]),
-      new \Twig_SimpleFunction('get_enclosure', [$this, 'getEnclosure'], ['is_safe' => ['html']]),
-      new \Twig_SimpleFunction('get_list_description', [$this, 'getListDescription'], ['is_safe' => ['html']]),
-      new \Twig_SimpleFunction('get_translated_absolute_path', [$this, 'getTranslatedAbsolutePath'], ['is_safe' => ['html']]),
-      new \Twig_SimpleFunction('strip_duplicate_leading_credit', [$this, 'stripDuplicateLeadingCredit'], ['is_safe' => ['html']]),
-      new \Twig_SimpleFunction('has_content', [$this, 'hasContent'], ['is_safe' => ['html']]),
+      new TwigFunction('get_blog_info', [$this, 'getBlogInfo'], ['is_safe' => ['html']]),
+      new TwigFunction('get_enclosure', [$this, 'getEnclosure'], ['is_safe' => ['html']]),
+      new TwigFunction('get_list_description', [$this, 'getListDescription'], ['is_safe' => ['html']]),
+      new TwigFunction('get_translated_absolute_path',
+       [$this, 'getTranslatedAbsolutePath'],
+       [
+         'is_safe' => ['html'],
+       ]),
+      new TwigFunction('strip_duplicate_leading_credit',
+       [$this, 'stripDuplicateLeadingCredit'],
+       [
+         'is_safe' => ['html'],
+       ]),
+      new TwigFunction('has_content', [$this, 'hasContent'], ['is_safe' => ['html']]),
       // This is borrowed from 'sfc' module based on discussions in
       // https://www.drupal.org/project/drupal/issues/2660002. This should be
       // used when you are going to be digging around in entity reference
@@ -174,7 +191,7 @@ class CgovCoreTwigExtensions extends \Twig_Extension {
    * provided ImageStyle.  The image's imagestyle file will be created on the
    * filesystem (which is required to determine the filesize properly).
    *
-   * @param Drupal\file\Entity\File $media_image_file
+   * @param \Drupal\file\Entity\File $media_image_file
    *   The File entity of an image field.
    * @param string $image_style
    *   The Image Style to render the image with.
@@ -187,8 +204,7 @@ class CgovCoreTwigExtensions extends \Twig_Extension {
     $image_uri = $media_image_file->getFileUri();
 
     // Generate new derivative image from imagestyle.
-    /** @var \Drupal\image\Entity\ImageStyle $imageStyle */
-    $imageStyle = ImageStyle::load($image_style);
+    $imageStyle = $this->entityTypeManager->getStorage('image_style')->load($image_style);
     // Get thumbnail_uri
     // (eg: public://styles/cgov_thumbail/public/2019-03/image.jpg).
     $thumbnail_uri = $imageStyle->buildUri($image_uri);
@@ -197,7 +213,7 @@ class CgovCoreTwigExtensions extends \Twig_Extension {
     $imageStyle->createDerivative($image_uri, $thumbnail_uri);
     // Convert 'public://path/image.jpg'
     // to '/sites/default/files/path/image.jpg'.
-    $relative_imagestyle_uri = file_url_transform_relative(file_create_url($thumbnail_uri));
+    $relative_imagestyle_uri = $this->fileUrlGenerator->generateString($thumbnail_uri);
     // Remove querystring, if present (eg: path/image.jpg?h=98765az)
     $relative_imagestyle_uri = strtok($relative_imagestyle_uri, '?');
     // Add HTTP scheme (HTTP[S]) and hostname.
@@ -235,7 +251,7 @@ class CgovCoreTwigExtensions extends \Twig_Extension {
     if (!$node) {
       return NULL;
     }
-
+    $description = NULL;
     // Check for available descriptions to display.
     if ($node->hasField('field_page_description')) {
       $description = $node->field_page_description->value;
@@ -319,7 +335,7 @@ class CgovCoreTwigExtensions extends \Twig_Extension {
   /**
    * Get the Blog Information about Series and Topics.
    *
-   * @param Drupal\views\ViewExecutable $view
+   * @param \Drupal\views\ViewExecutable $view
    *   The current view being displayed.  Uses Contextual Filters for details.
    *
    * @return array
@@ -331,6 +347,9 @@ class CgovCoreTwigExtensions extends \Twig_Extension {
 
     $series_nid = !empty($view->args) ? $view->args[0] : '';
     $topic_tid = count($view->args) > 1 ? $view->args[1] : NULL;
+    $series_name = NULL;
+    $series_link = NULL;
+    $series_desc = NULL;
 
     if ($series_nid) {
       if ($series_nid == 'all') {
@@ -409,7 +428,7 @@ class CgovCoreTwigExtensions extends \Twig_Extension {
    * @param int $nid
    *   Node ID to create enclosure tag from.
    *
-   * @return Drupal\file\Entity\File
+   * @return \Drupal\file\Entity\File
    *   The specified node or NULL
    */
   public function getNodeImageFile($nid) {

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/src/CgovHomeLandingPageTwigExtension.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/src/CgovHomeLandingPageTwigExtension.php
@@ -4,17 +4,18 @@ namespace Drupal\cgov_home_landing;
 
 use Twig\TwigFunction;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Twig\Extension\AbstractExtension;
 
 /**
- * Extend Drupal's Twig_Extension class.
+ * Extend Drupal's AbstractExtension class.
  */
-class CgovHomeLandingPageTwigExtension extends \Twig_Extension {
+class CgovHomeLandingPageTwigExtension extends AbstractExtension {
 
 
   /**
-   * The current Request object.
+   * The request stack.
    *
-   * @var \Symfony\Component\HttpFoundation\Request
+   * @var \Symfony\Component\HttpFoundation\RequestStack
    */
   protected $requestStack;
 

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_image/cgov_image.services.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_image/cgov_image.services.yml
@@ -12,7 +12,8 @@ services:
  # Defines a service of which returns the associated crop for  given image style
   cgov_image.image_tools:
     class: Drupal\cgov_image\CgovImageTools
-  cgov_image.twig.CgovImageTwigExtensions:    
-    class: Drupal\cgov_image\CgovImageTwigExtensions    
-    tags:      
+  cgov_image.twig.CgovImageTwigExtensions:
+    class: Drupal\cgov_image\CgovImageTwigExtensions
+    arguments: ['@file_url_generator', '@entity_type.manager']
+    tags:
       - { name: twig.extension }

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_image/src/CgovImageTwigExtensions.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_image/src/CgovImageTwigExtensions.php
@@ -2,21 +2,53 @@
 
 namespace Drupal\cgov_image;
 
-use Drupal\image\Entity\ImageStyle;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+use Drupal\Core\File\FileUrlGeneratorInterface;
 
 /**
- * Class CgovImageTwigExtensions.
+ * Cgov Image Twig Extensions.
  */
-class CgovImageTwigExtensions extends \Twig_Extension {
+class CgovImageTwigExtensions extends AbstractExtension {
 
   /**
-   * A list with all the defined functions. The first parameter is the name
-   * by which we will call the function. The second parameter is the
-   * name of the function that will implement the function.
+   * The file URL generator.
+   *
+   * @var \Drupal\Core\File\FileUrlGeneratorInterface
+   */
+  protected $fileUrlGenerator;
+
+  /**
+   * The entity type manager service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * Constructor.
+   *
+   * @param \Drupal\Core\File\FileUrlGeneratorInterface $file_url_generator
+   *   File url generator.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager service.
+   */
+  public function __construct(FileUrlGeneratorInterface $file_url_generator, EntityTypeManagerInterface $entity_type_manager) {
+    $this->fileUrlGenerator = $file_url_generator;
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * A list with all the defined functions.
+   *
+   * The first parameter is the name by which we will call the function.
+   * The second parameter is the name of the function that will implement
+   * the function.
    */
   public function getFunctions() {
     return [
-      new \Twig_SimpleFunction('get_placeholder_image', [$this, 'getPlaceholderImage']),
+      new TwigFunction('get_placeholder_image', [$this, 'getPlaceholderImage']),
     ];
   }
 
@@ -34,8 +66,8 @@ class CgovImageTwigExtensions extends \Twig_Extension {
     $test = new CgovImageTools();
     $crop = $test->findCropByStyle($image_style);
     $uri = 'module://cgov_image/img/placeholder-' . $crop . '.png';
-    $image_style = ImageStyle::load($image_style);
-    $absolute_path = \Drupal::service('file_url_generator')->transformRelative($image_style->buildUrl($uri));
+    $image_style = $this->entityTypeManager->getStorage('image_style')->load($image_style);
+    $absolute_path = $this->fileUrlGenerator->transformRelative($image_style->buildUrl($uri));
     return $absolute_path;
   }
 

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -56,9 +56,7 @@
   <exclude-pattern>*/themes/custom/cgov/cgov_common/dist</exclude-pattern>
   <!-- Temporary Excludes for bad files -->
   <exclude-pattern>docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/src/CgovBlogTwigExtensions.php</exclude-pattern>
-  <exclude-pattern>docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/CgovCoreTwigExtensions.php</exclude-pattern>
   <exclude-pattern>docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Plugin/Block/NcidsHeader.php</exclude-pattern>
-  <exclude-pattern>docroot/profiles/custom/cgov_site/modules/custom/cgov_image/src/CgovImageTwigExtensions.php</exclude-pattern>
   <exclude-pattern>docroot/profiles/custom/cgov_site/modules/custom/cgov_mail/src/Controller/MailAPIController.php</exclude-pattern>
   <exclude-pattern>docroot/profiles/custom/cgov_site/modules/custom/cgov_metatag/cgov_metatag.tokens.inc</exclude-pattern>
   <exclude-pattern>docroot/profiles/custom/cgov_site/modules/custom/cgov_vocab_manager/src/Manager/CgovVocabManager.php</exclude-pattern>

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -33,7 +33,6 @@ parameters:
     - docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.module
     - docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/CgovConfigOverrider.php
     - docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/CgovCoreTools.php
-    - docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/CgovCoreTwigExtensions.php
     - docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Controller/CgovMediaController.php
     - docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/EventSubscriber/CmsProtectionSubscriber.php
     - docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/EventSubscriber/ResponseCacheSubscriber.php
@@ -50,9 +49,7 @@ parameters:
     - docroot/profiles/custom/cgov_site/modules/custom/cgov_embedded_block/cgov_embedded_block.module
     - docroot/profiles/custom/cgov_site/modules/custom/cgov_event/src/Controller/ICalendarController.php
     - docroot/profiles/custom/cgov_site/modules/custom/cgov_file/src/EventSubscriber/DirectFileDownloadSubscriber.php
-    - docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/src/CgovHomeLandingPageTwigExtension.php
     - docroot/profiles/custom/cgov_site/modules/custom/cgov_image/cgov_image.module
-    - docroot/profiles/custom/cgov_site/modules/custom/cgov_image/src/CgovImageTwigExtensions.php
     - docroot/profiles/custom/cgov_site/modules/custom/cgov_image/src/EventSubscriber/ImageEventSubscriber.php
     - docroot/profiles/custom/cgov_site/modules/custom/cgov_image/src/Plugin/PathProcessor/ImageRedirectProcessor.php
     - docroot/profiles/custom/cgov_site/modules/custom/cgov_infographic/cgov_infographic.module


### PR DESCRIPTION
ODE: [ncigovcdode615.prod.acquia-sites.com](http://ncigovcdode615.prod.acquia-sites.com/AH_VIEW)
Closes #4002
Closes #3843 

-------------
### What Does this Touch?
There is no logic change in this item. Everything is expected to work the same way, and ALL of this stuff is used in the templates that show the front-end HTML. So no backend was touched at all.

* Viewing NCIDS Home and Landing
   * This is all front-end, no backend changes
   * Specifically the code where we check what the Page Style is to draw different things.
   * Also nothing really changed in the code, so if the old and new homepages display correctly in visual regressions, then it works.
* Updated how we get placeholder images for the new NCIDS home and landing.
   * This is all front-end, no backend changes.
   * The visual regression tests should check this.
* Blog & Press Release RSS feeds 
  * Code touched how information about the Blog Series is gotten.
  * Showing the correct image for the RSS item (called an "enclosure" in the XML)
  * Showing the description of the item
  * Showing the link for the item in the feed
  * The front-end cypress regression tests have test cases for blogs, so if that passes, then this passes.
*  Image captions
    * Credit Displaying: 
       * When the credit of an image starts with "Credit:" or "Crédito", the phrase "Credit:" or "Crédito" will display only once.
       * This is here to fix old images from Percussion that required the editors to actually enter "Credit:" into the CMS field. Drupal automatically adds it, so we added this to make sure it did not show up twice.
       * IDK where we would have a regression test, so just add "Credit: " to the beginning of a credit field of an image where the image is displayed on a page with the caption.
    * Prevent displaying of empty captions
       * The caption field is a WYSIWYG field, and that means it can have a lot of empty HTML tags and other stuff that amount to all empty space. 
       * So we have to make sure that at then end of the day there is actual text to display.
       * You will need to test this by making an image and giving it the following "content" (use source view). **Do not set a credit.** The gray caption box should not display under the image.
          ```
          <p>&nbsp;&nbsp;</p>
          ``` 
* Some caching stuff with lists that did not really change and I don't know how you would really test it, so don't worry about it.