### PR TITLE
(#4131) Enforce SAML authentication

### DIFF
--- a/cgov-drupal-users.yml
+++ b/cgov-drupal-users.yml
@@ -7,12 +7,14 @@ admin:
 additional_users:
   - username: 'author'
     password: 'password123'
+    saml: false
     roles:
       - 'content_author'
       - 'image_manager'
       - 'admin_ui'
   - username: 'editor'
     password: 'password123'
+    saml: false
     roles:
       - 'content_author'
       - 'content_editor'
@@ -20,6 +22,7 @@ additional_users:
       - 'admin_ui'
   - username: 'adveditor'
     password: 'password123'
+    saml: false
     roles:
       - 'content_author'
       - 'content_editor'
@@ -28,6 +31,7 @@ additional_users:
       - 'admin_ui'
   - username: 'siteadmin'
     password: 'password123'
+    saml: false
     roles:
       - 'content_author'
       - 'content_editor'
@@ -38,5 +42,6 @@ additional_users:
       - 'blog_manager'
   - username: 'preview'
     password: 'password123'
+    saml: false
     roles:
       - 'content_previewer'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_saml_auth_config/cgov_saml_auth_config.install
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_saml_auth_config/cgov_saml_auth_config.install
@@ -23,3 +23,30 @@ function cgov_saml_auth_config_update_9001() {
     $installer->install(['autologout']);
   }
 }
+
+/**
+ * Enforce samlauth for all users. (Issue #4131)
+ * One time update to make sure everyone has it enforced.
+ */
+function cgov_saml_auth_config_update_9002() {
+
+  $externalauth = \Drupal::service('externalauth.externalauth');
+
+  // Load all users.
+  $users = \Drupal::entityTypeManager()
+    ->getStorage('user')
+    ->loadMultiple();
+
+foreach ($users as $user) {
+  $authname = $user->getAccountName();
+
+  $excluded_usernames = ['siteadmin', 'author', 'editor', 'adveditor', 'preview', 'PDQ'];
+
+  // Link the user to 'samlauth' if not already linked.
+  if ($user->id() > 1 && // not admin
+      !in_array($authname, $excluded_usernames) // not one of our current standard accounts
+      ) {
+      $externalauth->linkExistingAccount($authname, 'samlauth', $user);
+    }
+  }
+}

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_saml_auth_config/cgov_saml_auth_config.module
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_saml_auth_config/cgov_saml_auth_config.module
@@ -1,12 +1,13 @@
 <?php
 
+use \Drupal\user\Entity\User;
+
 /**
  * @file
  * Contains cgov_saml_auth_config.module.
  */
 
 use Drupal\Core\Url;
