### PR TITLE
(#4156) Suppress missing saml array key on import

### DIFF
--- a/drush/Commands/cgov/CgovUserCommands.php
+++ b/drush/Commands/cgov/CgovUserCommands.php
@@ -234,7 +234,7 @@ class CgovUserCommands extends DrushCommands {
 
     // TODO: This should be more robust and check bad chars.
     // Password is optional, so not going to check it.
-    // saml is optional too, so not going to check it
+    // Saml is optional too, so not going to check it.
     $isValid = (
       array_key_exists('username', $user) &&
       $user['username'] != '' &&
@@ -278,6 +278,12 @@ class CgovUserCommands extends DrushCommands {
     else {
       $pwd = NULL;
     }
+    if (array_key_exists('saml', $user) && is_bool($user['saml'])) {
+      $saml = $user['saml'];
+    }
+    else {
+      $saml = TRUE;
+    }
 
     $account = user_load_by_name($name);
 
@@ -314,7 +320,7 @@ class CgovUserCommands extends DrushCommands {
     // If external authentication is available, set the user up to use it.
     if (\Drupal::hasService('externalauth.externalauth') &&
       \Drupal::moduleHandler()->moduleExists('samlauth') &&
-      $user['saml'] !== FALSE) {
+      $saml !== FALSE) {
       $externalauth = \Drupal::service('externalauth.externalauth');
       $externalauth->linkExistingAccount($name, 'samlauth', $account);
     }


### PR DESCRIPTION
Cuts down on noise during a fresh install. Not strictly necessary, but also would be good to not have extra lines:

````
 [success] Created a new user X with uid 41
 [warning] Undefined array key "saml" CgovUserCommands.php:317
 [success] Created a new user Y with uid 46
 [warning] Undefined array key "saml" CgovUserCommands.php:317
 [success] Created a new user Z with uid 51
 [warning] Undefined array key "saml" CgovUserCommands.php:317
 [success] Created a new user A with uid 56
 [warning] Undefined array key "saml" CgovUserCommands.php:317
 [success] Created a new user B with uid 61
 [warning] Undefined array key "saml" CgovUserCommands.php:317
````

Closes #4156