### PR TITLE
(#3532) Upgrade to PHP 8.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Setup PHP with tools
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
+          php-version: '8.1'
           ## This list of extensions matches those we install with our docker file, then I removed
           ## cli, common, fpm cause they would not install, then I removed xdebug cause why?
           extensions: bz2, curl, gd, mbstring, memcached, mysql, oauth, opcache, readline, sqlite3, soap, xml

--- a/.github/workflows/test-deployability.yml
+++ b/.github/workflows/test-deployability.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Setup PHP with tools
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
+          php-version: '8.1'
           ## This list of extensions matches those we install with our docker file, then I removed
           ## cli, common, fpm cause they would not install, then I removed xdebug cause why?
           extensions: bz2, curl, gd, mbstring, memcached, mysql, oauth, opcache, readline, sqlite3, soap, xml

--- a/blt/blt.yml
+++ b/blt/blt.yml
@@ -41,7 +41,7 @@ modules:
     uninstall: [syslog, cgov_caching_nocdn]
   test:
     enable: [dblog, acquia_connector, shield, simplesamlphp_auth, cgov_saml_auth_config, cgov_https_config, cgov_caching_nocdn]
-    uninstall: [syslog, devel, views_ui, cgov_caching_cdn, akamai]
+    uninstall: [syslog, devel, cgov_caching_cdn, akamai]
   ## We have no prod in ACE.
   01dev:
     enable: [dblog, acquia_connector, acsf, shield, simplesamlphp_auth, cgov_saml_auth_config, cgov_https_config, cgov_caching_cdn, akamai]

--- a/composer.json
+++ b/composer.json
@@ -31,11 +31,11 @@
         "dmore/behat-chrome-extension": "^1.4",
         "dmore/chrome-mink-driver": "^2.8",
         "drupal/acquia_connector": "^4.0.0",
-        "drupal/acquia_purge": "^1.0@beta",
+        "drupal/acquia_purge": "^1.3",
         "drupal/acsf": "^2.73",
         "drupal/address": "1.11.0",
         "drupal/admin_toolbar": "^3.0.3",
-        "drupal/akamai": "3.x-dev@dev",
+        "drupal/akamai": "4.0.0",
         "drupal/autologout": "^1.4",
         "drupal/clamav": "^2.0",
         "drupal/config_perms": "^2",
@@ -63,8 +63,8 @@
         "drupal/paragraphs": "^1.15",
         "drupal/paragraphs_asymmetric_translation_widgets": "^1.2",
         "drupal/pathauto": "^1.11",
-        "drupal/purge": "3.0.0",
-        "drupal/redirect": "^1.6",
+        "drupal/purge": "^3.4",
+        "drupal/redirect": "^1.9",
         "drupal/role_delegation": "^1.0",
         "drupal/seckit": "^2.0",
         "drupal/shield": "^1.2",
@@ -236,7 +236,7 @@
                 "3331203 : Core 9.5.0 causing broken-looking styling (Legacy widget, with Seven)": "https://www.drupal.org/files/issues/2023-02-22/3331203-11.patch"
             },
             "drupal/purge": {
-                "3094343 : Garbled purge tag IDs": "https://www.drupal.org/files/issues/2020-04-06/purge-3094343.patch"
+                "3094343 : Garbled purge tag IDs": "https://www.drupal.org/files/issues/2023-09-07/purge-3094343-15.patch"
             }
         },
         "drupal-scaffold": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "51b3c075adb4890bee72d1167c8eff60",
+    "content-hash": "d83ac54fabb688d31c63aaeffffedb19",
     "packages": [
         {
             "name": "acquia/acsf-tools",
@@ -4061,28 +4061,28 @@
         },
         {
             "name": "drupal/acquia_purge",
-            "version": "1.1.0",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/acquia_purge.git",
-                "reference": "8.x-1.1"
+                "reference": "8.x-1.3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/acquia_purge-8.x-1.1.zip",
-                "reference": "8.x-1.1",
-                "shasum": "6e4b819262f5ed82fa1bfd533cd7a35b70242e9b"
+                "url": "https://ftp.drupal.org/files/projects/acquia_purge-8.x-1.3.zip",
+                "reference": "8.x-1.3",
+                "shasum": "d93bc6dcee78658267d7cf5baf7d480642e1e65a"
             },
             "require": {
-                "drupal/core": "^8.8.6 || ^9",
-                "drupal/purge": "^3.0.0",
-                "php": ">=7.2"
+                "drupal/core": "^9.2 || ^10",
+                "drupal/purge": "^3.4",
+                "drupal/purge_queuer_coretags": "*"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-1.1",
-                    "datestamp": "1590768773",
+                    "version": "8.x-1.3",
+                    "datestamp": "1663188605",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -4600,11 +4600,17 @@
         },
         {
             "name": "drupal/akamai",
-            "version": "dev-3.x",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/akamai.git",
-                "reference": "d4e4c8167332c8cce4f65716683cfec64d1dae38"
+                "reference": "4.0.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/akamai-4.0.0.zip",
+                "reference": "4.0.0",
+                "shasum": "079e84087ecfbb110c6916b3f05d330148cab2d7"
             },
             "require": {
                 "akamai-open/edgegrid-auth": "~1.0.1",
@@ -4613,20 +4619,17 @@
             },
             "require-dev": {
                 "drupal/key": "~1.8",
-                "drupal/purge": "3.0-beta9",
+                "drupal/purge": "~3.2",
                 "drupal/token": "~1.6"
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-3.x": "3.x-dev"
-                },
                 "drupal": {
-                    "version": "8.x-3.0-alpha8+6-dev",
-                    "datestamp": "1621545412",
+                    "version": "4.0.0",
+                    "datestamp": "1634673223",
                     "security-coverage": {
-                        "status": "not-covered",
-                        "message": "Dev releases are not covered by Drupal security advisories."
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
                     }
                 },
                 "drush": {
@@ -7531,27 +7534,26 @@
         },
         {
             "name": "drupal/purge",
-            "version": "3.0.0",
+            "version": "3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/purge.git",
-                "reference": "8.x-3.0"
+                "reference": "8.x-3.4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/purge-8.x-3.0.zip",
-                "reference": "8.x-3.0",
-                "shasum": "e7113e9927dbdbbd5c2f4edc2649a14676e14f34"
+                "url": "https://ftp.drupal.org/files/projects/purge-8.x-3.4.zip",
+                "reference": "8.x-3.4",
+                "shasum": "deb4eccfe88af35445e8064a9a4a8a056bfb917f"
             },
             "require": {
-                "drupal/core": "^8.7.7 || ^9",
-                "php": ">=7.2"
+                "drupal/core": "^9.2 || ^10"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-3.0",
-                    "datestamp": "1590744318",
+                    "version": "8.x-3.4",
+                    "datestamp": "1663189449",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -7590,27 +7592,73 @@
             }
         },
         {
+            "name": "drupal/purge_queuer_coretags",
+            "version": "3.4.0",
+            "require": {
+                "drupal/core": "^9.2 || ^10",
+                "drupal/purge": "*"
+            },
+            "type": "metapackage",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-3.4",
+                    "datestamp": "1663189449",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "djbobbydrake",
+                    "homepage": "https://www.drupal.org/user/336378"
+                },
+                {
+                    "name": "japerry",
+                    "homepage": "https://www.drupal.org/user/45640"
+                },
+                {
+                    "name": "nielsvm",
+                    "homepage": "https://www.drupal.org/user/163285"
+                },
+                {
+                    "name": "SqyD",
+                    "homepage": "https://www.drupal.org/user/106525"
+                }
+            ],
+            "description": "Queues every tag that Drupal invalidates internally.",
+            "homepage": "https://www.drupal.org/project/purge",
+            "support": {
+                "source": "https://git.drupalcode.org/project/purge"
+            }
+        },
+        {
             "name": "drupal/redirect",
-            "version": "1.6.0",
+            "version": "1.9.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/redirect.git",
-                "reference": "8.x-1.6"
+                "reference": "8.x-1.9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/redirect-8.x-1.6.zip",
-                "reference": "8.x-1.6",
-                "shasum": "f848e001deac8425ae57d4b9397087c491d37294"
+                "url": "https://ftp.drupal.org/files/projects/redirect-8.x-1.9.zip",
+                "reference": "8.x-1.9",
+                "shasum": "2987de20f509e9f7cec8a0f81d3a6774f9b0ba3e"
             },
             "require": {
-                "drupal/core": "^8.8 || ^9"
+                "drupal/core": "^9.2 || ^10"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-1.6",
-                    "datestamp": "1589312204",
+                    "version": "8.x-1.9",
+                    "datestamp": "1693393506",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -10153,27 +10201,27 @@
         },
         {
             "name": "league/climate",
-            "version": "3.7.0",
+            "version": "3.8.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/climate.git",
-                "reference": "5c717c3032c5118be7ad2395dbe0813d9894e8c7"
+                "reference": "a785a3ac8f584eed4abd45e4e16fe64c46659a28"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/climate/zipball/5c717c3032c5118be7ad2395dbe0813d9894e8c7",
-                "reference": "5c717c3032c5118be7ad2395dbe0813d9894e8c7",
+                "url": "https://api.github.com/repos/thephpleague/climate/zipball/a785a3ac8f584eed4abd45e4e16fe64c46659a28",
+                "reference": "a785a3ac8f584eed4abd45e4e16fe64c46659a28",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.3 || ^8.0",
-                "psr/log": "^1.0",
+                "psr/log": "^1.0 || ^2.0 || ^3.0",
                 "seld/cli-prompt": "^1.0"
             },
             "require-dev": {
-                "mikey179/vfsstream": "^1.4",
+                "mikey179/vfsstream": "^1.6.10",
                 "mockery/mockery": "^1.4.2",
-                "phpunit/phpunit": "^9.5.0"
+                "phpunit/phpunit": "^9.5.10"
             },
             "suggest": {
                 "ext-mbstring": "If ext-mbstring is not available you MUST install symfony/polyfill-mbstring"
@@ -10212,9 +10260,9 @@
             ],
             "support": {
                 "issues": "https://github.com/thephpleague/climate/issues",
-                "source": "https://github.com/thephpleague/climate/tree/3.7.0"
+                "source": "https://github.com/thephpleague/climate/tree/3.8.2"
             },