-use Symfony\Component\HttpFoundation\RequestStack;
 use \Drupal\Core\Form\FormStateInterface;
 
  /**
@@ -77,4 +78,34 @@ function cgov_saml_auth_config_user_logout($account)
   $url = Url::fromRoute('user.login');
   $requestStack = \Drupal::requestStack();
   $requestStack->getCurrentRequest()->query->set('destination', $url->toString());
+}
+
+/**
+ * Extra submit action to add user to externalauth table.
+ */
+function user_form_submit($form, FormStateInterface $form_state) {
+
+  $name = $form_state->getValue('name');
+  $account = User::load($form_state->getValue('uid'));
+
+  $externalauth = \Drupal::service('externalauth.externalauth');
+
+  // Link the user to 'samlauth' if not already linked.
+  $externalauth->linkExistingAccount($name, 'samlauth', $account);
+}
+
+/**
+ * Implements hook_form_BASE_FORM_ID_alter() to hide password fields.
+ */
+function cgov_saml_auth_config_form_user_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+
+  if (\Drupal::hasService('externalauth.externalauth') &&
+  \Drupal::moduleHandler()->moduleExists('samlauth')) {
+
+    $form['account']['pass']['#access'] = FALSE;
+    $form['account']['pass']['#required'] = FALSE;
+    $form['actions']['submit']['#submit'][] = 'user_form_submit';
+
+  }
+
 }

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_saml_auth_config/tests/src/Functional/CgovSamlAuthConfigTest.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_saml_auth_config/tests/src/Functional/CgovSamlAuthConfigTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Drupal\Tests\cgov_saml_auth_config\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+use Drupal\user\Entity\Role;
+use CgovPlatform\Tests\CgovSchemaExclusions;
+
+/**
+ * Tests user form alterations.
+ *
+ * @group cgov_saml_auth_config
+ */
+class CgovSamlAuthConfigTest extends BrowserTestBase {
+
+  /**
+   * Use our own profile instead of the default.
+   *
+   * @var string
+   */
+  protected $profile = 'cgov_site';
+
+  /**
+   * The theme to use with this test.
+   *
+   * @var string
+   */
+  protected $defaultTheme = 'cgov_common';
+
+  /**
+   * An admin user for testing.
+   *
+   * @var \Drupal\user\Entity\User
+   */
+  protected $adminUser;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    static::$configSchemaCheckerExclusions = CgovSchemaExclusions::$configSchemaCheckerExclusions;
+    // Install Drupal.
+    parent::setUp();
+
+    // Create an admin user.
+    $this->adminUser = $this->drupalCreateUser([
+      'administer site configuration',
+      'administer users',
+      'access administration pages',
+    ]);
+    $this->adminUser->addRole(Role::load('administrator'));
+    $this->adminUser->save();
+  }
+
+  /**
+   * Tests user registration form alterations.
+   */
+  public function testUserFormAlterations() {
+    // Log in as the admin user.
+    $this->drupalLogin($this->adminUser);
+
+    // Visit the user add form.
+    $this->drupalGet('admin/people/create');
+
+    // Check if the password field is not present.
+    $this->assertSession()->fieldNotExists('pass[pass1]');
+    $this->assertSession()->fieldNotExists('pass[pass2]');
+
+    // Submit the user registration form.
+    $edit = [
+      'name' => $this->randomMachineName(),
+    ];
+    $this->submitForm($edit, 'Create new account');
+
+    // Check if an entry was added to the externalauth table.
+    $externalauth = \Drupal::service('externalauth.externalauth');
+    $addedEntry = $externalauth->load($edit['name'], 'samlauth');
+    $this->assertNotNull($addedEntry, 'Entry was added to the externalauth table.');
+
+    // Get the new user's ID.
+    $user = user_load_by_name($edit['name']);
+    $uid = $user->id();
+
+    // Visit the user edit form.
+    $this->drupalGet(sprintf('user/%s/edit', $uid));
+
+    // Check if the password field is not present.
+    $this->assertSession()->fieldNotExists('pass[pass1]');
+    $this->assertSession()->fieldNotExists('pass[pass2]');
+
+    // Delete the authmap entry to test re-adding it.
+    \Drupal::database()->delete('authmap')
+      ->condition('authname', $edit['name'])
+      ->execute();
+
+    // Submit the edit form.
+    $this->submitForm([], 'Save');
+
+    // Check if an entry was added to the externalauth table.
+    $editedEntry = $externalauth->load($edit['name'], 'samlauth');
+    $this->assertNotNull($editedEntry, 'Entry was added to the externalauth table.');
+
+  }
+
+}

--- a/docroot/sites/settings/cgov_saml_auth_config.settings.php
+++ b/docroot/sites/settings/cgov_saml_auth_config.settings.php
@@ -5,6 +5,8 @@
  * Set up SAML settings for Single Sign-On
  */
 
+ $samlDir = "";
+
 // Get our current environment
 if (file_exists('/var/www/site-php') && isset($_ENV['AH_SITE_ENVIRONMENT'])) {
   $samlDir = "/mnt/files/{$_ENV['AH_SITE_GROUP']}.{$_ENV['AH_SITE_ENVIRONMENT']}/saml";

--- a/drush/Commands/cgov/CgovUserCommands.php
+++ b/drush/Commands/cgov/CgovUserCommands.php
@@ -287,6 +287,7 @@ class CgovUserCommands extends DrushCommands {
       // Update the existing account.
       $this->logger->warning(dt('User !user exists already. Updating...', ['!user' => $name]));
       $account->setpassword($pwd);
+      $account->activate();
     }
     else {
       $new_user = [

--- a/drush/Commands/cgov/CgovUserCommands.php
+++ b/drush/Commands/cgov/CgovUserCommands.php
@@ -234,6 +234,7 @@ class CgovUserCommands extends DrushCommands {
 
     // TODO: This should be more robust and check bad chars.
     // Password is optional, so not going to check it.
+    // saml is optional too, so not going to check it
     $isValid = (
       array_key_exists('username', $user) &&
       $user['username'] != '' &&
@@ -309,6 +310,14 @@ class CgovUserCommands extends DrushCommands {
     }
 
     $account->save();
+
+    // If external authentication is available, set the user up to use it.
+    if (\Drupal::hasService('externalauth.externalauth') &&
+      \Drupal::moduleHandler()->moduleExists('samlauth') &&
+      $user['saml'] !== FALSE) {
+      $externalauth = \Drupal::service('externalauth.externalauth');
+      $externalauth->linkExistingAccount($name, 'samlauth', $account);
+    }
 
     if ($isNew) {
       $this->logger()->success(dt(


### PR DESCRIPTION
- Adds new user accounts to authmap table
- One time update to all users to ensure they are in authmap
- Unblocks user accounts on copy-down

Closes #4131
Closes #4129 