### PR TITLE
(#3541) simple sitemap module upgrade

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -66,7 +66,7 @@
         "drupal/samlauth": "3.x-dev@dev",
         "drupal/seckit": "^2.0.1",
         "drupal/shield": "^1.7.0",
-        "drupal/simple_sitemap": "^3.10.0",
+        "drupal/simple_sitemap": "^4.1",
         "drupal/token": "^1.12",
         "drupal/token_filter": "^1.3.0",
         "drupal/twig_field_value": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1c48dfe28e2f63c52089cefa300a1b68",
+    "content-hash": "b6bd14d880a32d4ebf3e6b1c4b48b026",
     "packages": [
         {
             "name": "acquia/acsf-tools",
@@ -7486,27 +7486,27 @@
         },
         {
             "name": "drupal/simple_sitemap",
-            "version": "3.10.0",
+            "version": "4.1.6",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/simple_sitemap.git",
-                "reference": "8.x-3.10"
+                "reference": "4.1.6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/simple_sitemap-8.x-3.10.zip",
-                "reference": "8.x-3.10",
-                "shasum": "4836e5d5bae0b4348406c832f81eabfaf16483e3"
+                "url": "https://ftp.drupal.org/files/projects/simple_sitemap-4.1.6.zip",
+                "reference": "4.1.6",
+                "shasum": "5ea5ee97ab4d59b43db86dd6279c3ac5ecbe69b9"
             },
             "require": {
-                "drupal/core": "^8 || ^9",
+                "drupal/core": "^9.3 || ^10",
                 "ext-xmlwriter": "*"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-3.10",
-                    "datestamp": "1617840662",
+                    "version": "4.1.6",
+                    "datestamp": "1686288643",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -7514,7 +7514,7 @@
                 },
                 "drush": {
                     "services": {
-                        "drush.services.yml": "^9 || ^10"
+                        "drush.services.yml": ">=9"
                     }
                 }
             },
@@ -7524,9 +7524,9 @@
             ],
             "authors": [
                 {
-                    "name": "Pawel Ginalski (gbyte.co)",
-                    "homepage": "https://www.drupal.org/u/gbyte.co",
-                    "email": "contact@gbyte.co",
+                    "name": "Pawel Ginalski (gbyte)",
+                    "homepage": "https://www.drupal.org/u/gbyte",
+                    "email": "contact@gbyte.dev",
                     "role": "Maintainer"
                 },
                 {
@@ -7538,8 +7538,7 @@
             "homepage": "https://drupal.org/project/simple_sitemap",
             "support": {
                 "source": "https://cgit.drupalcode.org/simple_sitemap",
-                "issues": "https://drupal.org/project/issues/simple_sitemap",
-                "irc": "irc://irc.freenode.org/drupal-contribute"
+                "issues": "https://drupal.org/project/issues/simple_sitemap"
             }
         },
         {

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_application_page/config/install/core.entity_form_display.node.cgov_application_page.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_application_page/config/install/core.entity_form_display.node.cgov_application_page.default.yml
@@ -194,6 +194,11 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  simple_sitemap:
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+    region: content
   status:
     type: boolean_checkbox
     weight: 25

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/cgov_article.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/cgov_article.info.yml
@@ -2,31 +2,31 @@ name: 'CGov Article'
 type: module
 package: 'CGov Digital Platform'
 description: 'The Article content type'
-core_version_requirement: ^8.9 || ^9
+core_version_requirement: '^9.4 || ^10'
 dependencies:
-  - cgov_core
-  - cgov_image
-  - cgov_list
-  - cgov_schema_org
-  - cgov_site_section
-  - cgov_syndication
-  - content_moderation
-  - content_translation
-  - datetime
-  - entity_browser
-  - entity_reference_revisions
-  - field
-  - language
-  - link
-  - metatag
-  - metatag_dc
-  - node
-  - options
-  - paragraphs
-  - paragraphs_asymmetric_translation_widgets
-  - path
-  - pathauto
-  - simple_sitemap
-  - text
-  - user
+  - 'cgov_core:cgov_core'
+  - 'cgov_image:cgov_image'
+  - 'cgov_list:cgov_list'
+  - 'cgov_schema_org:cgov_schema_org'
+  - 'cgov_site_section:cgov_site_section'
+  - 'cgov_syndication:cgov_syndication'
+  - 'drupal:content_moderation'
+  - 'drupal:content_translation'
+  - 'drupal:datetime'
+  - 'drupal:field'
+  - 'drupal:language'
+  - 'drupal:link'
+  - 'drupal:node'
+  - 'drupal:options'
+  - 'drupal:path'
+  - 'drupal:text'
+  - 'drupal:user'
+  - 'entity_browser:entity_browser'
+  - 'entity_reference_revisions:entity_reference_revisions'
+  - 'metatag:metatag'
+  - 'metatag:metatag_dc'
+  - 'paragraphs:paragraphs'
+  - 'paragraphs_asymmetric_translation_widgets:paragraphs_asymmetric_translation_widgets'
+  - 'pathauto:pathauto'
+  - 'simple_sitemap:simple_sitemap'
 core_incompatible: false

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/core.entity_form_display.node.cgov_article.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/core.entity_form_display.node.cgov_article.default.yml
@@ -26,9 +26,6 @@ dependencies:
     - field.field.node.cgov_article.field_search_engine_restrictions
     - field.field.node.cgov_article.field_site_section
     - node.type.cgov_article
-  enforced:
-    module:
-      - cgov_core
   module:
     - cgov_schema_org
     - cgov_syndication
@@ -38,6 +35,9 @@ dependencies:
     - paragraphs_asymmetric_translation_widgets
     - path
     - text
+  enforced:
+    module:
+      - cgov_core
 id: node.cgov_article.default
 targetEntityType: node
 bundle: cgov_article
@@ -252,6 +252,11 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  simple_sitemap:
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+    region: content
   status:
     type: boolean_checkbox
     settings:

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/core.entity_view_display.node.cgov_article.borderless_card_image.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/core.entity_view_display.node.cgov_article.borderless_card_image.yml
@@ -26,11 +26,11 @@ dependencies:
     - field.field.node.cgov_article.field_search_engine_restrictions
     - field.field.node.cgov_article.field_site_section
     - node.type.cgov_article
+  module:
+    - user
   enforced:
     module:
       - cgov_core
-  module:
-    - user
 id: node.cgov_article.borderless_card_image
 targetEntityType: node
 bundle: cgov_article

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/core.entity_view_display.node.cgov_article.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/core.entity_view_display.node.cgov_article.default.yml
@@ -25,15 +25,15 @@ dependencies:
     - field.field.node.cgov_article.field_search_engine_restrictions
     - field.field.node.cgov_article.field_site_section
     - node.type.cgov_article
-  enforced:
-    module:
-      - cgov_core
   module:
     - datetime
     - entity_reference_revisions
     - options
     - text
     - user
+  enforced:
+    module:
+      - cgov_core
 id: node.cgov_article.default
 targetEntityType: node
 bundle: cgov_article

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/core.entity_view_display.node.cgov_article.link.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/core.entity_view_display.node.cgov_article.link.yml
@@ -26,11 +26,11 @@ dependencies:
     - field.field.node.cgov_article.field_search_engine_restrictions
     - field.field.node.cgov_article.field_site_section
     - node.type.cgov_article
+  module:
+    - user
   enforced:
     module:
       - cgov_core
-  module:
-    - user
 id: node.cgov_article.link
 targetEntityType: node
 bundle: cgov_article

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/field.field.node.cgov_article.field_public_use.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/field.field.node.cgov_article.field_public_use.yml
@@ -4,11 +4,11 @@ dependencies:
   config:
     - field.storage.node.field_public_use
     - node.type.cgov_article
+  module:
+    - options
   enforced:
     module:
       - cgov_core
-  module:
-    - options
 id: node.cgov_article.field_public_use
 field_name: field_public_use
 entity_type: node

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/field.field.node.cgov_article.field_search_engine_restrictions.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/field.field.node.cgov_article.field_search_engine_restrictions.yml
@@ -4,11 +4,11 @@ dependencies:
   config:
     - field.storage.node.field_search_engine_restrictions
     - node.type.cgov_article
+  module:
+    - options
   enforced:
     module:
       - cgov_core
-  module:
-    - options
 id: node.cgov_article.field_search_engine_restrictions
 field_name: field_search_engine_restrictions
 entity_type: node

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_biography/cgov_biography.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_biography/cgov_biography.info.yml
@@ -2,7 +2,7 @@ name: 'CGov Biography'
 type: module
 package: 'CGov Digital Platform'
 description: 'The Biography content type'
-core_version_requirement: '^8.9 || ^9'
+core_version_requirement: '^9.4 || ^10'
 dependencies:
   - 'cgov_core:cgov_core'
   - 'cgov_image:cgov_image'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_biography/config/install/core.entity_form_display.node.cgov_biography.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_biography/config/install/core.entity_form_display.node.cgov_biography.default.yml
@@ -344,6 +344,11 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  simple_sitemap:
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+    region: content
   status:
     type: boolean_checkbox
     weight: 40

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_biography/config/install/core.entity_form_display.taxonomy_term.cgov_biography_campuses.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_biography/config/install/core.entity_form_display.taxonomy_term.cgov_biography_campuses.default.yml
@@ -33,6 +33,11 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+  simple_sitemap:
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+    region: content
   translation:
     weight: 3
     region: content

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/cgov_blog.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/cgov_blog.info.yml
@@ -2,7 +2,7 @@ name: 'CGov Blog'
 type: module
 package: 'CGov Digital Platform'
 description: 'Blog Post and Blog Series item functionality for CGov Digital Platform Sites'
-core_version_requirement: '^8.9 || ^9'
+core_version_requirement: '^9.4 || ^10'
 dependencies:
   - 'cgov_blog:cgov_blog'
   - 'cgov_core:cgov_core'
@@ -15,8 +15,8 @@ dependencies:
   - 'drupal:datetime'
   - 'drupal:field'
   - 'drupal:image'
-  - 'drupal:layout_builder'
   - 'drupal:language'
+  - 'drupal:layout_builder'
   - 'drupal:link'
   - 'drupal:node'
   - 'drupal:options'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/config/install/core.entity_form_display.node.cgov_blog_post.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/config/install/core.entity_form_display.node.cgov_blog_post.default.yml
@@ -225,6 +225,11 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  simple_sitemap:
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+    region: content
   title:
     type: string_textfield
     weight: 3

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/config/install/core.entity_form_display.node.cgov_blog_series.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/config/install/core.entity_form_display.node.cgov_blog_series.default.yml
@@ -232,6 +232,11 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  simple_sitemap:
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+    region: content
   title:
     type: string_textfield
     weight: 1

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/config/install/core.entity_form_display.taxonomy_term.cgov_blog_topics.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/config/install/core.entity_form_display.taxonomy_term.cgov_blog_topics.default.yml
@@ -49,6 +49,11 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+  simple_sitemap:
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+    region: content
   translation:
     weight: 5
     region: content

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/config/install/entity_browser.browser.cgov_blog_browser.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/config/install/entity_browser.browser.cgov_blog_browser.yml
@@ -19,12 +19,12 @@ widget_selector: tabs
 widget_selector_configuration: {  }
 widgets:
   f46a9eac-f95b-4e44-ae75-0ff115bed785:
-    id: view
-    uuid: f46a9eac-f95b-4e44-ae75-0ff115bed785
-    label: Find
-    weight: 1
     settings:
       submit_text: 'Add Blog content'
       auto_select: false
       view: cgov_blog_browser
       view_display: entity_browser_blog
+    uuid: f46a9eac-f95b-4e44-ae75-0ff115bed785
+    weight: 1
+    label: Find
+    id: view

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_center/cgov_cancer_center.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_center/cgov_cancer_center.info.yml
@@ -2,7 +2,7 @@ name: 'CGov Cancer Center'
 type: module
 package: 'CGov Digital Platform'
 description: 'The Cancer Center content type'
-core_version_requirement: '^8.9 || ^9'
+core_version_requirement: '^9.4 || ^10'
 dependencies:
   - 'address:address'
   - 'cgov_core:cgov_core'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_center/config/install/core.entity_form_display.node.cgov_cancer_center.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_center/config/install/core.entity_form_display.node.cgov_cancer_center.default.yml
@@ -298,6 +298,11 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  simple_sitemap:
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+    region: content
   status:
     type: boolean_checkbox
     weight: 35

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_center/config/install/core.entity_form_display.taxonomy_term.cgov_cancer_center_regions.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_center/config/install/core.entity_form_display.taxonomy_term.cgov_cancer_center_regions.default.yml
@@ -33,6 +33,11 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+  simple_sitemap:
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+    region: content
   translation:
     weight: 3
     region: content

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_center/config/install/core.entity_form_display.taxonomy_term.cgov_cancer_center_types.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_center/config/install/core.entity_form_display.taxonomy_term.cgov_cancer_center_types.default.yml
@@ -33,6 +33,11 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+  simple_sitemap:
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+    region: content
   translation:
     weight: 3
     region: content

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_research/cgov_cancer_research.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_research/cgov_cancer_research.info.yml
@@ -2,29 +2,29 @@ name: 'CGov Cancer Research List Page'
 type: module
 package: 'CGov Digital Platform'
 description: 'The Cancer Research List Page content type'
-core_version_requirement: ^8.9 || ^9
+core_version_requirement: '^9.4 || ^10'
 dependencies:
-  - cgov_core
-  - cgov_image
-  - cgov_list
-  - cgov_site_section
-  - content_moderation
-  - content_translation
-  - datetime
-  - entity_browser
-  - entity_reference_revisions
-  - field
-  - language
-  - link
-  - metatag
-  - metatag_dc
-  - node
-  - options
-  - paragraphs
-  - paragraphs_asymmetric_translation_widgets
-  - path
-  - pathauto
-  - simple_sitemap
-  - text
-  - user
+  - 'cgov_core:cgov_core'
+  - 'cgov_image:cgov_image'
+  - 'cgov_list:cgov_list'
+  - 'cgov_site_section:cgov_site_section'
+  - 'drupal:content_moderation'
+  - 'drupal:content_translation'
+  - 'drupal:datetime'
+  - 'drupal:field'
+  - 'drupal:language'
+  - 'drupal:link'
+  - 'drupal:node'
+  - 'drupal:options'
+  - 'drupal:path'
+  - 'drupal:text'
+  - 'drupal:user'
+  - 'entity_browser:entity_browser'
+  - 'entity_reference_revisions:entity_reference_revisions'
+  - 'metatag:metatag'
+  - 'metatag:metatag_dc'
+  - 'paragraphs:paragraphs'
+  - 'paragraphs_asymmetric_translation_widgets:paragraphs_asymmetric_translation_widgets'
+  - 'pathauto:pathauto'
+  - 'simple_sitemap:simple_sitemap'
 core_incompatible: false

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_research/config/install/core.entity_form_display.node.cgov_cancer_research.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_research/config/install/core.entity_form_display.node.cgov_cancer_research.default.yml
@@ -185,6 +185,11 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  simple_sitemap:
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+    region: content
   status:
     type: boolean_checkbox
     settings:

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.features.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.features.yml
@@ -20,4 +20,3 @@ excluded:
   - cgov_core.frontend_globals
 required:
   - simple_sitemap.settings
-  - simple_sitemap.variants.default_hreflang

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/config/install/simple_sitemap.settings.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/config/install/simple_sitemap.settings.yml
@@ -2,12 +2,15 @@ max_links: 20000
 cron_generate: true
 cron_generate_interval: 0
 generate_duration: 10000
+entities_per_queue_item: 50
 remove_duplicates: true
 skip_untranslated: true
 xsl: true
 base_url: ''
 default_variant: default
 custom_links_include_images: false
+disable_language_hreflang: false
+hide_branding: false
 excluded_languages: {  }
 enabled_entity_types:
   - node

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/config/install/simple_sitemap.variants.default_hreflang.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/config/install/simple_sitemap.variants.default_hreflang.yml
@@ -1,4 +1,0 @@
-variants:
-  default:
-    label: Default
-    weight: 0

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/cgov_cthp.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/cgov_cthp.info.yml
@@ -2,34 +2,34 @@ name: 'CGov Cancer Type Home Page'
 type: module
 package: 'CGov Digital Platform'
 description: 'The Cancer Type Home Page content type'
-core_version_requirement: ^8.9 || ^9
+core_version_requirement: '^9.4 || ^10'
 dependencies:
-  - block_content
-  - cgov_cancer_research
-  - cgov_core
-  - cgov_home_landing
-  - cgov_image
-  - cgov_list
-  - cgov_site_section
-  - cgov_video
-  - content_moderation
-  - content_translation
-  - entity_browser
-  - entity_reference_revisions
-  - field
-  - language
-  - link
-  - media
-  - metatag
-  - metatag_dc
-  - node
-  - options
-  - paragraphs
-  - paragraphs_asymmetric_translation_widgets
-  - path
-  - pathauto
-  - pdq_cancer_information_summary
-  - simple_sitemap
-  - text
-  - user
+  - 'cgov_cancer_research:cgov_cancer_research'
+  - 'cgov_core:cgov_core'
+  - 'cgov_home_landing:cgov_home_landing'
+  - 'cgov_image:cgov_image'
+  - 'cgov_list:cgov_list'
+  - 'cgov_site_section:cgov_site_section'
+  - 'cgov_video:cgov_video'
+  - 'drupal:block_content'
+  - 'drupal:content_moderation'
+  - 'drupal:content_translation'
+  - 'drupal:field'
+  - 'drupal:language'
+  - 'drupal:link'
+  - 'drupal:media'
+  - 'drupal:node'
+  - 'drupal:options'
+  - 'drupal:path'
+  - 'drupal:text'
+  - 'drupal:user'
+  - 'entity_browser:entity_browser'
+  - 'entity_reference_revisions:entity_reference_revisions'
+  - 'metatag:metatag'
+  - 'metatag:metatag_dc'
+  - 'paragraphs:paragraphs'
+  - 'paragraphs_asymmetric_translation_widgets:paragraphs_asymmetric_translation_widgets'
+  - 'pathauto:pathauto'
+  - 'pdq_cancer_information_summary:pdq_cancer_information_summary'
+  - 'simple_sitemap:simple_sitemap'
 core_incompatible: false

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/core.entity_form_display.node.cgov_cthp.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/core.entity_form_display.node.cgov_cthp.default.yml
@@ -17,14 +17,14 @@ dependencies:
     - field.field.node.cgov_cthp.field_search_engine_restrictions
     - field.field.node.cgov_cthp.field_site_section
     - node.type.cgov_cthp
-  enforced:
-    module:
-      - cgov_core
   module:
     - content_moderation
     - entity_browser
     - paragraphs_asymmetric_translation_widgets
     - path
+  enforced:
+    module:
+      - cgov_core
 id: node.cgov_cthp.default
 targetEntityType: node
 bundle: cgov_cthp
@@ -170,6 +170,11 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  simple_sitemap:
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+    region: content
   status:
     type: boolean_checkbox
     settings:

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/core.entity_view_display.node.cgov_cthp.borderless_card_image.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/core.entity_view_display.node.cgov_cthp.borderless_card_image.yml
@@ -17,11 +17,11 @@ dependencies:
     - field.field.node.cgov_cthp.field_search_engine_restrictions
     - field.field.node.cgov_cthp.field_site_section
     - node.type.cgov_cthp
+  module:
+    - user
   enforced:
     module:
       - cgov_core
-  module:
-    - user
 id: node.cgov_cthp.borderless_card_image
 targetEntityType: node
 bundle: cgov_cthp

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/core.entity_view_display.node.cgov_cthp.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/core.entity_view_display.node.cgov_cthp.default.yml
@@ -16,14 +16,14 @@ dependencies:
     - field.field.node.cgov_cthp.field_search_engine_restrictions
     - field.field.node.cgov_cthp.field_site_section
     - node.type.cgov_cthp
-  enforced:
-    module:
-      - cgov_core
   module:
     - entity_reference_revisions
     - metatag
     - options
     - user
+  enforced:
+    module:
+      - cgov_core
 id: node.cgov_cthp.default
 targetEntityType: node
 bundle: cgov_cthp

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/core.entity_view_display.node.cgov_cthp.link.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/core.entity_view_display.node.cgov_cthp.link.yml
@@ -17,11 +17,11 @@ dependencies:
     - field.field.node.cgov_cthp.field_search_engine_restrictions
     - field.field.node.cgov_cthp.field_site_section
     - node.type.cgov_cthp
+  module:
+    - user
   enforced:
     module:
       - cgov_core
-  module:
-    - user
 id: node.cgov_cthp.link
 targetEntityType: node
 bundle: cgov_cthp

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/field.field.node.cgov_cthp.field_search_engine_restrictions.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/field.field.node.cgov_cthp.field_search_engine_restrictions.yml
@@ -4,11 +4,11 @@ dependencies:
   config:
     - field.storage.node.field_search_engine_restrictions
     - node.type.cgov_cthp
+  module:
+    - options
   enforced:
     module:
       - cgov_core
-  module:
-    - options
 id: node.cgov_cthp.field_search_engine_restrictions
 field_name: field_search_engine_restrictions
 entity_type: node

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/field.storage.paragraph.field_cthp_card_theme.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/field.storage.paragraph.field_cthp_card_theme.yml
@@ -1,12 +1,12 @@
 langcode: en
 status: true
 dependencies:
-  enforced:
-    module:
-      - cgov_core
   module:
     - options
     - paragraphs
+  enforced:
+    module:
+      - cgov_core
 id: paragraph.field_cthp_card_theme
 field_name: field_cthp_card_theme
 entity_type: paragraph

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/field.storage.paragraph.field_cthp_card_title.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/field.storage.paragraph.field_cthp_card_title.yml
@@ -1,11 +1,11 @@
 langcode: en
 status: true
 dependencies:
+  module:
+    - paragraphs
   enforced:
     module:
       - cgov_core
-  module:
-    - paragraphs
 id: paragraph.field_cthp_card_title
 field_name: field_cthp_card_title
 entity_type: paragraph

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_event/cgov_event.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_event/cgov_event.info.yml
@@ -2,7 +2,7 @@ name: 'CGov Event'
 type: module
 package: 'CGov Digital Platform'
 description: 'The Event content type'
-core_version_requirement: '^8.9 || ^9'
+core_version_requirement: '^9.4 || ^10'
 dependencies:
   - 'cgov_core:cgov_core'
   - 'cgov_image:cgov_image'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_event/config/install/core.entity_form_display.node.cgov_event.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_event/config/install/core.entity_form_display.node.cgov_event.default.yml
@@ -236,6 +236,11 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  simple_sitemap:
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+    region: content
   status:
     type: boolean_checkbox
     weight: 26

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_event/config/install/core.entity_form_display.taxonomy_term.cgov_event_series.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_event/config/install/core.entity_form_display.taxonomy_term.cgov_event_series.default.yml
@@ -33,6 +33,11 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+  simple_sitemap:
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+    region: content
   translation:
     weight: 3
     region: content

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_event/config/install/core.entity_form_display.taxonomy_term.cgov_event_venues.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_event/config/install/core.entity_form_display.taxonomy_term.cgov_event_venues.default.yml
@@ -33,6 +33,11 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+  simple_sitemap:
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+    region: content
   translation:
     weight: 3
     region: content

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_file/config/install/core.entity_form_display.media.cgov_file.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_file/config/install/core.entity_form_display.media.cgov_file.default.yml
@@ -168,6 +168,11 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  simple_sitemap:
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+    region: content
   status:
     type: boolean_checkbox
     weight: 20

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/cgov_home_landing.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/cgov_home_landing.info.yml
@@ -2,7 +2,7 @@ name: 'CGov Home and Landing Page'
 type: module
 package: 'CGov Digital Platform'
 description: 'The home and landing page content type'
-core_version_requirement: '^8.9 || ^9'
+core_version_requirement: '^9.4 || ^10'
 dependencies:
   - 'cgov_core:cgov_core'
   - 'cgov_image:cgov_image'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/config/install/core.entity_form_display.node.cgov_home_landing.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/config/install/core.entity_form_display.node.cgov_home_landing.default.yml
@@ -203,6 +203,11 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  simple_sitemap:
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+    region: content
   status:
     type: boolean_checkbox
     weight: 23

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/config/install/core.entity_form_display.node.cgov_mini_landing.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/config/install/core.entity_form_display.node.cgov_mini_landing.default.yml
@@ -185,6 +185,11 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  simple_sitemap:
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+    region: content
   status:
     type: boolean_checkbox
     weight: 22

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/config/install/field.storage.paragraph.field_ncids_theme.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/config/install/field.storage.paragraph.field_ncids_theme.yml
@@ -18,7 +18,7 @@ settings:
       label: Light
     -
       value: nci-promo-block--dark
-      label: DON'T USE
+      label: 'DON''T USE'
   allowed_values_function: ''
 module: options
 locked: false

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_image/config/install/core.entity_form_display.media.cgov_contextual_image.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_image/config/install/core.entity_form_display.media.cgov_contextual_image.default.yml
@@ -91,6 +91,11 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+  simple_sitemap:
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+    region: content
   status:
     type: boolean_checkbox
     weight: 13

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_image/config/install/core.entity_form_display.media.cgov_image.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_image/config/install/core.entity_form_display.media.cgov_image.default.yml
@@ -166,6 +166,11 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+  simple_sitemap:
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+    region: content
   status:
     type: boolean_checkbox
     weight: 16

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_infographic/config/install/core.entity_form_display.media.cgov_infographic.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_infographic/config/install/core.entity_form_display.media.cgov_infographic.default.yml
@@ -218,6 +218,11 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  simple_sitemap:
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+    region: content
   status:
     type: boolean_checkbox
     weight: 22

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/cgov_press_release.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/cgov_press_release.info.yml
@@ -2,7 +2,7 @@ name: 'CGov Press Release'
 type: module
 package: 'CGov Digital Platform'
 description: 'The Press Release content type'
-core_version_requirement: '^8.9 || ^9'
+core_version_requirement: '^9.4 || ^10'
 dependencies:
   - 'cgov_core:cgov_core'
   - 'cgov_image:cgov_image'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/core.entity_form_display.node.cgov_press_release.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/core.entity_form_display.node.cgov_press_release.default.yml
@@ -246,6 +246,11 @@ content:
     settings:
       display_label: true
     third_party_settings: {  }
+  simple_sitemap:
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+    region: content
   status:
     type: boolean_checkbox
     weight: 30

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_site_section/cgov_site_section.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_site_section/cgov_site_section.info.yml
@@ -2,7 +2,7 @@ name: 'CGov Site Sections'
 type: module
 description: 'Cancer.gov Site Section module.'
 package: 'CGov Digital Platform'
-core_version_requirement: '^8.9 || ^9'
+core_version_requirement: '^9.4 || ^10'
 dependencies:
   - 'cgov_content_block:cgov_content_block'
   - 'cgov_core:cgov_core'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_site_section/config/install/core.entity_form_display.taxonomy_term.cgov_site_sections.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_site_section/config/install/core.entity_form_display.taxonomy_term.cgov_site_sections.default.yml
@@ -141,6 +141,11 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+  simple_sitemap:
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+    region: content
 hidden:
   path: true
   status: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_form_display.node.pdq_cancer_information_summary.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/core.entity_form_display.node.pdq_cancer_information_summary.default.yml
@@ -136,7 +136,7 @@ content:
     type: options_select
     weight: 17
     region: content
-    settings: { }
+    settings: {  }
     third_party_settings: {  }
   field_summary_sections:
     type: paragraphs_classic_asymmetric
@@ -176,6 +176,11 @@ content:
     settings:
       display_label: true
     third_party_settings: {  }
+  simple_sitemap:
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+    region: content
   status:
     type: boolean_checkbox
     weight: 9

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/entity_browser.browser.pdq_cis_browser.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/entity_browser.browser.pdq_cis_browser.yml
@@ -19,12 +19,12 @@ widget_selector: single
 widget_selector_configuration: {  }
 widgets:
   74bbf32c-32eb-4892-9d67-c6534cf7257a:
-    id: view
-    uuid: 74bbf32c-32eb-4892-9d67-c6534cf7257a
-    label: Select
-    weight: 1
     settings:
       submit_text: 'Select summary'
       auto_select: false
       view: pdq_cis_browser
       view_display: entity_browser_1
+    uuid: 74bbf32c-32eb-4892-9d67-c6534cf7257a
+    weight: 1
+    label: Select
+    id: view

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/pdq_cancer_information_summary.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/pdq_cancer_information_summary.info.yml
@@ -2,7 +2,7 @@ name: 'PDQ Cancer Information Summary'
 type: module
 package: 'CGov Digital Platform'
 description: 'The PDQ Cancer Information Summary content type'
-core_version_requirement: '^8.9 || ^9'
+core_version_requirement: '^9.4 || ^10'
 dependencies:
   - 'cgov_core:cgov_core'
   - 'cgov_syndication:cgov_syndication'

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_drug_information_summary/config/install/core.entity_form_display.node.pdq_drug_information_summary.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_drug_information_summary/config/install/core.entity_form_display.node.pdq_drug_information_summary.default.yml
@@ -15,14 +15,14 @@ dependencies:
     - field.field.node.pdq_drug_information_summary.field_pdq_url
     - field.field.node.pdq_drug_information_summary.field_public_use
     - node.type.pdq_drug_information_summary
-  enforced:
-    module:
-      - pdq_core
   module:
     - content_moderation
     - datetime
     - path
     - text
+  enforced:
+    module:
+      - pdq_core
 id: node.pdq_drug_information_summary.default
 targetEntityType: node
 bundle: pdq_drug_information_summary
@@ -139,6 +139,11 @@ content:
     weight: 6
     region: content
     third_party_settings: {  }
+  simple_sitemap:
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+    region: content
   status:
     type: boolean_checkbox
     settings:

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_drug_information_summary/config/install/core.entity_view_display.node.pdq_drug_information_summary.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_drug_information_summary/config/install/core.entity_view_display.node.pdq_drug_information_summary.default.yml
@@ -15,14 +15,14 @@ dependencies:
     - field.field.node.pdq_drug_information_summary.field_pdq_url
     - field.field.node.pdq_drug_information_summary.field_public_use
     - node.type.pdq_drug_information_summary
-  enforced:
-    module:
-      - pdq_core
   module:
     - cgov_core
     - options
     - text
     - user
+  enforced:
+    module:
+      - pdq_core
 id: node.pdq_drug_information_summary.default
 targetEntityType: node
 bundle: pdq_drug_information_summary

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_drug_information_summary/pdq_drug_information_summary.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_drug_information_summary/pdq_drug_information_summary.info.yml
@@ -2,25 +2,25 @@ name: 'PDQ Drug Information Summary'
 type: module
 package: 'CGov Digital Platform'
 description: 'The PDQ Drug Information Summary content type'
-core_version_requirement: ^8.9 || ^9
+core_version_requirement: '^9.4 || ^10'
 dependencies:
-  - basic_auth
-  - cgov_core
-  - content_moderation
-  - content_translation
-  - datetime
-  - field
-  - language
-  - metatag
-  - metatag_dc
-  - node
-  - options
-  - path
-  - pathauto
-  - pdq_core
-  - pdq_drug_information_summary
-  - rest
-  - serialization
-  - simple_sitemap
-  - text
-  - user
+  - 'cgov_core:cgov_core'
+  - 'drupal:basic_auth'
+  - 'drupal:content_moderation'
+  - 'drupal:content_translation'
+  - 'drupal:datetime'
+  - 'drupal:field'
+  - 'drupal:language'
+  - 'drupal:node'
+  - 'drupal:options'
+  - 'drupal:path'
+  - 'drupal:rest'
+  - 'drupal:serialization'
+  - 'drupal:text'
+  - 'drupal:user'
+  - 'metatag:metatag'
+  - 'metatag:metatag_dc'
+  - 'pathauto:pathauto'
+  - 'pdq_core:pdq_core'
+  - 'pdq_drug_information_summary:pdq_drug_information_summary'
+  - 'simple_sitemap:simple_sitemap'

--- a/hooks/common/post-code-deploy/post-code-deploy.sh
+++ b/hooks/common/post-code-deploy/post-code-deploy.sh
@@ -79,4 +79,8 @@ else
   drush pmu cgov_yaml_content
 fi
 
+## Make sure Drupal cron jobs (e.g. sitemap) get run at least once.
+drush cron
+drush cr
+
 set +v

--- a/hooks/common/post-code-update/post-code-update.sh
+++ b/hooks/common/post-code-update/post-code-update.sh
@@ -81,4 +81,8 @@ else
   drush pmu cgov_yaml_content
 fi
 
+## Make sure Drupal cron jobs (e.g. sitemap) get run at least once.
+drush cron
+drush cr
+
 set +v


### PR DESCRIPTION
Make sure cron jobs are run at least once so we can view sitemap.xml
on lower-tier environments.

Updates `core.entity_form_display` for all content types. (UI changes only visible with `admin` role.)

Closes https://github.com/NCIOCPL/cgov-digital-platform/issues/3541