-            "time": "2021-01-10T20:18:52+00:00"
+            "time": "2022-06-18T14:42:08+00:00"
         },
         {
             "name": "league/container",
@@ -10573,16 +10621,16 @@
         },
         {
             "name": "monolog/monolog",
-            "version": "1.26.1",
+            "version": "1.27.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/monolog.git",
-                "reference": "c6b00f05152ae2c9b04a448f99c7590beb6042f5"
+                "reference": "904713c5929655dc9b97288b69cfeedad610c9a1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/c6b00f05152ae2c9b04a448f99c7590beb6042f5",
-                "reference": "c6b00f05152ae2c9b04a448f99c7590beb6042f5",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/904713c5929655dc9b97288b69cfeedad610c9a1",
+                "reference": "904713c5929655dc9b97288b69cfeedad610c9a1",
                 "shasum": ""
             },
             "require": {
@@ -10643,7 +10691,7 @@
             ],
             "support": {
                 "issues": "https://github.com/Seldaek/monolog/issues",
-                "source": "https://github.com/Seldaek/monolog/tree/1.26.1"
+                "source": "https://github.com/Seldaek/monolog/tree/1.27.1"
             },
             "funding": [
                 {
@@ -10655,7 +10703,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-28T08:32:12+00:00"
+            "time": "2022-06-09T08:53:42+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -15353,6 +15401,7 @@
                 "issues": "https://github.com/tvdijen/simplesamlphp-module-sanitycheck/issues",
                 "source": "https://github.com/tvdijen/simplesamlphp-module-sanitycheck"
             },
+            "abandoned": true,
             "time": "2020-05-07T11:34:29+00:00"
         },
         {
@@ -18243,16 +18292,16 @@
         },
         {
             "name": "symfony/polyfill-php72",
-            "version": "v1.27.0",
+            "version": "v1.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php72.git",
-                "reference": "869329b1e9894268a8a61dabb69153029b7a8c97"
+                "reference": "70f4aebd92afca2f865444d30a4d2151c13c3179"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/869329b1e9894268a8a61dabb69153029b7a8c97",
-                "reference": "869329b1e9894268a8a61dabb69153029b7a8c97",
+                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/70f4aebd92afca2f865444d30a4d2151c13c3179",
+                "reference": "70f4aebd92afca2f865444d30a4d2151c13c3179",
                 "shasum": ""
             },
             "require": {
@@ -18261,7 +18310,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.27-dev"
+                    "dev-main": "1.28-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -18299,7 +18348,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php72/tree/v1.27.0"
+                "source": "https://github.com/symfony/polyfill-php72/tree/v1.28.0"
             },
             "funding": [
                 {
@@ -18315,7 +18364,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-03T14:55:06+00:00"
+            "time": "2023-01-26T09:26:14+00:00"
         },
         {
             "name": "symfony/polyfill-php73",
@@ -20746,13 +20795,11 @@
     "minimum-stability": "dev",
     "stability-flags": {
         "acquia/acsf-tools": 20,
-        "drupal/acquia_purge": 10,
-        "drupal/akamai": 20,
         "drupal/page_manager": 10
     },
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/docker/README.md
+++ b/docker/README.md
@@ -31,7 +31,7 @@ At some point in time there will be multiple websites within our project. (e.g. 
   * MySQL
 * web
   * OS: Ubuntu Bionic
-  * PHP 8.0
+  * PHP 8.1
     * bz2
     * cli
     * common

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -13,8 +13,8 @@ services:
       - ../:/var/www:cached
       ## Configs
       - ./web/runtime/apache2.conf:/etc/apache2/apache2.conf
-      - ./web/runtime/php_apache2.ini:/etc/php/8.0/apache2/php.ini
-      - ./web/runtime/php_cli.ini:/etc/php/8.0/cli/php.ini
+      - ./web/runtime/php_apache2.ini:/etc/php/8.1/apache2/php.ini
+      - ./web/runtime/php_cli.ini:/etc/php/8.1/cli/php.ini
       ## Block git repo management within the container
       - ./web/runtime/container-hooks:/var/www/scripts/hooks
       ## Npmrc for package installation.

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -47,24 +47,24 @@ RUN DEBIAN_FRONTEND=noninteractive \
   apt-get install -yq \
   apache2 \
   build-essential \
-  php8.0 \
-  libapache2-mod-php8.0 \
-  php8.0-bz2 \
-  php8.0-cli \
-  php8.0-common \
-  php8.0-curl \
-  php8.0-fpm \
-  php8.0-gd \
-  php8.0-mbstring \
-  php8.0-memcached \
-  php8.0-mysql \
-  php8.0-oauth \
-  php8.0-opcache \
-  php8.0-readline \
-  php8.0-sqlite3 \
-  php8.0-soap \
-  php8.0-xdebug \
-  php8.0-xml \
+  php8.1 \
+  libapache2-mod-php8.1 \
+  php8.1-bz2 \
+  php8.1-cli \
+  php8.1-common \
+  php8.1-curl \
+  php8.1-fpm \
+  php8.1-gd \
+  php8.1-mbstring \
+  php8.1-memcached \
+  php8.1-mysql \
+  php8.1-oauth \
+  php8.1-opcache \
+  php8.1-readline \
+  php8.1-sqlite3 \
+  php8.1-soap \
+  php8.1-xdebug \
+  php8.1-xml \
   mysql-client-8.0 \
   git \
   imagemagick \
@@ -82,7 +82,7 @@ COPY ./build/000-default.conf /etc/apache2/sites-available/000-default.conf
 ## These are the PHP modules that are available to be
 ## loaded by the CLI & apache. This should be inline with
 ## the modules installed above.
-COPY ./build/php-conf /etc/php/8.0/mods-available
+COPY ./build/php-conf /etc/php/8.1/mods-available
 
 # Enable mod_rewrite 'cause we needs it.
 RUN a2enmod rewrite

--- a/docker/web/build/php-conf/opcache.ini
+++ b/docker/web/build/php-conf/opcache.ini
@@ -1,3 +1,4 @@
 ; configuration for php opcache module
 ; priority=10
 zend_extension=opcache.so
+opcache.jit=off

--- a/docker/web/build/php-conf/xdebug.ini
+++ b/docker/web/build/php-conf/xdebug.ini
@@ -1,4 +1,3 @@
-[xdebug]
 zend_extension=xdebug.so
 xdebug.mode=debug
 xdebug.max_nesting_level=256

--- a/docker/web/runtime/php_apache2.ini
+++ b/docker/web/runtime/php_apache2.ini
@@ -17,7 +17,7 @@
 ; 6. The directory from the --with-config-file-path compile time option, or the
 ; Windows directory (usually C:\windows)
 ; See the PHP docs for more specific information.
-; http://php.net/configuration.file
+; https://php.net/configuration.file
 
 ; The syntax of the file is extremely simple.  Whitespace and lines
 ; beginning with a semicolon are silently ignored (as you probably guessed).
@@ -31,7 +31,7 @@
 ; special sections cannot be overridden by user-defined INI files or
 ; at runtime. Currently, [PATH=] and [HOST=] sections only work under
 ; CGI/FastCGI.
-; http://php.net/ini.sections
+; https://php.net/ini.sections
 
 ; Directives are specified using the following syntax:
 ; directive = value
@@ -181,7 +181,7 @@
 ;;;;;;;;;;;;;;;;;;;;
 
 ; Enable the PHP scripting language engine under Apache.
-; http://php.net/engine
+; https://php.net/engine
 engine = On
 
 ; This directive determines whether or not PHP will recognize code between
@@ -194,11 +194,11 @@ engine = On
 ; Default Value: On
 ; Development Value: Off
 ; Production Value: Off
-; http://php.net/short-open-tag
+; https://php.net/short-open-tag
 short_open_tag = Off
 
 ; The number of significant digits displayed in floating point numbers.
-; http://php.net/precision
+; https://php.net/precision
 precision = 14
 
 ; Output buffering is a mechanism for controlling how much output data
@@ -222,7 +222,7 @@ precision = 14
 ; Default Value: Off
 ; Development Value: 4096
 ; Production Value: 4096
-; http://php.net/output-buffering
+; https://php.net/output-buffering
 output_buffering = 4096
 
 ; You can redirect all of the output of your scripts to a function.  For
@@ -237,7 +237,7 @@ output_buffering = 4096
 ;   and you cannot use both "ob_gzhandler" and "zlib.output_compression".
 ; Note: output_handler must be empty if this is set 'On' !!!!
 ;   Instead you must use zlib.output_handler.
-; http://php.net/output-handler
+; https://php.net/output-handler
 ;output_handler =
 
 ; URL rewriter function rewrites URL on the fly by using
@@ -266,16 +266,16 @@ output_buffering = 4096
 ;   performance, enable output_buffering in addition.
 ; Note: You need to use zlib.output_handler instead of the standard
 ;   output_handler, or otherwise the output will be corrupted.
-; http://php.net/zlib.output-compression
+; https://php.net/zlib.output-compression
 zlib.output_compression = Off
 
-; http://php.net/zlib.output-compression-level
+; https://php.net/zlib.output-compression-level
 ;zlib.output_compression_level = -1
 
 ; You cannot specify additional output handlers if zlib.output_compression
 ; is activated here. This setting does the same as output_handler but in
 ; a different order.
-; http://php.net/zlib.output-handler
+; https://php.net/zlib.output-handler
 ;zlib.output_handler =
 
 ; Implicit flush tells PHP to tell the output layer to flush itself
@@ -283,7 +283,7 @@ zlib.output_compression = Off
 ; PHP function flush() after each and every call to print() or echo() and each
 ; and every HTML block.  Turning this option on has serious performance
 ; implications and is generally recommended for debugging purposes only.
-; http://php.net/implicit-flush
+; https://php.net/implicit-flush
 ; Note: This directive is hardcoded to On for the CLI SAPI
 implicit_flush = Off
 
@@ -314,22 +314,22 @@ serialize_precision = -1
 ; and below.  This directive makes most sense if used in a per-directory
 ; or per-virtualhost web server configuration file.
 ; Note: disables the realpath cache
-; http://php.net/open-basedir
+; https://php.net/open-basedir
 ;open_basedir =
 
 ; This directive allows you to disable certain functions.
 ; It receives a comma-delimited list of function names.
-; http://php.net/disable-functions
-disable_functions = pcntl_alarm,pcntl_fork,pcntl_waitpid,pcntl_wait,pcntl_wifexited,pcntl_wifstopped,pcntl_wifsignaled,pcntl_wifcontinued,pcntl_wexitstatus,pcntl_wtermsig,pcntl_wstopsig,pcntl_signal,pcntl_signal_get_handler,pcntl_signal_dispatch,pcntl_get_last_error,pcntl_strerror,pcntl_sigprocmask,pcntl_sigwaitinfo,pcntl_sigtimedwait,pcntl_exec,pcntl_getpriority,pcntl_setpriority,pcntl_async_signals,pcntl_unshare,
+; https://php.net/disable-functions
+disable_functions =
 
 ; This directive allows you to disable certain classes.
 ; It receives a comma-delimited list of class names.
-; http://php.net/disable-classes
+; https://php.net/disable-classes
 disable_classes =
 
 ; Colors for Syntax Highlighting mode.  Anything that's acceptable in
 ; <span style="color: ???????"> would work.
-; http://php.net/syntax-highlighting
+; https://php.net/syntax-highlighting
 ;highlight.string  = #DD0000
 ;highlight.comment = #FF9900
 ;highlight.keyword = #007700
@@ -340,24 +340,24 @@ disable_classes =
 ; the request. Consider enabling it if executing long requests, which may end up
 ; being interrupted by the user or a browser timing out. PHP's default behavior
 ; is to disable this feature.
-; http://php.net/ignore-user-abort
+; https://php.net/ignore-user-abort
 ;ignore_user_abort = On
 
 ; Determines the size of the realpath cache to be used by PHP. This value should
 ; be increased on systems where PHP opens many files to reflect the quantity of
 ; the file operations performed.
 ; Note: if open_basedir is set, the cache is disabled
-; http://php.net/realpath-cache-size
+; https://php.net/realpath-cache-size
 ;realpath_cache_size = 4096k
 
 ; Duration of time, in seconds for which to cache realpath information for a given
 ; file or directory. For systems with rarely changing files, consider increasing this
 ; value.
-; http://php.net/realpath-cache-ttl
+; https://php.net/realpath-cache-ttl
 ;realpath_cache_ttl = 120
 
 ; Enables or disables the circular reference collector.
-; http://php.net/zend.enable-gc
+; https://php.net/zend.enable-gc
 zend.enable_gc = On
 
 ; If enabled, scripts may be written in encodings that are incompatible with
@@ -396,7 +396,7 @@ zend.exception_string_param_max_len = 0
 ; (e.g. by adding its signature to the Web server header).  It is no security
 ; threat in any way, but it makes it possible to determine whether you use PHP
 ; on your server or not.
-; http://php.net/expose-php
+; https://php.net/expose-php
 expose_php = Off
 
 ;;;;;;;;;;;;;;;;;;;
@@ -404,7 +404,7 @@ expose_php = Off
 ;;;;;;;;;;;;;;;;;;;
 
 ; Maximum execution time of each script, in seconds
-; http://php.net/max-execution-time
+; https://php.net/max-execution-time
 ; Note: This directive is hardcoded to 0 for the CLI SAPI
 max_execution_time = 300
 
@@ -415,18 +415,23 @@ max_execution_time = 300
 ; Default Value: -1 (Unlimited)
 ; Development Value: 60 (60 seconds)
 ; Production Value: 60 (60 seconds)
-; http://php.net/max-input-time
+; https://php.net/max-input-time
 max_input_time = 60
 
 ; Maximum input variable nesting level
-; http://php.net/max-input-nesting-level
+; https://php.net/max-input-nesting-level
 ;max_input_nesting_level = 64
 
 ; How many GET/POST/COOKIE input variables may be accepted
 ;max_input_vars = 1000
 
+; How many multipart body parts (combined input variable and file uploads) may
+; be accepted.
+; Default Value: -1 (Sum of max_input_vars and max_file_uploads)
+;max_multipart_body_parts = 1500
+
 ; Maximum amount of memory a script may consume
-; http://php.net/memory-limit
+; https://php.net/memory-limit
 memory_limit = 256M
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -482,7 +487,7 @@ memory_limit = 256M
 ; Default Value: E_ALL
 ; Development Value: E_ALL
 ; Production Value: E_ALL & ~E_DEPRECATED & ~E_STRICT
-; http://php.net/error-reporting
+; https://php.net/error-reporting
 error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT
 
 ; This directive controls whether or not and where PHP will output errors,
@@ -499,7 +504,7 @@ error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT
 ; Default Value: On
 ; Development Value: On
 ; Production Value: Off
-; http://php.net/display-errors
+; https://php.net/display-errors
 display_errors = Off
 
 ; The display of errors which occur during PHP's startup sequence are handled
@@ -508,7 +513,7 @@ display_errors = Off
 ; Default Value: On
 ; Development Value: On
 ; Production Value: Off
-; http://php.net/display-startup-errors
+; https://php.net/display-startup-errors
 display_startup_errors = Off
 
 ; Besides displaying errors, PHP can also log errors to locations such as a
@@ -518,36 +523,31 @@ display_startup_errors = Off
 ; Default Value: Off
 ; Development Value: On
 ; Production Value: On
-; http://php.net/log-errors
+; https://php.net/log-errors
 log_errors = On
-
-; Set maximum length of log_errors. In error_log information about the source is
-; added. The default is 1024 and 0 allows to not apply any maximum length at all.
-; http://php.net/log-errors-max-len
-log_errors_max_len = 1024
 
 ; Do not log repeated messages. Repeated errors must occur in same file on same
 ; line unless ignore_repeated_source is set true.
-; http://php.net/ignore-repeated-errors
+; https://php.net/ignore-repeated-errors
 ignore_repeated_errors = Off
 
 ; Ignore source of message when ignoring repeated messages. When this setting
 ; is On you will not log errors with repeated messages from different files or
 ; source lines.
-; http://php.net/ignore-repeated-source
+; https://php.net/ignore-repeated-source
 ignore_repeated_source = Off
 
 ; If this parameter is set to Off, then memory leaks will not be shown (on
 ; stdout or in the log). This is only effective in a debug compile, and if
 ; error reporting includes E_WARNING in the allowed list
-; http://php.net/report-memleaks
+; https://php.net/report-memleaks
 report_memleaks = On
 
 ; This setting is off by default.
 ;report_zend_debug = 0
 
 ; Turn off normal error reporting and emit XML-RPC error XML
-; http://php.net/xmlrpc-errors
+; https://php.net/xmlrpc-errors
 ;xmlrpc_errors = 0
 
 ; An XML-RPC faultCode
@@ -557,40 +557,40 @@ report_memleaks = On
 ; error message as HTML for easier reading. This directive controls whether
 ; the error message is formatted as HTML or not.
 ; Note: This directive is hardcoded to Off for the CLI SAPI
-; http://php.net/html-errors
+; https://php.net/html-errors
 html_errors = On
 
 ; If html_errors is set to On *and* docref_root is not empty, then PHP
 ; produces clickable error messages that direct to a page describing the error
 ; or function causing the error in detail.
-; You can download a copy of the PHP manual from http://php.net/docs
+; You can download a copy of the PHP manual from https://php.net/docs
 ; and change docref_root to the base URL of your local copy including the
 ; leading '/'. You must also specify the file extension being used including
 ; the dot. PHP's default behavior is to leave these settings empty, in which
 ; case no links to documentation are generated.
 ; Note: Never use this feature for production boxes.
-; http://php.net/docref-root
+; https://php.net/docref-root
 ; Examples
 ;docref_root = "/phpmanual/"
 
-; http://php.net/docref-ext
+; https://php.net/docref-ext
 ;docref_ext = .html
 
 ; String to output before an error message. PHP's default behavior is to leave
 ; this setting blank.
-; http://php.net/error-prepend-string
+; https://php.net/error-prepend-string
 ; Example:
 ;error_prepend_string = "<span style='color: #ff0000'>"
 
 ; String to output after an error message. PHP's default behavior is to leave
 ; this setting blank.
-; http://php.net/error-append-string
+; https://php.net/error-append-string
 ; Example:
 ;error_append_string = "</span>"
 
 ; Log errors to specified file. PHP's default behavior is to leave this value
 ; empty.
-; http://php.net/error-log
+; https://php.net/error-log
 ; Example:
 ;error_log = php_errors.log
 ; Log errors to syslog (Event Log on Windows).
@@ -613,7 +613,7 @@ html_errors = On
 ;   no-ctrl (all characters except control characters)
 ;   all (all characters)
 ;   raw (like "all", but messages are not split at newlines)
-; http://php.net/syslog.filter
+; https://php.net/syslog.filter
 ;syslog.filter = ascii
 
 ;windows.show_crt_warning
@@ -627,14 +627,14 @@ html_errors = On
 
 ; The separator used in PHP generated URLs to separate arguments.
 ; PHP's default setting is "&".
-; http://php.net/arg-separator.output
+; https://php.net/arg-separator.output
 ; Example:
 ;arg_separator.output = "&amp;"
 
 ; List of separator(s) used by PHP to parse input URLs into variables.
 ; PHP's default setting is "&".
 ; NOTE: Every character in this directive is considered as separator!
-; http://php.net/arg-separator.input
+; https://php.net/arg-separator.input
 ; Example:
 ;arg_separator.input = ";&"
 
@@ -648,7 +648,7 @@ html_errors = On
 ; Default Value: "EGPCS"
 ; Development Value: "GPCS"
 ; Production Value: "GPCS";
-; http://php.net/variables-order
+; https://php.net/variables-order
 variables_order = "GPCS"
 
 ; This directive determines which super global data (G,P & C) should be
@@ -661,7 +661,7 @@ variables_order = "GPCS"
 ; Default Value: None
 ; Development Value: "GP"
 ; Production Value: "GP"
-; http://php.net/request-order
+; https://php.net/request-order
 request_order = "GP"
 
 ; This directive determines whether PHP registers $argv & $argc each time it
@@ -676,7 +676,7 @@ request_order = "GP"
 ; Default Value: On
 ; Development Value: Off
 ; Production Value: Off
-; http://php.net/register-argc-argv
+; https://php.net/register-argc-argv
 register_argc_argv = Off
 
 ; When enabled, the ENV, REQUEST and SERVER variables are created when they're
@@ -684,7 +684,7 @@ register_argc_argv = Off
 ; variables are not used within a script, having this directive on will result
 ; in a performance gain. The PHP directive register_argc_argv must be disabled
 ; for this directive to have any effect.
-; http://php.net/auto-globals-jit
+; https://php.net/auto-globals-jit
 auto_globals_jit = On
 
 ; Whether PHP will read the POST data.
@@ -693,48 +693,48 @@ auto_globals_jit = On
 ; and $_FILES to always be empty; the only way you will be able to read the
 ; POST data will be through the php://input stream wrapper. This can be useful
 ; to proxy requests or to process the POST data in a memory efficient fashion.
-; http://php.net/enable-post-data-reading
+; https://php.net/enable-post-data-reading
 ;enable_post_data_reading = Off
 
 ; Maximum size of POST data that PHP will accept.
 ; Its value may be 0 to disable the limit. It is ignored if POST data reading
 ; is disabled through enable_post_data_reading.
-; http://php.net/post-max-size
+; https://php.net/post-max-size
 post_max_size = 8M
 
 ; Automatically add files before PHP document.
-; http://php.net/auto-prepend-file
+; https://php.net/auto-prepend-file
 auto_prepend_file =
 
 ; Automatically add files after PHP document.
-; http://php.net/auto-append-file
+; https://php.net/auto-append-file
 auto_append_file =
 
 ; By default, PHP will output a media type using the Content-Type header. To
 ; disable this, simply set it to be empty.
 ;
 ; PHP's built-in default media type is set to text/html.
-; http://php.net/default-mimetype
+; https://php.net/default-mimetype
 default_mimetype = "text/html"
 
 ; PHP's default character set is set to UTF-8.
-; http://php.net/default-charset
+; https://php.net/default-charset
 default_charset = "UTF-8"
 
 ; PHP internal character encoding is set to empty.
 ; If empty, default_charset is used.
-; http://php.net/internal-encoding
+; https://php.net/internal-encoding
 ;internal_encoding =
 
 ; PHP input character encoding is set to empty.
 ; If empty, default_charset is used.
-; http://php.net/input-encoding
+; https://php.net/input-encoding
 ;input_encoding =
 
 ; PHP output character encoding is set to empty.
 ; If empty, default_charset is used.
 ; See also output_buffer.
-; http://php.net/output-encoding
+; https://php.net/output-encoding
 ;output_encoding =
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -748,23 +748,23 @@ default_charset = "UTF-8"
 ;include_path = ".;c:\php\includes"
 ;
 ; PHP's default setting for include_path is ".;/path/to/php/pear"
-; http://php.net/include-path
+; https://php.net/include-path
 
 ; The root of the PHP pages, used only if nonempty.
 ; if PHP was not compiled with FORCE_REDIRECT, you SHOULD set doc_root
 ; if you are running php as a CGI under any web server (other than IIS)
 ; see documentation for security issues.  The alternate is to use the
 ; cgi.force_redirect configuration below
-; http://php.net/doc-root
+; https://php.net/doc-root
 doc_root =
 
 ; The directory under which PHP opens the script using /~username used only
 ; if nonempty.
-; http://php.net/user-dir
+; https://php.net/user-dir
 user_dir =
 
 ; Directory in which the loadable extensions (modules) reside.
-; http://php.net/extension-dir
+; https://php.net/extension-dir
 ;extension_dir = "./"
 ; On windows:
 ;extension_dir = "ext"
@@ -776,14 +776,14 @@ user_dir =
 ; Whether or not to enable the dl() function.  The dl() function does NOT work
 ; properly in multithreaded servers, such as IIS or Zeus, and is automatically
 ; disabled on them.
-; http://php.net/enable-dl
+; https://php.net/enable-dl
 enable_dl = Off
 
 ; cgi.force_redirect is necessary to provide security running PHP as a CGI under
 ; most web servers.  Left undefined, PHP turns this on by default.  You can
 ; turn it off here AT YOUR OWN RISK
 ; **You CAN safely turn this off for IIS, in fact, you MUST.**
-; http://php.net/cgi.force-redirect
+; https://php.net/cgi.force-redirect
 ;cgi.force_redirect = 1
 
 ; if cgi.nph is enabled it will force cgi to always sent Status: 200 with
@@ -794,7 +794,7 @@ enable_dl = Off
 ; (iPlanet) web servers, you MAY need to set an environment variable name that PHP
 ; will look for to know it is OK to continue execution.  Setting this variable MAY
 ; cause security issues, KNOW WHAT YOU ARE DOING FIRST.
-; http://php.net/cgi.redirect-status-env
+; https://php.net/cgi.redirect-status-env
 ;cgi.redirect_status_env =
 
 ; cgi.fix_pathinfo provides *real* PATH_INFO/PATH_TRANSLATED support for CGI.  PHP's
@@ -803,7 +803,7 @@ enable_dl = Off
 ; this to 1 will cause PHP CGI to fix its paths to conform to the spec.  A setting
 ; of zero causes PHP to behave as before.  Default is 1.  You should fix your scripts
 ; to use SCRIPT_FILENAME rather than PATH_TRANSLATED.
-; http://php.net/cgi.fix-pathinfo
+; https://php.net/cgi.fix-pathinfo
 ;cgi.fix_pathinfo=1
 
 ; if cgi.discard_path is enabled, the PHP CGI binary can safely be placed outside
@@ -815,7 +815,7 @@ enable_dl = Off
 ; security context that the request runs under.  mod_fastcgi under Apache
 ; does not currently support this feature (03/17/2002)
 ; Set to 1 if running under IIS.  Default is zero.
-; http://php.net/fastcgi.impersonate
+; https://php.net/fastcgi.impersonate
 ;fastcgi.impersonate = 1
 
 ; Disable logging through FastCGI connection. PHP's default behavior is to enable
@@ -827,14 +827,14 @@ enable_dl = Off
 ; is supported by Apache. When this option is set to 1, PHP will send
 ; RFC2616 compliant header.
 ; Default is zero.
-; http://php.net/cgi.rfc2616-headers
+; https://php.net/cgi.rfc2616-headers
 ;cgi.rfc2616_headers = 0
 
 ; cgi.check_shebang_line controls whether CGI PHP checks for line starting with #!
 ; (shebang) at the top of the running script. This line might be needed if the
 ; script support running both as stand-alone script and via PHP CGI<. PHP in CGI
 ; mode skips this line and ignores its content if this directive is turned on.
-; http://php.net/cgi.check-shebang-line
+; https://php.net/cgi.check-shebang-line
 ;cgi.check_shebang_line=1
 
 ;;;;;;;;;;;;;;;;
@@ -842,17 +842,17 @@ enable_dl = Off
 ;;;;;;;;;;;;;;;;
 
 ; Whether to allow HTTP file uploads.
-; http://php.net/file-uploads
+; https://php.net/file-uploads
 file_uploads = On
 
 ; Temporary directory for HTTP uploaded files (will use system default if not
 ; specified).
-; http://php.net/upload-tmp-dir
+; https://php.net/upload-tmp-dir
 ;upload_tmp_dir =
 
 ; Maximum allowed size for uploaded files.
-; http://php.net/upload-max-filesize
-upload_max_filesize = 20M
+; https://php.net/upload-max-filesize
+upload_max_filesize = 2M
 
 ; Maximum number of files that can be uploaded via a single request
 max_file_uploads = 20
@@ -862,24 +862,24 @@ max_file_uploads = 20
 ;;;;;;;;;;;;;;;;;;
 
 ; Whether to allow the treatment of URLs (like http:// or ftp://) as files.
-; http://php.net/allow-url-fopen
+; https://php.net/allow-url-fopen
 allow_url_fopen = On
 
-; Whether to allow include/require to open URLs (like http:// or ftp://) as files.
-; http://php.net/allow-url-include
+; Whether to allow include/require to open URLs (like https:// or ftp://) as files.
+; https://php.net/allow-url-include
 allow_url_include = Off
 
 ; Define the anonymous ftp password (your email address). PHP's default setting
 ; for this is empty.
-; http://php.net/from
+; https://php.net/from
 ;from="john@doe.com"
 
 ; Define the User-Agent string. PHP's default setting for this is empty.
-; http://php.net/user-agent
+; https://php.net/user-agent
 ;user_agent="PHP"
 
 ; Default timeout for socket based streams (seconds)
-; http://php.net/default-socket-timeout
+; https://php.net/default-socket-timeout
 default_socket_timeout = 60
 
 ; If your scripts have to deal with files from Macintosh systems,
@@ -887,7 +887,7 @@ default_socket_timeout = 60
 ; unix or win32 systems, setting this flag will cause PHP to
 ; automatically detect the EOL character in those files so that
 ; fgets() and file() will work regardless of the source of the file.
-; http://php.net/auto-detect-line-endings
+; https://php.net/auto-detect-line-endings
 ;auto_detect_line_endings = Off
 
 ;;;;;;;;;;;;;;;;;;;;;;
@@ -920,6 +920,12 @@ default_socket_timeout = 60
 ;   Be sure to appropriately set the extension_dir directive.
 ;
 ;extension=bz2
+
+; The ldap extension must be before curl if OpenSSL 1.0.2 and OpenLDAP is used
+; otherwise it results in segfault when unloading after using SASL.
+; See https://github.com/php/php-src/issues/8620 for more info.
+;extension=ldap
+
 ;extension=curl
 ;extension=ffi
 ;extension=ftp
@@ -929,7 +935,6 @@ default_socket_timeout = 60
 ;extension=gmp
 ;extension=intl
 ;extension=imap
-;extension=ldap
 ;extension=mbstring
 ;extension=exif      ; Must be after mbstring as it depends on it
 ;extension=mysqli
@@ -947,7 +952,7 @@ default_socket_timeout = 60
 ;extension=shmop
 
 ; The MIBS data available in the PHP distribution must be installed.
-; See http://www.php.net/manual/en/snmp.installation.php
+; See https://www.php.net/manual/en/snmp.installation.php
 ;extension=snmp
 
 ;extension=soap
@@ -969,26 +974,26 @@ cli_server.color = On
 
 [Date]
 ; Defines the default timezone used by the date functions
-; http://php.net/date.timezone
+; https://php.net/date.timezone
 date.timezone = "UTC"
 
-; http://php.net/date.default-latitude
+; https://php.net/date.default-latitude
 ;date.default_latitude = 31.7667
 
-; http://php.net/date.default-longitude
+; https://php.net/date.default-longitude
 ;date.default_longitude = 35.2333
 
-; http://php.net/date.sunrise-zenith
+; https://php.net/date.sunrise-zenith
 ;date.sunrise_zenith = 90.833333
 
-; http://php.net/date.sunset-zenith
+; https://php.net/date.sunset-zenith
 ;date.sunset_zenith = 90.833333
 
 [filter]
-; http://php.net/filter.default
+; https://php.net/filter.default
 ;filter.default = unsafe_raw
 
-; http://php.net/filter.default-flags
+; https://php.net/filter.default-flags
 ;filter.default_flags =
 
 [iconv]
@@ -1026,7 +1031,7 @@ date.timezone = "UTC"
 
 [sqlite3]
 ; Directory pointing to SQLite3 extensions
-; http://php.net/sqlite3.extension-dir
+; https://php.net/sqlite3.extension-dir
 ;sqlite3.extension_dir =
 
 ; SQLite defensive mode flag (only available from SQLite 3.26+)
@@ -1040,14 +1045,14 @@ date.timezone = "UTC"
 
 [Pcre]
 ; PCRE library backtracking limit.
-; http://php.net/pcre.backtrack-limit
+; https://php.net/pcre.backtrack-limit
 ;pcre.backtrack_limit=100000
 
 ; PCRE library recursion limit.
 ; Please note that if you set this value to a high number you may consume all
 ; the available process stack and eventually crash PHP (due to reaching the
 ; stack size limit imposed by the Operating System).
-; http://php.net/pcre.recursion-limit
+; https://php.net/pcre.recursion-limit
 ;pcre.recursion_limit=100000
 
 ; Enables or disables JIT compilation of patterns. This requires the PCRE
@@ -1056,7 +1061,7 @@ date.timezone = "UTC"
 
 [Pdo]
 ; Whether to pool ODBC connections. Can be one of "strict", "relaxed" or "off"
-; http://php.net/pdo-odbc.connection-pooling
+; https://php.net/pdo-odbc.connection-pooling
 ;pdo_odbc.connection_pooling=strict
 
 [Pdo_mysql]
@@ -1065,27 +1070,27 @@ date.timezone = "UTC"
 pdo_mysql.default_socket=
 
 [Phar]
-; http://php.net/phar.readonly
+; https://php.net/phar.readonly
 ;phar.readonly = On
 
-; http://php.net/phar.require-hash
+; https://php.net/phar.require-hash
 ;phar.require_hash = On
 
 ;phar.cache_list =
 
 [mail function]
 ; For Win32 only.
-; http://php.net/smtp
+; https://php.net/smtp
 SMTP = localhost
-; http://php.net/smtp-port
+; https://php.net/smtp-port
 smtp_port = 25
 
 ; For Win32 only.
-; http://php.net/sendmail-from
+; https://php.net/sendmail-from
 ;sendmail_from = me@example.com
 
 ; For Unix only.  You may supply arguments as well (default: "sendmail -t -i").
-; http://php.net/sendmail-path
+; https://php.net/sendmail-path
 ;sendmail_path =
 
 ; Force the addition of the specified parameters to be passed as extra parameters
@@ -1103,13 +1108,13 @@ mail.add_x_header = Off
 ;mail.log = syslog
 
 [ODBC]
-; http://php.net/odbc.default-db
+; https://php.net/odbc.default-db
 ;odbc.default_db    =  Not yet implemented
 
-; http://php.net/odbc.default-user
+; https://php.net/odbc.default-user
 ;odbc.default_user  =  Not yet implemented
 
-; http://php.net/odbc.default-pw
+; https://php.net/odbc.default-pw
 ;odbc.default_pw    =  Not yet implemented
 
 ; Controls the ODBC cursor model.
@@ -1117,68 +1122,72 @@ mail.add_x_header = Off
 ;odbc.default_cursortype
 
 ; Allow or prevent persistent links.
-; http://php.net/odbc.allow-persistent
+; https://php.net/odbc.allow-persistent
 odbc.allow_persistent = On
 
 ; Check that a connection is still valid before reuse.
-; http://php.net/odbc.check-persistent
+; https://php.net/odbc.check-persistent
 odbc.check_persistent = On
 
 ; Maximum number of persistent links.  -1 means no limit.
-; http://php.net/odbc.max-persistent
+; https://php.net/odbc.max-persistent
 odbc.max_persistent = -1
 
 ; Maximum number of links (persistent + non-persistent).  -1 means no limit.
-; http://php.net/odbc.max-links
+; https://php.net/odbc.max-links
 odbc.max_links = -1
 
 ; Handling of LONG fields.  Returns number of bytes to variables.  0 means
 ; passthru.
-; http://php.net/odbc.defaultlrl
+; https://php.net/odbc.defaultlrl
 odbc.defaultlrl = 4096
 
 ; Handling of binary data.  0 means passthru, 1 return as is, 2 convert to char.
 ; See the documentation on odbc_binmode and odbc_longreadlen for an explanation
 ; of odbc.defaultlrl and odbc.defaultbinmode
-; http://php.net/odbc.defaultbinmode
+; https://php.net/odbc.defaultbinmode
 odbc.defaultbinmode = 1
 
 [MySQLi]
 
 ; Maximum number of persistent links.  -1 means no limit.
-; http://php.net/mysqli.max-persistent
+; https://php.net/mysqli.max-persistent
 mysqli.max_persistent = -1
 
 ; Allow accessing, from PHP's perspective, local files with LOAD DATA statements
-; http://php.net/mysqli.allow_local_infile
+; https://php.net/mysqli.allow_local_infile
 ;mysqli.allow_local_infile = On
 
+; It allows the user to specify a folder where files that can be sent via LOAD DATA
+; LOCAL can exist. It is ignored if mysqli.allow_local_infile is enabled.
+;mysqli.local_infile_directory =
+
 ; Allow or prevent persistent links.
-; http://php.net/mysqli.allow-persistent
+; https://php.net/mysqli.allow-persistent
 mysqli.allow_persistent = On
 
 ; Maximum number of links.  -1 means no limit.
-; http://php.net/mysqli.max-links
+; https://php.net/mysqli.max-links
 mysqli.max_links = -1
 
 ; Default port number for mysqli_connect().  If unset, mysqli_connect() will use
 ; the $MYSQL_TCP_PORT or the mysql-tcp entry in /etc/services or the
 ; compile-time value defined MYSQL_PORT (in that order).  Win32 will only look
 ; at MYSQL_PORT.
-; http://php.net/mysqli.default-port
+; https://php.net/mysqli.default-port
 mysqli.default_port = 3306
 
 ; Default socket name for local MySQL connects.  If empty, uses the built-in
 ; MySQL defaults.
-; http://php.net/mysqli.default-socket
+; https://php.net/mysqli.default-socket
 mysqli.default_socket =
 
 ; Default host for mysqli_connect() (doesn't apply in safe mode).
-; http://php.net/mysqli.default-host
+; https://php.net/mysqli.default-host
 mysqli.default_host =
 
 ; Default user for mysqli_connect() (doesn't apply in safe mode).
-; http://php.net/mysqli.default-user
+; https://php.net/mysqli.default-user
 mysqli.default_user =
 
 ; Default password for mysqli_connect() (doesn't apply in safe mode).
@@ -1186,11 +1195,16 @@ mysqli.default_user =
 ; *Any* user with PHP access can run 'echo get_cfg_var("mysqli.default_pw")
 ; and reveal this password!  And of course, any users with read access to this
 ; file will be able to reveal the password as well.
-; http://php.net/mysqli.default-pw
+; https://php.net/mysqli.default-pw
 mysqli.default_pw =
 
 ; Allow or prevent reconnect
 mysqli.reconnect = Off
+
+; If this option is enabled, closing a persistent connection will rollback
+; any pending transactions of this connection, before it is put back
+; into the persistent connection pool.
+;mysqli.rollback_on_cached_plink = Off
 
 [mysqlnd]
 ; Enable / Disable collection of general statistics by mysqlnd which can be
@@ -1203,7 +1217,7 @@ mysqlnd.collect_memory_statistics = Off
 
 ; Records communication from all extensions using mysqlnd to the specified log
 ; file.
-; http://php.net/mysqlnd.debug
+; https://php.net/mysqlnd.debug
 ;mysqlnd.debug =
 
 ; Defines which queries will be logged.
@@ -1230,25 +1244,25 @@ mysqlnd.collect_memory_statistics = Off
 
 ; Connection: Enables privileged connections using external
 ; credentials (OCI_SYSOPER, OCI_SYSDBA)
-; http://php.net/oci8.privileged-connect
+; https://php.net/oci8.privileged-connect
 ;oci8.privileged_connect = Off
 
 ; Connection: The maximum number of persistent OCI8 connections per
 ; process. Using -1 means no limit.
-; http://php.net/oci8.max-persistent
+; https://php.net/oci8.max-persistent
 ;oci8.max_persistent = -1
 
 ; Connection: The maximum number of seconds a process is allowed to
 ; maintain an idle persistent connection. Using -1 means idle
 ; persistent connections will be maintained forever.
-; http://php.net/oci8.persistent-timeout
+; https://php.net/oci8.persistent-timeout
 ;oci8.persistent_timeout = -1
 
 ; Connection: The number of seconds that must pass before issuing a
 ; ping during oci_pconnect() to check the connection validity. When
 ; set to 0, each oci_pconnect() will cause a ping. Using -1 disables
 ; pings completely.
-; http://php.net/oci8.ping-interval
+; https://php.net/oci8.ping-interval
 ;oci8.ping_interval = 60
 
 ; Connection: Set this to a user chosen connection class to be used
@@ -1266,59 +1280,59 @@ mysqlnd.collect_memory_statistics = Off
 
 ; Tuning: This option enables statement caching, and specifies how
 ; many statements to cache. Using 0 disables statement caching.
-; http://php.net/oci8.statement-cache-size
+; https://php.net/oci8.statement-cache-size
 ;oci8.statement_cache_size = 20
 
 ; Tuning: Enables statement prefetching and sets the default number of
 ; rows that will be fetched automatically after statement execution.
-; http://php.net/oci8.default-prefetch
+; https://php.net/oci8.default-prefetch
 ;oci8.default_prefetch = 100
 
 ; Compatibility. Using On means oci_close() will not close
 ; oci_connect() and oci_new_connect() connections.
-; http://php.net/oci8.old-oci-close-semantics
+; https://php.net/oci8.old-oci-close-semantics
 ;oci8.old_oci_close_semantics = Off
 
 [PostgreSQL]
 ; Allow or prevent persistent links.
-; http://php.net/pgsql.allow-persistent
+; https://php.net/pgsql.allow-persistent
 pgsql.allow_persistent = On
 
 ; Detect broken persistent links always with pg_pconnect().
 ; Auto reset feature requires a little overheads.
-; http://php.net/pgsql.auto-reset-persistent
+; https://php.net/pgsql.auto-reset-persistent
 pgsql.auto_reset_persistent = Off
 
 ; Maximum number of persistent links.  -1 means no limit.
-; http://php.net/pgsql.max-persistent
+; https://php.net/pgsql.max-persistent
 pgsql.max_persistent = -1
 
 ; Maximum number of links (persistent+non persistent).  -1 means no limit.
-; http://php.net/pgsql.max-links
+; https://php.net/pgsql.max-links
 pgsql.max_links = -1
 
 ; Ignore PostgreSQL backends Notice message or not.
 ; Notice message logging require a little overheads.
-; http://php.net/pgsql.ignore-notice
+; https://php.net/pgsql.ignore-notice
 pgsql.ignore_notice = 0
 
 ; Log PostgreSQL backends Notice message or not.
 ; Unless pgsql.ignore_notice=0, module cannot log notice message.
-; http://php.net/pgsql.log-notice
+; https://php.net/pgsql.log-notice
 pgsql.log_notice = 0
 
 [bcmath]
 ; Number of decimal digits for all bcmath functions.
-; http://php.net/bcmath.scale
+; https://php.net/bcmath.scale
 bcmath.scale = 0
 
 [browscap]
-; http://php.net/browscap
+; https://php.net/browscap
 ;browscap = extra/browscap.ini
 
 [Session]
 ; Handler used to store/retrieve data.
-; http://php.net/session.save-handler
+; https://php.net/session.save-handler
 session.save_handler = files
 
 ; Argument passed to save_handler.  In the case of files, this is the path
@@ -1347,7 +1361,7 @@ session.save_handler = files
 ;
 ; where MODE is the octal representation of the mode. Note that this
 ; does not overwrite the process's umask.
-; http://php.net/session.save-path
+; https://php.net/session.save-path
 ;session.save_path = "/var/lib/php/sessions"
 
 ; Whether to use strict session mode.
@@ -1360,42 +1374,42 @@ session.save_handler = files
 session.use_strict_mode = 0
 
 ; Whether to use cookies.
-; http://php.net/session.use-cookies
+; https://php.net/session.use-cookies
 session.use_cookies = 1
 
-; http://php.net/session.cookie-secure
+; https://php.net/session.cookie-secure
 ;session.cookie_secure =
 
 ; This option forces PHP to fetch and use a cookie for storing and maintaining
 ; the session id. We encourage this operation as it's very helpful in combating
 ; session hijacking when not specifying and managing your own session id. It is
 ; not the be-all and end-all of session hijacking defense, but it's a good start.
-; http://php.net/session.use-only-cookies
+; https://php.net/session.use-only-cookies
 session.use_only_cookies = 1
 
 ; Name of the session (used as cookie name).
-; http://php.net/session.name
+; https://php.net/session.name
 session.name = PHPSESSID
 
 ; Initialize session on request startup.
-; http://php.net/session.auto-start
+; https://php.net/session.auto-start
 session.auto_start = 0
 
 ; Lifetime in seconds of cookie or, if 0, until browser is restarted.
-; http://php.net/session.cookie-lifetime
+; https://php.net/session.cookie-lifetime
 session.cookie_lifetime = 0
 
 ; The path for which the cookie is valid.
-; http://php.net/session.cookie-path
+; https://php.net/session.cookie-path
 session.cookie_path = /
 
 ; The domain for which the cookie is valid.
-; http://php.net/session.cookie-domain
+; https://php.net/session.cookie-domain
 session.cookie_domain =
 
 ; Whether or not to add the httpOnly flag to the cookie, which makes it
 ; inaccessible to browser scripting languages such as JavaScript.
-; http://php.net/session.cookie-httponly
+; https://php.net/session.cookie-httponly
 session.cookie_httponly =
 
 ; Add SameSite attribute to cookie to help mitigate Cross-Site Request Forgery (CSRF/XSRF)
@@ -1405,7 +1419,7 @@ session.cookie_httponly =
 session.cookie_samesite =
 
 ; Handler used to serialize data. php is the standard serializer of PHP.
-; http://php.net/session.serialize-handler
+; https://php.net/session.serialize-handler
 session.serialize_handler = php
 
 ; Defines the probability that the 'garbage collection' process is started on every
@@ -1414,7 +1428,7 @@ session.serialize_handler = php
 ; Default Value: 1
 ; Development Value: 1
 ; Production Value: 1
-; http://php.net/session.gc-probability
+; https://php.net/session.gc-probability
 session.gc_probability = 0
 
 ; Defines the probability that the 'garbage collection' process is started on every
@@ -1424,12 +1438,12 @@ session.gc_probability = 0
 ; Default Value: 100
 ; Development Value: 1000
 ; Production Value: 1000
-; http://php.net/session.gc-divisor
+; https://php.net/session.gc-divisor
 session.gc_divisor = 1000
 
 ; After this number of seconds, stored data will be seen as 'garbage' and
 ; cleaned up by the garbage collection process.
-; http://php.net/session.gc-maxlifetime
+; https://php.net/session.gc-maxlifetime
 session.gc_maxlifetime = 1440
 
 ; NOTE: If you are using the subdirectory option for storing session files
@@ -1443,16 +1457,16 @@ session.gc_maxlifetime = 1440
 ; Check HTTP Referer to invalidate externally stored URLs containing ids.
 ; HTTP_REFERER has to contain this substring for the session to be
 ; considered as valid.
-; http://php.net/session.referer-check
+; https://php.net/session.referer-check
 session.referer_check =
 
 ; Set to {nocache,private,public,} to determine HTTP caching aspects
 ; or leave this empty to avoid sending anti-caching headers.
-; http://php.net/session.cache-limiter
+; https://php.net/session.cache-limiter
 session.cache_limiter = nocache
 
 ; Document expires after n minutes.
-; http://php.net/session.cache-expire
+; https://php.net/session.cache-expire
 session.cache_expire = 180
 
 ; trans sid support is disabled by default.
@@ -1464,13 +1478,13 @@ session.cache_expire = 180
 ;   in publicly accessible computer.
 ; - User may access your site with the same session ID
 ;   always using URL stored in browser's history or bookmarks.
-; http://php.net/session.use-trans-sid
+; https://php.net/session.use-trans-sid
 session.use_trans_sid = 0
 
 ; Set session ID character length. This value could be between 22 to 256.
 ; Shorter length than default is supported only for compatibility reason.
 ; Users should use 32 or more chars.
-; http://php.net/session.sid-length
+; https://php.net/session.sid-length
 ; Default Value: 32
 ; Development Value: 26
 ; Production Value: 26
@@ -1485,7 +1499,7 @@ session.sid_length = 26
 ; Default Value: "a=href,area=href,frame=src,form="
 ; Development Value: "a=href,area=href,frame=src,form="
 ; Production Value: "a=href,area=href,frame=src,form="
-; http://php.net/url-rewriter.tags
+; https://php.net/url-rewriter.tags
 session.trans_sid_tags = "a=href,area=href,frame=src,form="
 
 ; URL rewriter does not rewrite absolute URLs by default.
@@ -1510,14 +1524,14 @@ session.trans_sid_tags = "a=href,area=href,frame=src,form="
 ; Default Value: 4
 ; Development Value: 5
 ; Production Value: 5
-; http://php.net/session.hash-bits-per-character
+; https://php.net/session.hash-bits-per-character
 session.sid_bits_per_character = 5
 
 ; Enable upload progress tracking in $_SESSION
 ; Default Value: On
 ; Development Value: On
 ; Production Value: On
-; http://php.net/session.upload-progress.enabled
+; https://php.net/session.upload-progress.enabled
 ;session.upload_progress.enabled = On
 
 ; Cleanup the progress information as soon as all POST data has been read
@@ -1525,14 +1539,14 @@ session.sid_bits_per_character = 5
 ; Default Value: On
 ; Development Value: On
 ; Production Value: On
-; http://php.net/session.upload-progress.cleanup
+; https://php.net/session.upload-progress.cleanup
 ;session.upload_progress.cleanup = On
 
 ; A prefix used for the upload progress key in $_SESSION
 ; Default Value: "upload_progress_"
 ; Development Value: "upload_progress_"
 ; Production Value: "upload_progress_"
-; http://php.net/session.upload-progress.prefix
+; https://php.net/session.upload-progress.prefix
 ;session.upload_progress.prefix = "upload_progress_"
 
 ; The index name (concatenated with the prefix) in $_SESSION
@@ -1540,7 +1554,7 @@ session.sid_bits_per_character = 5
 ; Default Value: "PHP_SESSION_UPLOAD_PROGRESS"
 ; Development Value: "PHP_SESSION_UPLOAD_PROGRESS"
 ; Production Value: "PHP_SESSION_UPLOAD_PROGRESS"
-; http://php.net/session.upload-progress.name
+; https://php.net/session.upload-progress.name
 ;session.upload_progress.name = "PHP_SESSION_UPLOAD_PROGRESS"
 
 ; How frequently the upload progress should be updated.
@@ -1548,18 +1562,18 @@ session.sid_bits_per_character = 5
 ; Default Value: "1%"
 ; Development Value: "1%"
 ; Production Value: "1%"
-; http://php.net/session.upload-progress.freq
+; https://php.net/session.upload-progress.freq
 ;session.upload_progress.freq =  "1%"
 
 ; The minimum delay between updates, in seconds
 ; Default Value: 1
 ; Development Value: 1
 ; Production Value: 1
-; http://php.net/session.upload-progress.min-freq
+; https://php.net/session.upload-progress.min-freq
 ;session.upload_progress.min_freq = "1"
 
 ; Only write session data when session data is changed. Enabled by default.
-; http://php.net/session.lazy-write
+; https://php.net/session.lazy-write
 ;session.lazy_write = On
 
 [Assertion]
@@ -1571,48 +1585,48 @@ session.sid_bits_per_character = 5
 ; Default Value: 1
 ; Development Value: 1
 ; Production Value: -1
-; http://php.net/zend.assertions
+; https://php.net/zend.assertions
 zend.assertions = -1
 
 ; Assert(expr); active by default.
-; http://php.net/assert.active
+; https://php.net/assert.active
 ;assert.active = On
 
 ; Throw an AssertionError on failed assertions
-; http://php.net/assert.exception
+; https://php.net/assert.exception
 ;assert.exception = On
 
 ; Issue a PHP warning for each failed assertion. (Overridden by assert.exception if active)
-; http://php.net/assert.warning
+; https://php.net/assert.warning
 ;assert.warning = On
 
 ; Don't bail out by default.
-; http://php.net/assert.bail
+; https://php.net/assert.bail
 ;assert.bail = Off
 
 ; User-function to be called if an assertion fails.
-; http://php.net/assert.callback
+; https://php.net/assert.callback
 ;assert.callback = 0
 
 [COM]
 ; path to a file containing GUIDs, IIDs or filenames of files with TypeLibs
-; http://php.net/com.typelib-file
+; https://php.net/com.typelib-file
 ;com.typelib_file =
 
 ; allow Distributed-COM calls
-; http://php.net/com.allow-dcom
+; https://php.net/com.allow-dcom
 ;com.allow_dcom = true
 
-; autoregister constants of a component's typlib on com_load()
-; http://php.net/com.autoregister-typelib
+; autoregister constants of a component's typelib on com_load()
+; https://php.net/com.autoregister-typelib
 ;com.autoregister_typelib = true
 
 ; register constants casesensitive
-; http://php.net/com.autoregister-casesensitive
+; https://php.net/com.autoregister-casesensitive
 ;com.autoregister_casesensitive = false
 
 ; show warnings on duplicate constant registrations
-; http://php.net/com.autoregister-verbose
+; https://php.net/com.autoregister-verbose
 ;com.autoregister_verbose = true
 
 ; The default character set code-page to use when passing strings to and from COM objects.
@@ -1626,7 +1640,7 @@ zend.assertions = -1
 [mbstring]
 ; language for internal character representation.
 ; This affects mb_send_mail() and mbstring.detect_order.
-; http://php.net/mbstring.language
+; https://php.net/mbstring.language
 ;mbstring.language = Japanese
 
 ; Use of this INI entry is deprecated, use global internal_encoding instead.
@@ -1641,7 +1655,7 @@ zend.assertions = -1
 ; mbstring.encoding_translation = On is needed to use this setting.
 ; If empty, default_charset or input_encoding or mbstring.input is used.
 ; The precedence is: default_charset < input_encoding < mbstring.http_input
-; http://php.net/mbstring.http-input
+; https://php.net/mbstring.http-input
 ;mbstring.http_input =
 
 ; Use of this INI entry is deprecated, use global output_encoding instead.
@@ -1651,7 +1665,7 @@ zend.assertions = -1
 ; The precedence is: default_charset < output_encoding < mbstring.http_output
 ; To use an output encoding conversion, mbstring's output handler must be set
 ; otherwise output encoding conversion cannot be performed.
-; http://php.net/mbstring.http-output
+; https://php.net/mbstring.http-output
 ;mbstring.http_output =
 
 ; enable automatic encoding translation according to
@@ -1659,17 +1673,17 @@ zend.assertions = -1
 ; converted to internal encoding by setting this to On.
 ; Note: Do _not_ use automatic encoding translation for
 ;       portable libs/applications.
-; http://php.net/mbstring.encoding-translation
+; https://php.net/mbstring.encoding-translation
 ;mbstring.encoding_translation = Off
 
 ; automatic encoding detection order.
 ; "auto" detect order is changed according to mbstring.language
-; http://php.net/mbstring.detect-order
+; https://php.net/mbstring.detect-order
 ;mbstring.detect_order = auto
 
 ; substitute_character used when character cannot be converted
 ; one from another
-; http://php.net/mbstring.substitute-character
+; https://php.net/mbstring.substitute-character
 ;mbstring.substitute_character = none
 
 ; Enable strict encoding detection.
@@ -1692,7 +1706,7 @@ zend.assertions = -1
 ; Tell the jpeg decode to ignore warnings and try to create
 ; a gd image. The warning will then be displayed as notices
 ; disabled by default
-; http://php.net/gd.jpeg-ignore-warning
+; https://php.net/gd.jpeg-ignore-warning
 ;gd.jpeg_ignore_warning = 1
 
 [exif]
@@ -1701,47 +1715,47 @@ zend.assertions = -1
 ; given by corresponding encode setting. When empty mbstring.internal_encoding
 ; is used. For the decode settings you can distinguish between motorola and
 ; intel byte order. A decode setting cannot be empty.
-; http://php.net/exif.encode-unicode
+; https://php.net/exif.encode-unicode
 ;exif.encode_unicode = ISO-8859-15
 
-; http://php.net/exif.decode-unicode-motorola
+; https://php.net/exif.decode-unicode-motorola
 ;exif.decode_unicode_motorola = UCS-2BE
 
-; http://php.net/exif.decode-unicode-intel
+; https://php.net/exif.decode-unicode-intel
 ;exif.decode_unicode_intel    = UCS-2LE
 
-; http://php.net/exif.encode-jis
+; https://php.net/exif.encode-jis
 ;exif.encode_jis =
 
-; http://php.net/exif.decode-jis-motorola
+; https://php.net/exif.decode-jis-motorola
 ;exif.decode_jis_motorola = JIS
 
-; http://php.net/exif.decode-jis-intel
+; https://php.net/exif.decode-jis-intel
 ;exif.decode_jis_intel    = JIS
 
 [Tidy]
 ; The path to a default tidy configuration file to use when using tidy
-; http://php.net/tidy.default-config
+; https://php.net/tidy.default-config
 ;tidy.default_config = /usr/local/lib/php/default.tcfg
 
 ; Should tidy clean and repair output automatically?
 ; WARNING: Do not use this option if you are generating non-html content
 ; such as dynamic images
-; http://php.net/tidy.clean-output
+; https://php.net/tidy.clean-output
 tidy.clean_output = Off
 
 [soap]
 ; Enables or disables WSDL caching feature.
-; http://php.net/soap.wsdl-cache-enabled
+; https://php.net/soap.wsdl-cache-enabled
 soap.wsdl_cache_enabled=1
 
 ; Sets the directory name where SOAP extension will put cache files.
-; http://php.net/soap.wsdl-cache-dir
+; https://php.net/soap.wsdl-cache-dir
 soap.wsdl_cache_dir="/tmp"
 
 ; (time to live) Sets the number of second while cached file will be used
 ; instead of original one.
-; http://php.net/soap.wsdl-cache-ttl
+; https://php.net/soap.wsdl-cache-ttl
 soap.wsdl_cache_ttl=86400
 
 ; Sets the size of the cache limit. (Max. number of WSDL files to cache)
@@ -1881,8 +1895,13 @@ ldap.max_links = -1
 ;opcache.file_cache_fallback=1
 
 ; Enables or disables copying of PHP code (text segment) into HUGE PAGES.
-; This should improve performance, but requires appropriate OS configuration.
-;opcache.huge_code_pages=1
+; Under certain circumstances (if only a single global PHP process is
+; started from which all others fork), this can increase performance
+; by a tiny amount because TLB misses are reduced.  On the other hand, this
+; delays PHP startup, increases memory usage and degrades performance
+; under memory pressure - use with care.
+; Requires appropriate OS configuration.
+;opcache.huge_code_pages=0
 
 ; Validate cached file permissions.
 ;opcache.validate_permission=0
@@ -1896,12 +1915,12 @@ ldap.max_links = -1
 
 ; Specifies a PHP script that is going to be compiled and executed at server
 ; start-up.
-; http://php.net/opcache.preload
+; https://php.net/opcache.preload
 ;opcache.preload=
 
 ; Preloading code as root is not allowed for security reasons. This directive
 ; facilitates to let the preloading to be run as another user.
-; http://php.net/opcache.preload_user
+; https://php.net/opcache.preload_user
 ;opcache.preload_user=
 
 ; Prevents caching files that are less than this number of seconds old. It

--- a/docker/web/runtime/php_cli.ini
+++ b/docker/web/runtime/php_cli.ini
@@ -17,7 +17,7 @@
 ; 6. The directory from the --with-config-file-path compile time option, or the
 ; Windows directory (usually C:\windows)
 ; See the PHP docs for more specific information.
-; http://php.net/configuration.file
+; https://php.net/configuration.file
 
 ; The syntax of the file is extremely simple.  Whitespace and lines
 ; beginning with a semicolon are silently ignored (as you probably guessed).
@@ -31,7 +31,7 @@
 ; special sections cannot be overridden by user-defined INI files or
 ; at runtime. Currently, [PATH=] and [HOST=] sections only work under
 ; CGI/FastCGI.
-; http://php.net/ini.sections
+; https://php.net/ini.sections
 
 ; Directives are specified using the following syntax:
 ; directive = value
@@ -181,7 +181,7 @@
 ;;;;;;;;;;;;;;;;;;;;
 
 ; Enable the PHP scripting language engine under Apache.
-; http://php.net/engine
+; https://php.net/engine
 engine = On
 
 ; This directive determines whether or not PHP will recognize code between
@@ -194,11 +194,11 @@ engine = On
 ; Default Value: On
 ; Development Value: Off
 ; Production Value: Off
-; http://php.net/short-open-tag
+; https://php.net/short-open-tag
 short_open_tag = Off
 
 ; The number of significant digits displayed in floating point numbers.
-; http://php.net/precision
+; https://php.net/precision
 precision = 14
 
 ; Output buffering is a mechanism for controlling how much output data
@@ -222,7 +222,7 @@ precision = 14
 ; Default Value: Off
 ; Development Value: 4096
 ; Production Value: 4096
-; http://php.net/output-buffering
+; https://php.net/output-buffering
 output_buffering = 4096
 
 ; You can redirect all of the output of your scripts to a function.  For
@@ -237,7 +237,7 @@ output_buffering = 4096
 ;   and you cannot use both "ob_gzhandler" and "zlib.output_compression".
 ; Note: output_handler must be empty if this is set 'On' !!!!
 ;   Instead you must use zlib.output_handler.
-; http://php.net/output-handler
+; https://php.net/output-handler
 ;output_handler =
 
 ; URL rewriter function rewrites URL on the fly by using
@@ -266,16 +266,16 @@ output_buffering = 4096
 ;   performance, enable output_buffering in addition.
 ; Note: You need to use zlib.output_handler instead of the standard
 ;   output_handler, or otherwise the output will be corrupted.
-; http://php.net/zlib.output-compression
+; https://php.net/zlib.output-compression
 zlib.output_compression = Off
 
-; http://php.net/zlib.output-compression-level
+; https://php.net/zlib.output-compression-level
 ;zlib.output_compression_level = -1
 
 ; You cannot specify additional output handlers if zlib.output_compression
 ; is activated here. This setting does the same as output_handler but in
 ; a different order.
-; http://php.net/zlib.output-handler
+; https://php.net/zlib.output-handler
 ;zlib.output_handler =
 
 ; Implicit flush tells PHP to tell the output layer to flush itself
@@ -283,7 +283,7 @@ zlib.output_compression = Off
 ; PHP function flush() after each and every call to print() or echo() and each
 ; and every HTML block.  Turning this option on has serious performance
 ; implications and is generally recommended for debugging purposes only.
-; http://php.net/implicit-flush
+; https://php.net/implicit-flush
 ; Note: This directive is hardcoded to On for the CLI SAPI
 implicit_flush = Off
 
@@ -314,22 +314,22 @@ serialize_precision = -1
 ; and below.  This directive makes most sense if used in a per-directory
 ; or per-virtualhost web server configuration file.
 ; Note: disables the realpath cache
-; http://php.net/open-basedir
+; https://php.net/open-basedir
 ;open_basedir =
 
 ; This directive allows you to disable certain functions.
 ; It receives a comma-delimited list of function names.
-; http://php.net/disable-functions
+; https://php.net/disable-functions
 disable_functions =
 
 ; This directive allows you to disable certain classes.
 ; It receives a comma-delimited list of class names.
-; http://php.net/disable-classes
+; https://php.net/disable-classes
 disable_classes =
 
 ; Colors for Syntax Highlighting mode.  Anything that's acceptable in
 ; <span style="color: ???????"> would work.
-; http://php.net/syntax-highlighting
+; https://php.net/syntax-highlighting
 ;highlight.string  = #DD0000
 ;highlight.comment = #FF9900
 ;highlight.keyword = #007700
@@ -340,24 +340,24 @@ disable_classes =
 ; the request. Consider enabling it if executing long requests, which may end up
 ; being interrupted by the user or a browser timing out. PHP's default behavior
 ; is to disable this feature.
-; http://php.net/ignore-user-abort
+; https://php.net/ignore-user-abort
 ;ignore_user_abort = On
 
 ; Determines the size of the realpath cache to be used by PHP. This value should
 ; be increased on systems where PHP opens many files to reflect the quantity of
 ; the file operations performed.
 ; Note: if open_basedir is set, the cache is disabled
-; http://php.net/realpath-cache-size
+; https://php.net/realpath-cache-size
 ;realpath_cache_size = 4096k
 
 ; Duration of time, in seconds for which to cache realpath information for a given
 ; file or directory. For systems with rarely changing files, consider increasing this
 ; value.
-; http://php.net/realpath-cache-ttl
+; https://php.net/realpath-cache-ttl
 ;realpath_cache_ttl = 120
 
 ; Enables or disables the circular reference collector.
-; http://php.net/zend.enable-gc
+; https://php.net/zend.enable-gc
 zend.enable_gc = On
 
 ; If enabled, scripts may be written in encodings that are incompatible with
@@ -396,7 +396,7 @@ zend.exception_string_param_max_len = 0
 ; (e.g. by adding its signature to the Web server header).  It is no security
 ; threat in any way, but it makes it possible to determine whether you use PHP
 ; on your server or not.
-; http://php.net/expose-php
+; https://php.net/expose-php
 expose_php = On
 
 ;;;;;;;;;;;;;;;;;;;
@@ -404,7 +404,7 @@ expose_php = On
 ;;;;;;;;;;;;;;;;;;;
 
 ; Maximum execution time of each script, in seconds
-; http://php.net/max-execution-time
+; https://php.net/max-execution-time
 ; Note: This directive is hardcoded to 0 for the CLI SAPI
 max_execution_time = 30
 
@@ -415,18 +415,23 @@ max_execution_time = 30
 ; Default Value: -1 (Unlimited)
 ; Development Value: 60 (60 seconds)
 ; Production Value: 60 (60 seconds)
-; http://php.net/max-input-time
+; https://php.net/max-input-time
 max_input_time = 60
 
 ; Maximum input variable nesting level
-; http://php.net/max-input-nesting-level
+; https://php.net/max-input-nesting-level
 ;max_input_nesting_level = 64
 
 ; How many GET/POST/COOKIE input variables may be accepted
 ;max_input_vars = 1000
 
+; How many multipart body parts (combined input variable and file uploads) may
+; be accepted.
+; Default Value: -1 (Sum of max_input_vars and max_file_uploads)
+;max_multipart_body_parts = 1500
+
 ; Maximum amount of memory a script may consume
-; http://php.net/memory-limit
+; https://php.net/memory-limit
 memory_limit = -1
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -482,7 +487,7 @@ memory_limit = -1
 ; Default Value: E_ALL
 ; Development Value: E_ALL
 ; Production Value: E_ALL & ~E_DEPRECATED & ~E_STRICT
-; http://php.net/error-reporting
+; https://php.net/error-reporting
 error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT
 
 ; This directive controls whether or not and where PHP will output errors,
@@ -499,7 +504,7 @@ error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT
 ; Default Value: On
 ; Development Value: On
 ; Production Value: Off
-; http://php.net/display-errors
+; https://php.net/display-errors
 display_errors = Off
 
 ; The display of errors which occur during PHP's startup sequence are handled
@@ -508,7 +513,7 @@ display_errors = Off
 ; Default Value: On
 ; Development Value: On
 ; Production Value: Off
-; http://php.net/display-startup-errors
+; https://php.net/display-startup-errors
 display_startup_errors = Off
 
 ; Besides displaying errors, PHP can also log errors to locations such as a
@@ -518,36 +523,31 @@ display_startup_errors = Off
 ; Default Value: Off
 ; Development Value: On
 ; Production Value: On
-; http://php.net/log-errors
+; https://php.net/log-errors
 log_errors = On
-
-; Set maximum length of log_errors. In error_log information about the source is
-; added. The default is 1024 and 0 allows to not apply any maximum length at all.
-; http://php.net/log-errors-max-len
-log_errors_max_len = 1024
 
 ; Do not log repeated messages. Repeated errors must occur in same file on same
 ; line unless ignore_repeated_source is set true.
-; http://php.net/ignore-repeated-errors
+; https://php.net/ignore-repeated-errors
 ignore_repeated_errors = Off
 
 ; Ignore source of message when ignoring repeated messages. When this setting
 ; is On you will not log errors with repeated messages from different files or
 ; source lines.
-; http://php.net/ignore-repeated-source
+; https://php.net/ignore-repeated-source
 ignore_repeated_source = Off
 
 ; If this parameter is set to Off, then memory leaks will not be shown (on
 ; stdout or in the log). This is only effective in a debug compile, and if
 ; error reporting includes E_WARNING in the allowed list
-; http://php.net/report-memleaks
+; https://php.net/report-memleaks
 report_memleaks = On
 
 ; This setting is off by default.
 ;report_zend_debug = 0
 
 ; Turn off normal error reporting and emit XML-RPC error XML
-; http://php.net/xmlrpc-errors
+; https://php.net/xmlrpc-errors
 ;xmlrpc_errors = 0
 
 ; An XML-RPC faultCode
@@ -557,40 +557,40 @@ report_memleaks = On
 ; error message as HTML for easier reading. This directive controls whether
 ; the error message is formatted as HTML or not.
 ; Note: This directive is hardcoded to Off for the CLI SAPI
-; http://php.net/html-errors
-html_errors = On
+; https://php.net/html-errors
+;html_errors = On
 
 ; If html_errors is set to On *and* docref_root is not empty, then PHP
 ; produces clickable error messages that direct to a page describing the error
 ; or function causing the error in detail.
-; You can download a copy of the PHP manual from http://php.net/docs
+; You can download a copy of the PHP manual from https://php.net/docs
 ; and change docref_root to the base URL of your local copy including the
 ; leading '/'. You must also specify the file extension being used including
 ; the dot. PHP's default behavior is to leave these settings empty, in which
 ; case no links to documentation are generated.
 ; Note: Never use this feature for production boxes.
-; http://php.net/docref-root
+; https://php.net/docref-root
 ; Examples
 ;docref_root = "/phpmanual/"
 
-; http://php.net/docref-ext
+; https://php.net/docref-ext
 ;docref_ext = .html
 
 ; String to output before an error message. PHP's default behavior is to leave
 ; this setting blank.
-; http://php.net/error-prepend-string
+; https://php.net/error-prepend-string
 ; Example:
 ;error_prepend_string = "<span style='color: #ff0000'>"
 
 ; String to output after an error message. PHP's default behavior is to leave
 ; this setting blank.
-; http://php.net/error-append-string
+; https://php.net/error-append-string
 ; Example:
 ;error_append_string = "</span>"
 
 ; Log errors to specified file. PHP's default behavior is to leave this value
 ; empty.
-; http://php.net/error-log
+; https://php.net/error-log
 ; Example:
 ;error_log = php_errors.log
 ; Log errors to syslog (Event Log on Windows).
@@ -613,7 +613,7 @@ html_errors = On
 ;   no-ctrl (all characters except control characters)
 ;   all (all characters)
 ;   raw (like "all", but messages are not split at newlines)
-; http://php.net/syslog.filter
+; https://php.net/syslog.filter
 ;syslog.filter = ascii
 
 ;windows.show_crt_warning
@@ -627,14 +627,14 @@ html_errors = On
 
 ; The separator used in PHP generated URLs to separate arguments.
 ; PHP's default setting is "&".
-; http://php.net/arg-separator.output
+; https://php.net/arg-separator.output
 ; Example:
 ;arg_separator.output = "&amp;"
 
 ; List of separator(s) used by PHP to parse input URLs into variables.
 ; PHP's default setting is "&".
 ; NOTE: Every character in this directive is considered as separator!
-; http://php.net/arg-separator.input
+; https://php.net/arg-separator.input
 ; Example:
 ;arg_separator.input = ";&"
 
@@ -648,7 +648,7 @@ html_errors = On
 ; Default Value: "EGPCS"
 ; Development Value: "GPCS"
 ; Production Value: "GPCS";
-; http://php.net/variables-order
+; https://php.net/variables-order
 variables_order = "GPCS"
 
 ; This directive determines which super global data (G,P & C) should be
@@ -661,7 +661,7 @@ variables_order = "GPCS"
 ; Default Value: None
 ; Development Value: "GP"
 ; Production Value: "GP"
-; http://php.net/request-order
+; https://php.net/request-order
 request_order = "GP"
 
 ; This directive determines whether PHP registers $argv & $argc each time it
@@ -676,7 +676,7 @@ request_order = "GP"
 ; Default Value: On
 ; Development Value: Off
 ; Production Value: Off
-; http://php.net/register-argc-argv
+; https://php.net/register-argc-argv
 register_argc_argv = Off
 
 ; When enabled, the ENV, REQUEST and SERVER variables are created when they're
@@ -684,7 +684,7 @@ register_argc_argv = Off
 ; variables are not used within a script, having this directive on will result
 ; in a performance gain. The PHP directive register_argc_argv must be disabled
 ; for this directive to have any effect.
-; http://php.net/auto-globals-jit
+; https://php.net/auto-globals-jit
 auto_globals_jit = On
 
 ; Whether PHP will read the POST data.
@@ -693,48 +693,48 @@ auto_globals_jit = On
 ; and $_FILES to always be empty; the only way you will be able to read the
 ; POST data will be through the php://input stream wrapper. This can be useful
 ; to proxy requests or to process the POST data in a memory efficient fashion.
-; http://php.net/enable-post-data-reading
+; https://php.net/enable-post-data-reading
 ;enable_post_data_reading = Off
 
 ; Maximum size of POST data that PHP will accept.
 ; Its value may be 0 to disable the limit. It is ignored if POST data reading
 ; is disabled through enable_post_data_reading.
-; http://php.net/post-max-size
+; https://php.net/post-max-size
 post_max_size = 8M
 
 ; Automatically add files before PHP document.
-; http://php.net/auto-prepend-file
+; https://php.net/auto-prepend-file
 auto_prepend_file =
 
 ; Automatically add files after PHP document.
-; http://php.net/auto-append-file
+; https://php.net/auto-append-file
 auto_append_file =
 
 ; By default, PHP will output a media type using the Content-Type header. To
 ; disable this, simply set it to be empty.
 ;
 ; PHP's built-in default media type is set to text/html.
-; http://php.net/default-mimetype
+; https://php.net/default-mimetype
 default_mimetype = "text/html"
 
 ; PHP's default character set is set to UTF-8.
-; http://php.net/default-charset
+; https://php.net/default-charset
 default_charset = "UTF-8"
 
 ; PHP internal character encoding is set to empty.
 ; If empty, default_charset is used.
-; http://php.net/internal-encoding
+; https://php.net/internal-encoding
 ;internal_encoding =
 
 ; PHP input character encoding is set to empty.
 ; If empty, default_charset is used.
-; http://php.net/input-encoding
+; https://php.net/input-encoding
 ;input_encoding =
 
 ; PHP output character encoding is set to empty.
 ; If empty, default_charset is used.
 ; See also output_buffer.
-; http://php.net/output-encoding
+; https://php.net/output-encoding
 ;output_encoding =
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -748,23 +748,23 @@ default_charset = "UTF-8"
 ;include_path = ".;c:\php\includes"
 ;
 ; PHP's default setting for include_path is ".;/path/to/php/pear"
-; http://php.net/include-path
+; https://php.net/include-path
 
 ; The root of the PHP pages, used only if nonempty.
 ; if PHP was not compiled with FORCE_REDIRECT, you SHOULD set doc_root
 ; if you are running php as a CGI under any web server (other than IIS)
 ; see documentation for security issues.  The alternate is to use the
 ; cgi.force_redirect configuration below
-; http://php.net/doc-root
+; https://php.net/doc-root
 doc_root =
 
 ; The directory under which PHP opens the script using /~username used only
 ; if nonempty.
-; http://php.net/user-dir
+; https://php.net/user-dir
 user_dir =
 
 ; Directory in which the loadable extensions (modules) reside.
-; http://php.net/extension-dir
+; https://php.net/extension-dir
 ;extension_dir = "./"
 ; On windows:
 ;extension_dir = "ext"
@@ -776,14 +776,14 @@ user_dir =
 ; Whether or not to enable the dl() function.  The dl() function does NOT work
 ; properly in multithreaded servers, such as IIS or Zeus, and is automatically
 ; disabled on them.
-; http://php.net/enable-dl
+; https://php.net/enable-dl
 enable_dl = Off
 
 ; cgi.force_redirect is necessary to provide security running PHP as a CGI under
 ; most web servers.  Left undefined, PHP turns this on by default.  You can
 ; turn it off here AT YOUR OWN RISK
 ; **You CAN safely turn this off for IIS, in fact, you MUST.**
-; http://php.net/cgi.force-redirect
+; https://php.net/cgi.force-redirect
 ;cgi.force_redirect = 1
 
 ; if cgi.nph is enabled it will force cgi to always sent Status: 200 with
@@ -794,7 +794,7 @@ enable_dl = Off
 ; (iPlanet) web servers, you MAY need to set an environment variable name that PHP
 ; will look for to know it is OK to continue execution.  Setting this variable MAY
 ; cause security issues, KNOW WHAT YOU ARE DOING FIRST.
-; http://php.net/cgi.redirect-status-env
+; https://php.net/cgi.redirect-status-env
 ;cgi.redirect_status_env =
 
 ; cgi.fix_pathinfo provides *real* PATH_INFO/PATH_TRANSLATED support for CGI.  PHP's
@@ -803,7 +803,7 @@ enable_dl = Off
 ; this to 1 will cause PHP CGI to fix its paths to conform to the spec.  A setting
 ; of zero causes PHP to behave as before.  Default is 1.  You should fix your scripts
 ; to use SCRIPT_FILENAME rather than PATH_TRANSLATED.
-; http://php.net/cgi.fix-pathinfo
+; https://php.net/cgi.fix-pathinfo
 ;cgi.fix_pathinfo=1
 
 ; if cgi.discard_path is enabled, the PHP CGI binary can safely be placed outside
@@ -815,7 +815,7 @@ enable_dl = Off
 ; security context that the request runs under.  mod_fastcgi under Apache
 ; does not currently support this feature (03/17/2002)
 ; Set to 1 if running under IIS.  Default is zero.
-; http://php.net/fastcgi.impersonate
+; https://php.net/fastcgi.impersonate
 ;fastcgi.impersonate = 1
 
 ; Disable logging through FastCGI connection. PHP's default behavior is to enable
@@ -827,14 +827,14 @@ enable_dl = Off
 ; is supported by Apache. When this option is set to 1, PHP will send
 ; RFC2616 compliant header.
 ; Default is zero.
-; http://php.net/cgi.rfc2616-headers
+; https://php.net/cgi.rfc2616-headers
 ;cgi.rfc2616_headers = 0
 
 ; cgi.check_shebang_line controls whether CGI PHP checks for line starting with #!
 ; (shebang) at the top of the running script. This line might be needed if the
 ; script support running both as stand-alone script and via PHP CGI<. PHP in CGI
 ; mode skips this line and ignores its content if this directive is turned on.
-; http://php.net/cgi.check-shebang-line
+; https://php.net/cgi.check-shebang-line
 ;cgi.check_shebang_line=1
 
 ;;;;;;;;;;;;;;;;
@@ -842,16 +842,16 @@ enable_dl = Off
 ;;;;;;;;;;;;;;;;
 
 ; Whether to allow HTTP file uploads.
-; http://php.net/file-uploads
+; https://php.net/file-uploads
 file_uploads = On
 
 ; Temporary directory for HTTP uploaded files (will use system default if not
 ; specified).
-; http://php.net/upload-tmp-dir
+; https://php.net/upload-tmp-dir
 ;upload_tmp_dir =
 
 ; Maximum allowed size for uploaded files.
-; http://php.net/upload-max-filesize
+; https://php.net/upload-max-filesize
 upload_max_filesize = 20M
 
 ; Maximum number of files that can be uploaded via a single request
@@ -862,24 +862,24 @@ max_file_uploads = 20
 ;;;;;;;;;;;;;;;;;;
 
 ; Whether to allow the treatment of URLs (like http:// or ftp://) as files.
-; http://php.net/allow-url-fopen
+; https://php.net/allow-url-fopen
 allow_url_fopen = On
 
-; Whether to allow include/require to open URLs (like http:// or ftp://) as files.
-; http://php.net/allow-url-include
+; Whether to allow include/require to open URLs (like https:// or ftp://) as files.
+; https://php.net/allow-url-include
 allow_url_include = Off
 
 ; Define the anonymous ftp password (your email address). PHP's default setting
 ; for this is empty.
-; http://php.net/from
+; https://php.net/from
 ;from="john@doe.com"
 
 ; Define the User-Agent string. PHP's default setting for this is empty.
-; http://php.net/user-agent
+; https://php.net/user-agent
 ;user_agent="PHP"
 
 ; Default timeout for socket based streams (seconds)
-; http://php.net/default-socket-timeout
+; https://php.net/default-socket-timeout
 default_socket_timeout = 60
 
 ; If your scripts have to deal with files from Macintosh systems,
@@ -887,7 +887,7 @@ default_socket_timeout = 60
 ; unix or win32 systems, setting this flag will cause PHP to
 ; automatically detect the EOL character in those files so that
 ; fgets() and file() will work regardless of the source of the file.
-; http://php.net/auto-detect-line-endings
+; https://php.net/auto-detect-line-endings
 ;auto_detect_line_endings = Off
 
 ;;;;;;;;;;;;;;;;;;;;;;
@@ -920,6 +920,12 @@ default_socket_timeout = 60
 ;   Be sure to appropriately set the extension_dir directive.
 ;
 ;extension=bz2
+
+; The ldap extension must be before curl if OpenSSL 1.0.2 and OpenLDAP is used
+; otherwise it results in segfault when unloading after using SASL.
+; See https://github.com/php/php-src/issues/8620 for more info.
+;extension=ldap
+
 ;extension=curl
 ;extension=ffi
 ;extension=ftp
@@ -929,7 +935,6 @@ default_socket_timeout = 60
 ;extension=gmp
 ;extension=intl
 ;extension=imap
-;extension=ldap
 ;extension=mbstring
 ;extension=exif      ; Must be after mbstring as it depends on it
 ;extension=mysqli
@@ -947,7 +952,7 @@ default_socket_timeout = 60
 ;extension=shmop
 
 ; The MIBS data available in the PHP distribution must be installed.
-; See http://www.php.net/manual/en/snmp.installation.php
+; See https://www.php.net/manual/en/snmp.installation.php
 ;extension=snmp
 
 ;extension=soap
@@ -969,26 +974,26 @@ cli_server.color = On
 
 [Date]
 ; Defines the default timezone used by the date functions
-; http://php.net/date.timezone
+; https://php.net/date.timezone
 date.timezone = "UTC"
 
-; http://php.net/date.default-latitude
+; https://php.net/date.default-latitude
 ;date.default_latitude = 31.7667
 
-; http://php.net/date.default-longitude
+; https://php.net/date.default-longitude
 ;date.default_longitude = 35.2333
 
-; http://php.net/date.sunrise-zenith
+; https://php.net/date.sunrise-zenith
 ;date.sunrise_zenith = 90.833333
 
-; http://php.net/date.sunset-zenith
+; https://php.net/date.sunset-zenith
 ;date.sunset_zenith = 90.833333
 
 [filter]
-; http://php.net/filter.default
+; https://php.net/filter.default
 ;filter.default = unsafe_raw
 
-; http://php.net/filter.default-flags
+; https://php.net/filter.default-flags
 ;filter.default_flags =
 
 [iconv]
@@ -1026,7 +1031,7 @@ date.timezone = "UTC"
 
 [sqlite3]
 ; Directory pointing to SQLite3 extensions
-; http://php.net/sqlite3.extension-dir
+; https://php.net/sqlite3.extension-dir
 ;sqlite3.extension_dir =
 
 ; SQLite defensive mode flag (only available from SQLite 3.26+)
@@ -1040,14 +1045,14 @@ date.timezone = "UTC"
 
 [Pcre]
 ; PCRE library backtracking limit.
-; http://php.net/pcre.backtrack-limit
+; https://php.net/pcre.backtrack-limit
 ;pcre.backtrack_limit=100000
 
 ; PCRE library recursion limit.
 ; Please note that if you set this value to a high number you may consume all
 ; the available process stack and eventually crash PHP (due to reaching the
 ; stack size limit imposed by the Operating System).
-; http://php.net/pcre.recursion-limit
+; https://php.net/pcre.recursion-limit
 ;pcre.recursion_limit=100000
 
 ; Enables or disables JIT compilation of patterns. This requires the PCRE
@@ -1056,7 +1061,7 @@ date.timezone = "UTC"
 
 [Pdo]
 ; Whether to pool ODBC connections. Can be one of "strict", "relaxed" or "off"
-; http://php.net/pdo-odbc.connection-pooling
+; https://php.net/pdo-odbc.connection-pooling
 ;pdo_odbc.connection_pooling=strict
 
 [Pdo_mysql]
@@ -1065,27 +1070,27 @@ date.timezone = "UTC"
 pdo_mysql.default_socket=
 
 [Phar]
-; http://php.net/phar.readonly
+; https://php.net/phar.readonly
 ;phar.readonly = On
 
-; http://php.net/phar.require-hash
+; https://php.net/phar.require-hash
 ;phar.require_hash = On
 
 ;phar.cache_list =
 
 [mail function]
 ; For Win32 only.
-; http://php.net/smtp
+; https://php.net/smtp
 SMTP = localhost
-; http://php.net/smtp-port
+; https://php.net/smtp-port
 smtp_port = 25
 
 ; For Win32 only.
-; http://php.net/sendmail-from
+; https://php.net/sendmail-from
 ;sendmail_from = me@example.com
 
 ; For Unix only.  You may supply arguments as well (default: "sendmail -t -i").
-; http://php.net/sendmail-path
+; https://php.net/sendmail-path
 ;sendmail_path =
 
 ; Force the addition of the specified parameters to be passed as extra parameters
@@ -1103,13 +1108,13 @@ mail.add_x_header = Off
 ;mail.log = syslog
 
 [ODBC]
-; http://php.net/odbc.default-db
+; https://php.net/odbc.default-db
 ;odbc.default_db    =  Not yet implemented
 
-; http://php.net/odbc.default-user
+; https://php.net/odbc.default-user
 ;odbc.default_user  =  Not yet implemented
 
-; http://php.net/odbc.default-pw
+; https://php.net/odbc.default-pw
 ;odbc.default_pw    =  Not yet implemented
 
 ; Controls the ODBC cursor model.
@@ -1117,68 +1122,72 @@ mail.add_x_header = Off
 ;odbc.default_cursortype
 
 ; Allow or prevent persistent links.
-; http://php.net/odbc.allow-persistent
+; https://php.net/odbc.allow-persistent
 odbc.allow_persistent = On
 
 ; Check that a connection is still valid before reuse.
-; http://php.net/odbc.check-persistent
+; https://php.net/odbc.check-persistent
 odbc.check_persistent = On
 
 ; Maximum number of persistent links.  -1 means no limit.
-; http://php.net/odbc.max-persistent
+; https://php.net/odbc.max-persistent
 odbc.max_persistent = -1
 
 ; Maximum number of links (persistent + non-persistent).  -1 means no limit.
-; http://php.net/odbc.max-links
+; https://php.net/odbc.max-links
 odbc.max_links = -1
 
 ; Handling of LONG fields.  Returns number of bytes to variables.  0 means
 ; passthru.
-; http://php.net/odbc.defaultlrl
+; https://php.net/odbc.defaultlrl
 odbc.defaultlrl = 4096
 
 ; Handling of binary data.  0 means passthru, 1 return as is, 2 convert to char.
 ; See the documentation on odbc_binmode and odbc_longreadlen for an explanation
 ; of odbc.defaultlrl and odbc.defaultbinmode
-; http://php.net/odbc.defaultbinmode
+; https://php.net/odbc.defaultbinmode
 odbc.defaultbinmode = 1
 
 [MySQLi]
 
 ; Maximum number of persistent links.  -1 means no limit.
-; http://php.net/mysqli.max-persistent
+; https://php.net/mysqli.max-persistent
 mysqli.max_persistent = -1
 
 ; Allow accessing, from PHP's perspective, local files with LOAD DATA statements
-; http://php.net/mysqli.allow_local_infile
+; https://php.net/mysqli.allow_local_infile
 ;mysqli.allow_local_infile = On
 
+; It allows the user to specify a folder where files that can be sent via LOAD DATA
+; LOCAL can exist. It is ignored if mysqli.allow_local_infile is enabled.
+;mysqli.local_infile_directory =
+
 ; Allow or prevent persistent links.
-; http://php.net/mysqli.allow-persistent
+; https://php.net/mysqli.allow-persistent
 mysqli.allow_persistent = On
 
 ; Maximum number of links.  -1 means no limit.
-; http://php.net/mysqli.max-links
+; https://php.net/mysqli.max-links
 mysqli.max_links = -1
 
 ; Default port number for mysqli_connect().  If unset, mysqli_connect() will use
 ; the $MYSQL_TCP_PORT or the mysql-tcp entry in /etc/services or the
 ; compile-time value defined MYSQL_PORT (in that order).  Win32 will only look
 ; at MYSQL_PORT.
-; http://php.net/mysqli.default-port
+; https://php.net/mysqli.default-port
 mysqli.default_port = 3306
 
 ; Default socket name for local MySQL connects.  If empty, uses the built-in
 ; MySQL defaults.
-; http://php.net/mysqli.default-socket
+; https://php.net/mysqli.default-socket
 mysqli.default_socket =
 
 ; Default host for mysqli_connect() (doesn't apply in safe mode).
-; http://php.net/mysqli.default-host
+; https://php.net/mysqli.default-host
 mysqli.default_host =
 
 ; Default user for mysqli_connect() (doesn't apply in safe mode).
-; http://php.net/mysqli.default-user
+; https://php.net/mysqli.default-user
 mysqli.default_user =
 
 ; Default password for mysqli_connect() (doesn't apply in safe mode).
@@ -1186,11 +1195,16 @@ mysqli.default_user =
 ; *Any* user with PHP access can run 'echo get_cfg_var("mysqli.default_pw")
 ; and reveal this password!  And of course, any users with read access to this
 ; file will be able to reveal the password as well.
-; http://php.net/mysqli.default-pw
+; https://php.net/mysqli.default-pw
 mysqli.default_pw =
 
 ; Allow or prevent reconnect
 mysqli.reconnect = Off
+
+; If this option is enabled, closing a persistent connection will rollback
+; any pending transactions of this connection, before it is put back
+; into the persistent connection pool.
+;mysqli.rollback_on_cached_plink = Off
 
 [mysqlnd]
 ; Enable / Disable collection of general statistics by mysqlnd which can be
@@ -1203,7 +1217,7 @@ mysqlnd.collect_memory_statistics = Off
 
 ; Records communication from all extensions using mysqlnd to the specified log
 ; file.
-; http://php.net/mysqlnd.debug
+; https://php.net/mysqlnd.debug
 ;mysqlnd.debug =
 
 ; Defines which queries will be logged.
@@ -1230,25 +1244,25 @@ mysqlnd.collect_memory_statistics = Off
 
 ; Connection: Enables privileged connections using external
 ; credentials (OCI_SYSOPER, OCI_SYSDBA)
-; http://php.net/oci8.privileged-connect
+; https://php.net/oci8.privileged-connect
 ;oci8.privileged_connect = Off
 
 ; Connection: The maximum number of persistent OCI8 connections per
 ; process. Using -1 means no limit.
-; http://php.net/oci8.max-persistent
+; https://php.net/oci8.max-persistent
 ;oci8.max_persistent = -1
 
 ; Connection: The maximum number of seconds a process is allowed to
 ; maintain an idle persistent connection. Using -1 means idle
 ; persistent connections will be maintained forever.
-; http://php.net/oci8.persistent-timeout
+; https://php.net/oci8.persistent-timeout
 ;oci8.persistent_timeout = -1
 
 ; Connection: The number of seconds that must pass before issuing a
 ; ping during oci_pconnect() to check the connection validity. When
 ; set to 0, each oci_pconnect() will cause a ping. Using -1 disables
 ; pings completely.
-; http://php.net/oci8.ping-interval
+; https://php.net/oci8.ping-interval
 ;oci8.ping_interval = 60
 
 ; Connection: Set this to a user chosen connection class to be used
@@ -1266,59 +1280,59 @@ mysqlnd.collect_memory_statistics = Off
 
 ; Tuning: This option enables statement caching, and specifies how
 ; many statements to cache. Using 0 disables statement caching.
-; http://php.net/oci8.statement-cache-size
+; https://php.net/oci8.statement-cache-size
 ;oci8.statement_cache_size = 20
 
 ; Tuning: Enables statement prefetching and sets the default number of
 ; rows that will be fetched automatically after statement execution.
-; http://php.net/oci8.default-prefetch
+; https://php.net/oci8.default-prefetch
 ;oci8.default_prefetch = 100
 
 ; Compatibility. Using On means oci_close() will not close
 ; oci_connect() and oci_new_connect() connections.
-; http://php.net/oci8.old-oci-close-semantics
+; https://php.net/oci8.old-oci-close-semantics
 ;oci8.old_oci_close_semantics = Off
 
 [PostgreSQL]
 ; Allow or prevent persistent links.
-; http://php.net/pgsql.allow-persistent
+; https://php.net/pgsql.allow-persistent
 pgsql.allow_persistent = On
 
 ; Detect broken persistent links always with pg_pconnect().
 ; Auto reset feature requires a little overheads.
-; http://php.net/pgsql.auto-reset-persistent
+; https://php.net/pgsql.auto-reset-persistent
 pgsql.auto_reset_persistent = Off
 
 ; Maximum number of persistent links.  -1 means no limit.
-; http://php.net/pgsql.max-persistent
+; https://php.net/pgsql.max-persistent
 pgsql.max_persistent = -1
 
 ; Maximum number of links (persistent+non persistent).  -1 means no limit.
-; http://php.net/pgsql.max-links
+; https://php.net/pgsql.max-links
 pgsql.max_links = -1
 
 ; Ignore PostgreSQL backends Notice message or not.
 ; Notice message logging require a little overheads.
-; http://php.net/pgsql.ignore-notice
+; https://php.net/pgsql.ignore-notice
 pgsql.ignore_notice = 0
 
 ; Log PostgreSQL backends Notice message or not.
 ; Unless pgsql.ignore_notice=0, module cannot log notice message.
-; http://php.net/pgsql.log-notice
+; https://php.net/pgsql.log-notice
 pgsql.log_notice = 0
 
 [bcmath]
 ; Number of decimal digits for all bcmath functions.
-; http://php.net/bcmath.scale
+; https://php.net/bcmath.scale
 bcmath.scale = 0
 
 [browscap]
-; http://php.net/browscap
+; https://php.net/browscap
 ;browscap = extra/browscap.ini
 
 [Session]
 ; Handler used to store/retrieve data.
-; http://php.net/session.save-handler
+; https://php.net/session.save-handler
 session.save_handler = files
 
 ; Argument passed to save_handler.  In the case of files, this is the path
@@ -1347,7 +1361,7 @@ session.save_handler = files
 ;
 ; where MODE is the octal representation of the mode. Note that this
 ; does not overwrite the process's umask.
-; http://php.net/session.save-path
+; https://php.net/session.save-path
 ;session.save_path = "/var/lib/php/sessions"
 
 ; Whether to use strict session mode.
@@ -1360,42 +1374,42 @@ session.save_handler = files
 session.use_strict_mode = 0
 
 ; Whether to use cookies.
-; http://php.net/session.use-cookies
+; https://php.net/session.use-cookies
 session.use_cookies = 1
 
-; http://php.net/session.cookie-secure
+; https://php.net/session.cookie-secure
 ;session.cookie_secure =
 
 ; This option forces PHP to fetch and use a cookie for storing and maintaining
 ; the session id. We encourage this operation as it's very helpful in combating
 ; session hijacking when not specifying and managing your own session id. It is
 ; not the be-all and end-all of session hijacking defense, but it's a good start.
-; http://php.net/session.use-only-cookies
+; https://php.net/session.use-only-cookies
 session.use_only_cookies = 1
 
 ; Name of the session (used as cookie name).
-; http://php.net/session.name
+; https://php.net/session.name
 session.name = PHPSESSID
 
 ; Initialize session on request startup.
-; http://php.net/session.auto-start
+; https://php.net/session.auto-start
 session.auto_start = 0
 
 ; Lifetime in seconds of cookie or, if 0, until browser is restarted.
-; http://php.net/session.cookie-lifetime
+; https://php.net/session.cookie-lifetime
 session.cookie_lifetime = 0
 
 ; The path for which the cookie is valid.
-; http://php.net/session.cookie-path
+; https://php.net/session.cookie-path
 session.cookie_path = /
 
 ; The domain for which the cookie is valid.
-; http://php.net/session.cookie-domain
+; https://php.net/session.cookie-domain
 session.cookie_domain =
 
 ; Whether or not to add the httpOnly flag to the cookie, which makes it
 ; inaccessible to browser scripting languages such as JavaScript.
-; http://php.net/session.cookie-httponly
+; https://php.net/session.cookie-httponly
 session.cookie_httponly =
 
 ; Add SameSite attribute to cookie to help mitigate Cross-Site Request Forgery (CSRF/XSRF)
@@ -1405,7 +1419,7 @@ session.cookie_httponly =
 session.cookie_samesite =
 
 ; Handler used to serialize data. php is the standard serializer of PHP.
-; http://php.net/session.serialize-handler
+; https://php.net/session.serialize-handler
 session.serialize_handler = php
 
 ; Defines the probability that the 'garbage collection' process is started on every
@@ -1414,7 +1428,7 @@ session.serialize_handler = php
 ; Default Value: 1
 ; Development Value: 1
 ; Production Value: 1
-; http://php.net/session.gc-probability
+; https://php.net/session.gc-probability
 session.gc_probability = 0
 
 ; Defines the probability that the 'garbage collection' process is started on every
@@ -1424,12 +1438,12 @@ session.gc_probability = 0
 ; Default Value: 100
 ; Development Value: 1000
 ; Production Value: 1000
-; http://php.net/session.gc-divisor
+; https://php.net/session.gc-divisor
 session.gc_divisor = 1000
 
 ; After this number of seconds, stored data will be seen as 'garbage' and
 ; cleaned up by the garbage collection process.
-; http://php.net/session.gc-maxlifetime
+; https://php.net/session.gc-maxlifetime
 session.gc_maxlifetime = 1440
 
 ; NOTE: If you are using the subdirectory option for storing session files
@@ -1443,16 +1457,16 @@ session.gc_maxlifetime = 1440
 ; Check HTTP Referer to invalidate externally stored URLs containing ids.
 ; HTTP_REFERER has to contain this substring for the session to be
 ; considered as valid.
-; http://php.net/session.referer-check
+; https://php.net/session.referer-check
 session.referer_check =
 
 ; Set to {nocache,private,public,} to determine HTTP caching aspects
 ; or leave this empty to avoid sending anti-caching headers.
-; http://php.net/session.cache-limiter
+; https://php.net/session.cache-limiter
 session.cache_limiter = nocache
 
 ; Document expires after n minutes.
-; http://php.net/session.cache-expire
+; https://php.net/session.cache-expire
 session.cache_expire = 180
 
 ; trans sid support is disabled by default.
@@ -1464,13 +1478,13 @@ session.cache_expire = 180
 ;   in publicly accessible computer.
 ; - User may access your site with the same session ID
 ;   always using URL stored in browser's history or bookmarks.
-; http://php.net/session.use-trans-sid
+; https://php.net/session.use-trans-sid
 session.use_trans_sid = 0
 
 ; Set session ID character length. This value could be between 22 to 256.
 ; Shorter length than default is supported only for compatibility reason.
 ; Users should use 32 or more chars.
-; http://php.net/session.sid-length
+; https://php.net/session.sid-length
 ; Default Value: 32
 ; Development Value: 26
 ; Production Value: 26
@@ -1485,7 +1499,7 @@ session.sid_length = 26
 ; Default Value: "a=href,area=href,frame=src,form="
 ; Development Value: "a=href,area=href,frame=src,form="
 ; Production Value: "a=href,area=href,frame=src,form="
-; http://php.net/url-rewriter.tags
+; https://php.net/url-rewriter.tags
 session.trans_sid_tags = "a=href,area=href,frame=src,form="
 
 ; URL rewriter does not rewrite absolute URLs by default.
@@ -1510,14 +1524,14 @@ session.trans_sid_tags = "a=href,area=href,frame=src,form="
 ; Default Value: 4
 ; Development Value: 5
 ; Production Value: 5
-; http://php.net/session.hash-bits-per-character
+; https://php.net/session.hash-bits-per-character
 session.sid_bits_per_character = 5
 
 ; Enable upload progress tracking in $_SESSION
 ; Default Value: On
 ; Development Value: On
 ; Production Value: On
-; http://php.net/session.upload-progress.enabled
+; https://php.net/session.upload-progress.enabled
 ;session.upload_progress.enabled = On
 
 ; Cleanup the progress information as soon as all POST data has been read
@@ -1525,14 +1539,14 @@ session.sid_bits_per_character = 5
 ; Default Value: On
 ; Development Value: On
 ; Production Value: On
-; http://php.net/session.upload-progress.cleanup
+; https://php.net/session.upload-progress.cleanup
 ;session.upload_progress.cleanup = On
 
 ; A prefix used for the upload progress key in $_SESSION
 ; Default Value: "upload_progress_"
 ; Development Value: "upload_progress_"
 ; Production Value: "upload_progress_"
-; http://php.net/session.upload-progress.prefix
+; https://php.net/session.upload-progress.prefix
 ;session.upload_progress.prefix = "upload_progress_"
 
 ; The index name (concatenated with the prefix) in $_SESSION
@@ -1540,7 +1554,7 @@ session.sid_bits_per_character = 5
 ; Default Value: "PHP_SESSION_UPLOAD_PROGRESS"
 ; Development Value: "PHP_SESSION_UPLOAD_PROGRESS"
 ; Production Value: "PHP_SESSION_UPLOAD_PROGRESS"
-; http://php.net/session.upload-progress.name
+; https://php.net/session.upload-progress.name
 ;session.upload_progress.name = "PHP_SESSION_UPLOAD_PROGRESS"
 
 ; How frequently the upload progress should be updated.
@@ -1548,18 +1562,18 @@ session.sid_bits_per_character = 5
 ; Default Value: "1%"
 ; Development Value: "1%"
 ; Production Value: "1%"
-; http://php.net/session.upload-progress.freq
+; https://php.net/session.upload-progress.freq
 ;session.upload_progress.freq =  "1%"
 
 ; The minimum delay between updates, in seconds
 ; Default Value: 1
 ; Development Value: 1
 ; Production Value: 1
-; http://php.net/session.upload-progress.min-freq
+; https://php.net/session.upload-progress.min-freq
 ;session.upload_progress.min_freq = "1"
 
 ; Only write session data when session data is changed. Enabled by default.
-; http://php.net/session.lazy-write
+; https://php.net/session.lazy-write
 ;session.lazy_write = On
 
 [Assertion]
@@ -1571,48 +1585,48 @@ session.sid_bits_per_character = 5
 ; Default Value: 1
 ; Development Value: 1
 ; Production Value: -1
-; http://php.net/zend.assertions
+; https://php.net/zend.assertions
 zend.assertions = -1
 
 ; Assert(expr); active by default.
-; http://php.net/assert.active
+; https://php.net/assert.active
 ;assert.active = On
 
 ; Throw an AssertionError on failed assertions
-; http://php.net/assert.exception
+; https://php.net/assert.exception
 ;assert.exception = On
 
 ; Issue a PHP warning for each failed assertion. (Overridden by assert.exception if active)
-; http://php.net/assert.warning
+; https://php.net/assert.warning
 ;assert.warning = On
 
 ; Don't bail out by default.
-; http://php.net/assert.bail
+; https://php.net/assert.bail
 ;assert.bail = Off
 
 ; User-function to be called if an assertion fails.
-; http://php.net/assert.callback
+; https://php.net/assert.callback
 ;assert.callback = 0
 
 [COM]
 ; path to a file containing GUIDs, IIDs or filenames of files with TypeLibs
-; http://php.net/com.typelib-file
+; https://php.net/com.typelib-file
 ;com.typelib_file =
 
 ; allow Distributed-COM calls
-; http://php.net/com.allow-dcom
+; https://php.net/com.allow-dcom
 ;com.allow_dcom = true
 
-; autoregister constants of a component's typlib on com_load()
-; http://php.net/com.autoregister-typelib
+; autoregister constants of a component's typelib on com_load()
+; https://php.net/com.autoregister-typelib
 ;com.autoregister_typelib = true
 
 ; register constants casesensitive
-; http://php.net/com.autoregister-casesensitive
+; https://php.net/com.autoregister-casesensitive
 ;com.autoregister_casesensitive = false
 
 ; show warnings on duplicate constant registrations
-; http://php.net/com.autoregister-verbose
+; https://php.net/com.autoregister-verbose
 ;com.autoregister_verbose = true
 
 ; The default character set code-page to use when passing strings to and from COM objects.
@@ -1626,7 +1640,7 @@ zend.assertions = -1
 [mbstring]
 ; language for internal character representation.
 ; This affects mb_send_mail() and mbstring.detect_order.
-; http://php.net/mbstring.language
+; https://php.net/mbstring.language
 ;mbstring.language = Japanese
 
 ; Use of this INI entry is deprecated, use global internal_encoding instead.
@@ -1641,7 +1655,7 @@ zend.assertions = -1
 ; mbstring.encoding_translation = On is needed to use this setting.
 ; If empty, default_charset or input_encoding or mbstring.input is used.
 ; The precedence is: default_charset < input_encoding < mbstring.http_input
-; http://php.net/mbstring.http-input
+; https://php.net/mbstring.http-input
 ;mbstring.http_input =
 
 ; Use of this INI entry is deprecated, use global output_encoding instead.
@@ -1651,7 +1665,7 @@ zend.assertions = -1
 ; The precedence is: default_charset < output_encoding < mbstring.http_output
 ; To use an output encoding conversion, mbstring's output handler must be set
 ; otherwise output encoding conversion cannot be performed.
-; http://php.net/mbstring.http-output
+; https://php.net/mbstring.http-output
 ;mbstring.http_output =
 
 ; enable automatic encoding translation according to
@@ -1659,17 +1673,17 @@ zend.assertions = -1
 ; converted to internal encoding by setting this to On.
 ; Note: Do _not_ use automatic encoding translation for
 ;       portable libs/applications.
-; http://php.net/mbstring.encoding-translation
+; https://php.net/mbstring.encoding-translation
 ;mbstring.encoding_translation = Off
 
 ; automatic encoding detection order.
 ; "auto" detect order is changed according to mbstring.language
-; http://php.net/mbstring.detect-order
+; https://php.net/mbstring.detect-order
 ;mbstring.detect_order = auto
 
 ; substitute_character used when character cannot be converted
 ; one from another
-; http://php.net/mbstring.substitute-character
+; https://php.net/mbstring.substitute-character
 ;mbstring.substitute_character = none
 
 ; Enable strict encoding detection.
@@ -1692,7 +1706,7 @@ zend.assertions = -1
 ; Tell the jpeg decode to ignore warnings and try to create
 ; a gd image. The warning will then be displayed as notices
 ; disabled by default
-; http://php.net/gd.jpeg-ignore-warning
+; https://php.net/gd.jpeg-ignore-warning
 ;gd.jpeg_ignore_warning = 1
 
 [exif]
@@ -1701,47 +1715,47 @@ zend.assertions = -1
 ; given by corresponding encode setting. When empty mbstring.internal_encoding
 ; is used. For the decode settings you can distinguish between motorola and
 ; intel byte order. A decode setting cannot be empty.
-; http://php.net/exif.encode-unicode
+; https://php.net/exif.encode-unicode
 ;exif.encode_unicode = ISO-8859-15
 
-; http://php.net/exif.decode-unicode-motorola
+; https://php.net/exif.decode-unicode-motorola
 ;exif.decode_unicode_motorola = UCS-2BE
 
-; http://php.net/exif.decode-unicode-intel
+; https://php.net/exif.decode-unicode-intel
 ;exif.decode_unicode_intel    = UCS-2LE
 
-; http://php.net/exif.encode-jis
+; https://php.net/exif.encode-jis
 ;exif.encode_jis =
 
-; http://php.net/exif.decode-jis-motorola
+; https://php.net/exif.decode-jis-motorola
 ;exif.decode_jis_motorola = JIS
 
-; http://php.net/exif.decode-jis-intel
+; https://php.net/exif.decode-jis-intel
 ;exif.decode_jis_intel    = JIS
 
 [Tidy]
 ; The path to a default tidy configuration file to use when using tidy
-; http://php.net/tidy.default-config
+; https://php.net/tidy.default-config
 ;tidy.default_config = /usr/local/lib/php/default.tcfg
 
 ; Should tidy clean and repair output automatically?
 ; WARNING: Do not use this option if you are generating non-html content
 ; such as dynamic images
-; http://php.net/tidy.clean-output
+; https://php.net/tidy.clean-output
 tidy.clean_output = Off
 
 [soap]
 ; Enables or disables WSDL caching feature.
-; http://php.net/soap.wsdl-cache-enabled
+; https://php.net/soap.wsdl-cache-enabled
 soap.wsdl_cache_enabled=1
 
 ; Sets the directory name where SOAP extension will put cache files.
-; http://php.net/soap.wsdl-cache-dir
+; https://php.net/soap.wsdl-cache-dir
 soap.wsdl_cache_dir="/tmp"
 
 ; (time to live) Sets the number of second while cached file will be used
 ; instead of original one.
-; http://php.net/soap.wsdl-cache-ttl
+; https://php.net/soap.wsdl-cache-ttl
 soap.wsdl_cache_ttl=86400
 
 ; Sets the size of the cache limit. (Max. number of WSDL files to cache)
@@ -1881,8 +1895,13 @@ ldap.max_links = -1
 ;opcache.file_cache_fallback=1
 
 ; Enables or disables copying of PHP code (text segment) into HUGE PAGES.
-; This should improve performance, but requires appropriate OS configuration.
-;opcache.huge_code_pages=1
+; Under certain circumstances (if only a single global PHP process is
+; started from which all others fork), this can increase performance
+; by a tiny amount because TLB misses are reduced.  On the other hand, this
+; delays PHP startup, increases memory usage and degrades performance
+; under memory pressure - use with care.
+; Requires appropriate OS configuration.
+;opcache.huge_code_pages=0
 
 ; Validate cached file permissions.
 ;opcache.validate_permission=0
@@ -1896,12 +1915,12 @@ ldap.max_links = -1
 
 ; Specifies a PHP script that is going to be compiled and executed at server
 ; start-up.
-; http://php.net/opcache.preload
+; https://php.net/opcache.preload
 ;opcache.preload=
 
 ; Preloading code as root is not allowed for security reasons. This directive
 ; facilitates to let the preloading to be run as another user.
-; http://php.net/opcache.preload_user
+; https://php.net/opcache.preload_user
 ;opcache.preload_user=
 
 ; Prevents caching files that are less than this number of seconds old. It

--- a/docroot/modules/custom/app_module/tests/src/Functional/AppModuleEntityTest.php
+++ b/docroot/modules/custom/app_module/tests/src/Functional/AppModuleEntityTest.php
@@ -21,7 +21,7 @@ class AppModuleEntityTest extends BrowserTestBase {
    *
    * @var array
    */
-  public static $modules = ['app_module', 'app_module_test'];
+  protected static $modules = ['app_module', 'app_module_test'];
 
   /**
    * The installation profile to use with this test.

--- a/docroot/modules/custom/app_module/tests/src/Functional/AppModuleFieldBrowserTestBase.php
+++ b/docroot/modules/custom/app_module/tests/src/Functional/AppModuleFieldBrowserTestBase.php
@@ -51,7 +51,7 @@ abstract class AppModuleFieldBrowserTestBase extends BrowserTestBase {
    *
    * @var array
    */
-  public static $modules = [
+  protected static $modules = [
     'language',
     'path',
     'block',
@@ -66,7 +66,7 @@ abstract class AppModuleFieldBrowserTestBase extends BrowserTestBase {
    *
    * @var string
    */
-  protected $defaultTheme = 'classy';
+  protected $defaultTheme = 'stable9';
 
   /**
    * {@inheritdoc}

--- a/docroot/modules/custom/app_module/tests/src/Functional/AppModulePluginBaseTest.php
+++ b/docroot/modules/custom/app_module/tests/src/Functional/AppModulePluginBaseTest.php
@@ -20,7 +20,7 @@ class AppModulePluginBaseTest extends BrowserTestBase {
    *
    * @var array
    */
-  public static $modules = ['app_module', 'app_module_test'];
+  protected static $modules = ['app_module', 'app_module_test'];
 
   /**
    * The installation profile to use with this test.

--- a/docroot/modules/custom/app_module/tests/src/Functional/AppModuleRenderArrayBuilderTest.php
+++ b/docroot/modules/custom/app_module/tests/src/Functional/AppModuleRenderArrayBuilderTest.php
@@ -23,7 +23,7 @@ class AppModuleRenderArrayBuilderTest extends BrowserTestBase {
    *
    * @var array
    */
-  public static $modules = [
+  protected static $modules = [
     'app_module',
     'app_module_test',
   ];

--- a/docroot/modules/custom/app_module/tests/src/Kernel/AppPathStorageTest.php
+++ b/docroot/modules/custom/app_module/tests/src/Kernel/AppPathStorageTest.php
@@ -16,7 +16,7 @@ class AppPathStorageTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  public static $modules = ['system', 'path_alias', 'app_module'];
+  protected static $modules = ['system', 'path_alias', 'app_module'];
 
   /**
    * Gets the path storage.

--- a/docroot/modules/custom/app_module/tests/src/Kernel/AppPathTest.php
+++ b/docroot/modules/custom/app_module/tests/src/Kernel/AppPathTest.php
@@ -15,7 +15,7 @@ class AppPathTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  public static $modules = [
+  protected static $modules = [
     'system',
     'user',
     'path_alias',

--- a/docroot/modules/custom/cgov_adobe/tests/src/Functional/CgovAdobeRenderTest.php
+++ b/docroot/modules/custom/cgov_adobe/tests/src/Functional/CgovAdobeRenderTest.php
@@ -18,7 +18,7 @@ class CgovAdobeRenderTest extends BrowserTestBase {
    *
    * @var array
    */
-  public static $modules = [
+  protected static $modules = [
     'language',
     'path',
     'block',
@@ -39,7 +39,7 @@ class CgovAdobeRenderTest extends BrowserTestBase {
    *
    * @var string
    */
-  protected $defaultTheme = 'classy';
+  protected $defaultTheme = 'stable9';
 
   /**
    * The content type name.

--- a/docroot/modules/custom/cgov_cts/tests/src/Functional/ZipCodeLookupResourceTest.php
+++ b/docroot/modules/custom/cgov_cts/tests/src/Functional/ZipCodeLookupResourceTest.php
@@ -19,7 +19,7 @@ class ZipCodeLookupResourceTest extends BrowserTestBase {
    *
    * @var array
    */
-  public static $modules = ['app_module', 'cgov_cts'];
+  protected static $modules = ['app_module', 'cgov_cts'];
 
   /**
    * The installation profile to use with this test.
@@ -33,7 +33,7 @@ class ZipCodeLookupResourceTest extends BrowserTestBase {
    *
    * @var string
    */
-  protected $defaultTheme = 'classy';
+  protected $defaultTheme = 'stable9';
 
   /**
    * Tests the zip code lookup.

--- a/docroot/modules/custom/cgov_js_app_module/tests/src/Functional/JSOnlyAppModulePluginBuildTest.php
+++ b/docroot/modules/custom/cgov_js_app_module/tests/src/Functional/JSOnlyAppModulePluginBuildTest.php
@@ -18,7 +18,7 @@ class JSOnlyAppModulePluginBuildTest extends BrowserTestBase {
    *
    * @var array
    */
-  public static $modules = [
+  protected static $modules = [
     'language',
     'path',
     'block',
@@ -68,7 +68,7 @@ class JSOnlyAppModulePluginBuildTest extends BrowserTestBase {
    *
    * @var string
    */
-  protected $defaultTheme = 'classy';
+  protected $defaultTheme = 'stable9';
 
   /**
    * These are a set of default options for the plugin methods.
@@ -419,15 +419,6 @@ class JSOnlyAppModulePluginBuildTest extends BrowserTestBase {
     $this->submitForm([
       'settings[target_type]' => 'app_module',
     ], 'Save field settings');
-    dump(
-      (string) new FormattableMarkup('Saved settings for field %field_name with widget %widget_type and cardinality 1',
-        [
-          '%field_name' => $field_name,
-          '%widget_type' => $widget_type,
-          '%cardinality' => "1",
-        ]
-      )
-    );
     $assert->pageTextContains((string) new FormattableMarkup('Updated field @name field settings.', ['@name' => $field_name]));
 
     // Set the widget type for the newly created field.

--- a/docroot/modules/custom/json_data_field/tests/src/Functional/JsonDataFieldBrowserTestBase.php
+++ b/docroot/modules/custom/json_data_field/tests/src/Functional/JsonDataFieldBrowserTestBase.php
@@ -44,7 +44,7 @@ abstract class JsonDataFieldBrowserTestBase extends BrowserTestBase {
    *
    * @var array
    */
-  public static $modules = [
+  protected static $modules = [
     'language',
     'path',
     'block',
@@ -57,9 +57,13 @@ abstract class JsonDataFieldBrowserTestBase extends BrowserTestBase {
   /**
    * The theme to use with this test.
    *
+   * Olivero is required for us to find the pre tag in the widget test.
+   * Stable9 does not add in the class attributes for fields, and our
+   * xpath query was not finding the json content.
+   *
    * @var string
    */
-  protected $defaultTheme = 'classy';
+  protected $defaultTheme = 'olivero';
 
   /**
    * {@inheritdoc}

--- a/docroot/modules/custom/json_data_field/tests/src/Functional/JsonDataFieldWidgetTest.php
+++ b/docroot/modules/custom/json_data_field/tests/src/Functional/JsonDataFieldWidgetTest.php
@@ -68,6 +68,7 @@ class JsonDataFieldWidgetTest extends JsonDataFieldBrowserTestBase {
     $expected = str_replace('"', "", $single_line_yaml);
 
     // Check that the YAML is correct after saving.
+    // Stable9 is not outputting class names.
     $field_value = $this->xpath("//div[contains(@class,'field--type-json-data')]/div/pre/code");
     $actual = (string) $field_value[0]->getText();
     $actual = str_replace("'", "", $actual);

--- a/docroot/modules/custom/json_data_field/tests/src/Kernel/KernelTestBase.php
+++ b/docroot/modules/custom/json_data_field/tests/src/Kernel/KernelTestBase.php
@@ -18,7 +18,7 @@ abstract class KernelTestBase extends DrupalKernelTestBase {
   /**
    * {@inheritdoc}
    */
-  public static $modules = [
+  protected static $modules = [
     'json_data_field',
     'field',
     'user',

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/CgovCoreTools.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/CgovCoreTools.php
@@ -425,7 +425,8 @@ class CgovCoreTools {
    *   Returns one of the following: 'prod', 'test', 'dev', 'local'.
    */
   public function getCloudEnvironment() {
-    $site_env = strtolower($this->getAhSiteEnvironment());
+    // Null coalescing is to prevent deprecations warning in tests.
+    $site_env = strtolower($this->getAhSiteEnvironment() ?? '');
 
     // Check if site_env matches a prod environment name...
     if (in_array($site_env, self::PROD_AH_SITE_ENVS) ||

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Services/CgovNavigationManager.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Services/CgovNavigationManager.php
@@ -347,7 +347,7 @@ class CgovNavigationManager {
 
     // Get the index of the root, the next item in the array would ve the next
     // menu item that would get highlighted.
-    $idxRoot = array_search($navRoot, $this->fullAncestry);
+    $idxRoot = array_search($navRoot, $this->fullAncestry, TRUE);
     if ($idxRoot !== FALSE) {
       if (($idxRoot - 1) >= 0) {
         // Make sure the child is not set as display in main nav false.
@@ -489,7 +489,7 @@ class CgovNavigationManager {
     $menu_filter = 'hide_in_' . $menu_type;
 
     // We have a root. Now we need to figure out where we fall in the tree.
-    $root_idx = array_search($root_term, $this->fullAncestry);
+    $root_idx = array_search($root_term, $this->fullAncestry, TRUE);
 
     // If the root idx is 0, then the URL being viewed is the landing page for
     // root, so we can just return the id of the root. If we hit this condition

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_site_section/cgov_site_section.module
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_site_section/cgov_site_section.module
@@ -55,7 +55,11 @@ function cgov_site_section_taxonomy_term_presave(EntityInterface $entity) {
   // the server is case-sensitive.
   if ($entity->hasField('field_pretty_url') && !empty($entity->get('field_pretty_url'))) {
     $field_pretty_url = $entity->get('field_pretty_url')->value;
-    $entity->set('field_pretty_url', strtolower($field_pretty_url));
+    // Must still test if $field_pretty_url is not NULL for deprecations
+    // in tests.
+    if ($field_pretty_url !== NULL) {
+      $entity->set('field_pretty_url', strtolower($field_pretty_url));
+    }
   }
 
   // Calculate and set the compute_path field.
@@ -733,7 +737,11 @@ function cgov_site_section_entity_presave($entity) {
 
     if ($entity->hasField('field_pretty_url') && !empty($entity->get('field_pretty_url'))) {
       $field_pretty_url = $entity->get('field_pretty_url')->value;
-      $entity->set('field_pretty_url', strtolower($field_pretty_url));
+      // Must still test if $field_pretty_url is not NULL for deprecations
+      // in tests.
+      if ($field_pretty_url !== NULL) {
+        $entity->set('field_pretty_url', strtolower($field_pretty_url));
+      }
     }
   }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -39,8 +39,8 @@
     <!--env name="SIMPLETEST_DB" value=""/-->
     <!-- Example BROWSERTEST_OUTPUT_DIRECTORY value: /path/to/webroot/sites/simpletest/browser_output -->
     <env name="BROWSERTEST_OUTPUT_DIRECTORY" value=""/>
-    <!-- To disable deprecation testing completely uncomment the next line. -->
-    <!-- <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled"/> -->
+    <!-- See https://symfony.com/doc/current/components/phpunit_bridge.html for how to configure this. -->
+    <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled"/>
     <!-- Example for changing the driver class for mink tests MINK_DRIVER_CLASS value: 'Drupal\FunctionalJavascriptTests\DrupalSelenium2Driver' -->
     <!-- Example for changing the driver args to mink tests MINK_DRIVER_ARGS value: '["http://127.0.0.1:8510"]' -->
     <!-- Example for changing the driver args to phantomjs tests MINK_DRIVER_ARGS_PHANTOMJS value: '["http://127.0.0.1:8510"]' -->
@@ -61,11 +61,11 @@
     </testsuite>
   </testsuites>
   <!-- The Symfony deprecation listener has to come after the Drupal listener COMMENT -->
-  <!--listeners>
+  <listeners>
     <listener class="\Drupal\Tests\Listeners\DrupalListener">
     </listener>
     <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener">
     </listener>
-  </listeners -->
+  </listeners>
   <!-- Filter for coverage reports. -->
 </phpunit>


### PR DESCRIPTION
- Classy theme is going away in 10.0.0, and we needed to change out our tests that used it. They were mostly under docroot/modules.
- Bumped redirect module as it was throwing some errors
- Fixed deprecation warnings when strtolower(NULL) was *possible*. A number of changes will go into affect as part of PHP 9.0 resulting in value functions and other things dealing with values not working with NULL. The key term is NULL Coercion Consistency.  See https://wiki.php.net/rfc/deprecate_null_to_scalar_internal_arg

Closes #3532

ODE: https://www-test-ac.cancer.gov

Regression Tests (Front-end and CMS): https://github.com/NCIOCPL/cgov-digital-platform-acceptance-tests/actions/runs/6090063138/job/16524161910
