### PR TITLE
(#4163, #4165, #4166, #4167, #4164, #4168) Misc D10 Blockers

### DIFF
--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_application_page/config/install/pathauto.pattern.application_page_url.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_application_page/config/install/pathauto.pattern.application_page_url.yml
@@ -9,13 +9,13 @@ type: 'canonical_entities:node'
 pattern: '/[cgov_tokens:cgov-computed-path]/[node:field_pretty_url:value]'
 selection_criteria:
   9078cc95-999d-470e-b9ae-420ce30fbfa5:
-    id: node_type
-    bundles:
-      cgov_application_page: cgov_application_page
+    id: 'entity_bundle:node'
     negate: false
+    uuid: 9078cc95-999d-470e-b9ae-420ce30fbfa5
     context_mapping:
       node: node
-    uuid: 9078cc95-999d-470e-b9ae-420ce30fbfa5
+    bundles:
+      cgov_application_page: cgov_application_page
 selection_logic: and
 weight: -5
 relationships: {  }

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/pathauto.pattern.article_url.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/pathauto.pattern.article_url.yml
@@ -9,13 +9,13 @@ type: 'canonical_entities:node'
 pattern: '/[cgov_tokens:cgov-computed-path]/[node:field_pretty_url:value]'
 selection_criteria:
   aa91e8ac-3e1c-46e4-94e4-2f815d03b5d9:
-    id: node_type
-    bundles:
-      cgov_article: cgov_article
+    id: 'entity_bundle:node'
     negate: false
+    uuid: aa91e8ac-3e1c-46e4-94e4-2f815d03b5d9
     context_mapping:
       node: node
-    uuid: aa91e8ac-3e1c-46e4-94e4-2f815d03b5d9
+    bundles:
+      cgov_article: cgov_article
 selection_logic: and
 weight: -5
 relationships: {  }

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_biography/cgov_biography.install
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_biography/cgov_biography.install
@@ -62,14 +62,16 @@ EOMarkup;
     'weight' => 0,
     'theme' => $block_theme,
     'visibility' => [
-      'node_type' =>
+      'entity_bundle:node' =>
         [
-          'id' => 'node_type',
-          'bundles' => ['cgov_biography' => 'cgov_biography'],
-          'context_mapping' =>
-            [
-              'node' => '@node.node_route_context:node',
-            ],
+          'id' => 'entity_bundle:node',
+          'negate' => FALSE,
+          'context_mapping' => [
+            'node' => '@node.node_route_context:node',
+          ],
+          'bundles' => [
+            'cgov_biography' => 'cgov_biography',
+          ],
         ],
       'language' =>
         [

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_biography/config/install/pathauto.pattern.biography_url.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_biography/config/install/pathauto.pattern.biography_url.yml
@@ -9,13 +9,13 @@ type: 'canonical_entities:node'
 pattern: '/[cgov_tokens:cgov-computed-path]/[node:field_pretty_url:value]'
 selection_criteria:
   82798133-0309-4131-8259-a7c420cd43f2:
-    id: node_type
-    bundles:
-      cgov_biography: cgov_biography
+    id: 'entity_bundle:node'
     negate: false
+    uuid: 82798133-0309-4131-8259-a7c420cd43f2
     context_mapping:
       node: node
-    uuid: 82798133-0309-4131-8259-a7c420cd43f2
+    bundles:
+      cgov_biography: cgov_biography
 selection_logic: and
 weight: -5
 relationships: {  }

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/config/install/pathauto.pattern.blog_series_url.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/config/install/pathauto.pattern.blog_series_url.yml
@@ -9,7 +9,7 @@ type: 'canonical_entities:node'
 pattern: '/[cgov_tokens:cgov-computed-path]/[node:field_pretty_url:value]'
 selection_criteria:
   90f2308f-2f3c-41a0-8db1-e6c7c3e9dbf0:
-    id: node_type
+    id: 'entity_bundle:node'
     negate: false
     uuid: 90f2308f-2f3c-41a0-8db1-e6c7c3e9dbf0
     context_mapping:

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/config/install/pathauto.pattern.cgov_blog_post_url.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/config/install/pathauto.pattern.cgov_blog_post_url.yml
@@ -9,7 +9,7 @@ type: 'canonical_entities:node'
 pattern: '/[cgov_tokens:blog-post-path]/[node:field_pretty_url:value]'
 selection_criteria:
   2dd39476-d6f0-929a-9a8a-d64d1e09f0ce:
-    id: node_type
+    id: 'entity_bundle:node'
     negate: false
     uuid: 2dd39476-d6f0-929a-9a8a-d64d1e09f0ce
     context_mapping:

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_center/config/install/pathauto.pattern.cancer_center_url.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_center/config/install/pathauto.pattern.cancer_center_url.yml
@@ -9,13 +9,13 @@ type: 'canonical_entities:node'
 pattern: '/[cgov_tokens:cgov-computed-path]/[node:field_pretty_url:value]'
 selection_criteria:
   eec0cd92-8867-4c8e-b31a-7c9417592c26:
-    id: node_type
-    bundles:
-      cgov_cancer_center: cgov_cancer_center
+    id: 'entity_bundle:node'
     negate: false
+    uuid: eec0cd92-8867-4c8e-b31a-7c9417592c26
     context_mapping:
       node: node
-    uuid: eec0cd92-8867-4c8e-b31a-7c9417592c26
+    bundles:
+      cgov_cancer_center: cgov_cancer_center
 selection_logic: and
 weight: -5
 relationships: {  }

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_research/config/install/pathauto.pattern.cancer_research_url.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_research/config/install/pathauto.pattern.cancer_research_url.yml
@@ -9,13 +9,13 @@ type: 'canonical_entities:node'
 pattern: '/[cgov_tokens:cgov-computed-path]/[node:field_pretty_url:value]'
 selection_criteria:
   235fed31-5185-4684-83cf-d44fa141ec5d:
-    id: node_type
-    bundles:
-      cgov_cancer_research: cgov_cancer_research
+    id: 'entity_bundle:node'
     negate: false
+    uuid: 235fed31-5185-4684-83cf-d44fa141ec5d
     context_mapping:
       node: node
-    uuid: 235fed31-5185-4684-83cf-d44fa141ec5d
+    bundles:
+      cgov_cancer_research: cgov_cancer_research
 selection_logic: and
 weight: -5
 relationships: {  }

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.info.yml
@@ -35,6 +35,7 @@ dependencies:
   - 'linkit:linkit'
   - 'metatag:metatag'
   - 'metatag:metatag_dc'
+  - 'moderation_sidebar:moderation_sidebar'
   - 'paragraphs:paragraphs'
   - 'paragraphs_asymmetric_translation_widgets:paragraphs_asymmetric_translation_widgets'
   - 'pathauto:pathauto'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.install
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.install
@@ -79,7 +79,6 @@ function _cgov_core_install_permissions(CgovCoreTools $siteHelper) {
     'content_author' => [
       'access content overview',
       'create content translations',
-      'edit content translations',
       'use editorial_workflow transition back_to_draft',
       'use editorial_workflow transition back_to_editing',
       'use editorial_workflow transition request_archive',

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.install
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.install
@@ -423,3 +423,25 @@ function cgov_core_update_9005() {
 function cgov_core_update_9006() {
   \Drupal::service('theme_installer')->install(['claro']);
 }
+
+/**
+ * Fixed up block visibility for configs referencing node_type. (Issue #4163)
+ *
+ * 2 years ago this update hook went in place to migrate this to the new
+ * way. We did not know and did not update our install hooks in biography
+ * and press release. So we need to update any blocks using the old way.
+ */
+function cgov_core_update_9007() {
+  $config_factory = \Drupal::configFactory();
+  foreach ($config_factory->listAll('block.block.') as $block_config_name) {
+    $block = $config_factory->getEditable($block_config_name);
+
+    if ($block->get('visibility.node_type')) {
+      $configuration = $block->get('visibility.node_type');
+      $configuration['id'] = 'entity_bundle:node';
+      $block->set('visibility.entity_bundle:node', $configuration);
+      $block->clear('visibility.node_type');
+      $block->save(TRUE);
+    }
+  }
+}

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/pathauto.pattern.cthp_url.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/pathauto.pattern.cthp_url.yml
@@ -9,13 +9,13 @@ type: 'canonical_entities:node'
 pattern: '/[cgov_tokens:cgov-computed-path]/[node:field_pretty_url:value]'
 selection_criteria:
   606e7ad8-0c32-4b96-a141-ac0850ea3302:
-    id: node_type
-    bundles:
-      cgov_cthp: cgov_cthp
+    id: 'entity_bundle:node'
     negate: false
+    uuid: 606e7ad8-0c32-4b96-a141-ac0850ea3302
     context_mapping:
       node: node
-    uuid: 606e7ad8-0c32-4b96-a141-ac0850ea3302
+    bundles:
+      cgov_cthp: cgov_cthp
 selection_logic: and
 weight: -5
 relationships: {  }

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_event/config/install/pathauto.pattern.event_url.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_event/config/install/pathauto.pattern.event_url.yml
@@ -9,7 +9,7 @@ type: 'canonical_entities:node'
 pattern: '/[cgov_tokens:cgov-computed-path]/[node:field_pretty_url:value]'
 selection_criteria:
   ef804804-ab78-4ada-918b-5df04f096255:
-    id: node_type
+    id: 'entity_bundle:node'
     negate: false
     uuid: ef804804-ab78-4ada-918b-5df04f096255
     context_mapping:

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/config/install/pathauto.pattern.home_and_landing_url.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/config/install/pathauto.pattern.home_and_landing_url.yml
@@ -9,7 +9,7 @@ type: 'canonical_entities:node'
 pattern: '/[cgov_tokens:cgov-computed-path]/[node:field_pretty_url:value]'
 selection_criteria:
   d38ab68a-916f-4169-80d9-1c3acbbbb46d:
-    id: node_type
+    id: 'entity_bundle:node'
     negate: false
     uuid: d38ab68a-916f-4169-80d9-1c3acbbbb46d
     context_mapping:

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/config/install/pathauto.pattern.mini_landing_page_url.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/config/install/pathauto.pattern.mini_landing_page_url.yml
@@ -9,7 +9,7 @@ type: 'canonical_entities:node'
 pattern: '/[cgov_tokens:cgov-computed-path]/[node:field_pretty_url:value]'
 selection_criteria:
   d591e21e-caae-4bdc-9fca-3a210bbbed6d:
-    id: node_type
+    id: 'entity_bundle:node'
     negate: false
     uuid: d591e21e-caae-4bdc-9fca-3a210bbbed6d
     context_mapping:

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/cgov_press_release.install
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/cgov_press_release.install
@@ -66,14 +66,16 @@ EOMarkup;
     'weight' => 0,
     'theme' => $block_theme,
     'visibility' => [
-      'node_type' =>
+      'entity_bundle:node' =>
         [
-          'id' => 'node_type',
-          'bundles' => ['cgov_press_release' => 'cgov_press_release'],
-          'context_mapping' =>
-            [
-              'node' => '@node.node_route_context:node',
-            ],
+          'id' => 'entity_bundle:node',
+          'negate' => FALSE,
+          'context_mapping' => [
+            'node' => '@node.node_route_context:node',
+          ],
+          'bundles' => [
+            'cgov_press_release' => 'cgov_press_release',
+          ],
         ],
       'language' =>
         [

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/pathauto.pattern.press_release_url_pattern.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/pathauto.pattern.press_release_url_pattern.yml
@@ -9,7 +9,7 @@ type: 'canonical_entities:node'
 pattern: '/[cgov_tokens:cgov-computed-path]/[node:field_pretty_url:value]'
 selection_criteria:
   0ae5c1dc-d956-41a7-ac6b-502a6c3e933e:
-    id: node_type
+    id: 'entity_bundle:node'
     negate: false
     uuid: 0ae5c1dc-d956-41a7-ac6b-502a6c3e933e
     context_mapping:

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/src/Service/CgovYamlContentEventSubscriber.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/src/Service/CgovYamlContentEventSubscriber.php
@@ -2,6 +2,8 @@
 
 namespace Drupal\cgov_yaml_content\Service;
 
+use Drupal\block\Entity\Block;
+use Drupal\block_content\Entity\BlockContent;
 use Drupal\Component\EventDispatcher\ContainerAwareEventDispatcher;
 use Drupal\Component\Render\PlainTextOutput;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
@@ -11,8 +13,6 @@ use Drupal\Core\File\FileSystemInterface;
 use Drupal\Core\Theme\ThemeManagerInterface;
 use Drupal\Core\TypedData\Exception\MissingDataException;
 use Drupal\Core\Utility\Token;
-use Drupal\block\Entity\Block;
-use Drupal\block_content\Entity\BlockContent;
 use Drupal\file\FileRepositoryInterface;
 use Drupal\file\Plugin\Field\FieldType\FileFieldItemList;
 use Drupal\image\Plugin\Field\FieldType\ImageItem;
@@ -20,9 +20,9 @@ use Drupal\media\Entity\Media;
 use Drupal\node\Entity\Node;
 use Drupal\paragraphs\Entity\Paragraph;
 use Drupal\taxonomy\Entity\Term;
-use Drupal\yaml_content\Event\YamlContentEvents;
 use Drupal\yaml_content\Event\EntityPostSaveEvent;
 use Drupal\yaml_content\Event\EntityPreSaveEvent;
+use Drupal\yaml_content\Event\YamlContentEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
@@ -543,7 +543,7 @@ class CgovYamlContentEventSubscriber implements EventSubscriberInterface {
     // Raise the preSave event so that other subscribers can modify
     // the entity before saving.
     $entity_pre_save_event = new EntityPreSaveEvent($event->getContentLoader(), $spanishTranslation, $yamlContent);
-    $this->eventDispatcher->dispatch(YamlContentEvents::ENTITY_PRE_SAVE, $entity_pre_save_event);
+    $this->eventDispatcher->dispatch($entity_pre_save_event, YamlContentEvents::ENTITY_PRE_SAVE);
 
     // We need to discreetly save the translation to trigger pathauto
     // url alias building.

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/pathauto.pattern.pdq_cis_url.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/pathauto.pattern.pdq_cis_url.yml
@@ -9,7 +9,7 @@ type: 'canonical_entities:node'
 pattern: '[node:field_pdq_url:value]'
 selection_criteria:
   6d81fb7c-9081-47ab-97e2-f333cc5a6fcc:
-    id: node_type
+    id: 'entity_bundle:node'
     negate: false
     uuid: 6d81fb7c-9081-47ab-97e2-f333cc5a6fcc
     context_mapping:

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_core/pdq_core.install
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_core/pdq_core.install
@@ -21,9 +21,6 @@ function pdq_core_install() {
   // Add Roles.
   $siteHelper->addRole('pdq_importer', 'PDQ Importer', -3);
 
-  // Add content type permissions and assign to workflow.
-  $siteHelper->addContentTypePermissions('pdq_cancer_information_summary', ['pdq_importer'], CgovCoreTools::DEFAULT_PERMISSIONS);
-
   // Create importer user.
   $user = User::create();
   $user->setUsername('PDQ');
@@ -46,9 +43,6 @@ function pdq_core_install() {
  */
 function pdq_core_install_permissions(CgovCoreTools $siteHelper) {
   $perms = [
-    'admin_ui' => [
-      'access pdq_cis_browser entity browser pages',
-    ],
     'pdq_importer' => [
       'restful delete pdq_api',
       'restful get pdq_api',

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_drug_information_summary/config/install/pathauto.pattern.pdq_dis_url.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_drug_information_summary/config/install/pathauto.pattern.pdq_dis_url.yml
@@ -9,13 +9,13 @@ type: 'canonical_entities:node'
 pattern: '[node:field_pdq_url:value]'
 selection_criteria:
   c37bffdc-c407-4a47-aaca-2a8c44762dc3:
-    id: node_type
-    bundles:
-      pdq_drug_information_summary: pdq_drug_information_summary
+    id: 'entity_bundle:node'
     negate: false
+    uuid: c37bffdc-c407-4a47-aaca-2a8c44762dc3
     context_mapping:
       node: node
-    uuid: c37bffdc-c407-4a47-aaca-2a8c44762dc3
+    bundles:
+      pdq_drug_information_summary: pdq_drug_information_summary
 selection_logic: and
 weight: -5
 relationships: {  }

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/block/breadcrumb/block--cgov-breadcrumb.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/block/breadcrumb/block--cgov-breadcrumb.html.twig
@@ -1,6 +1,6 @@
 {% if content.breadcrumbs|length > 0 %}
   <ul class="breadcrumbs">
-    {% for breadcrumb in content.breadcrumbs if breadcrumb.href %}
+    {% for breadcrumb in content.breadcrumbs|filter(breadcrumb => breadcrumb.href) %}
       <li>
         <a href="{{ breadcrumb.href|e }}">{{ breadcrumb.label|e }}</a>
       </li>

--- a/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/templates/block/ncids/block--cgov-breadcrumb.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/templates/block/ncids/block--cgov-breadcrumb.html.twig
@@ -1,7 +1,7 @@
 {% if content.breadcrumbs|length > 0 %}
   <nav class="usa-breadcrumb usa-breadcrumb--wrap" aria-label="{{'Breadcrumbs'|t}}">
     <ol class="usa-breadcrumb__list">
-      {% for breadcrumb in content.breadcrumbs if breadcrumb.href %}
+      {% for breadcrumb in content.breadcrumbs|filter(breadcrumb => breadcrumb.href) %}
         <li class="usa-breadcrumb__list-item">
           <a href="{{ breadcrumb.href|e }}" class="usa-breadcrumb__link">
             <span>{{ breadcrumb.label|e }}</span>


### PR DESCRIPTION
ODE: https://ncigovcdode657.prod.acquia-sites.com/
This closes multiple D10 blockers.

## Testing Instructions

### 4163
* This updates the configurations that generate URLs
   * So create a new page of each content type from the content menu. (Media are not affected)
* Also how the Contact Info blocks are created for Biographies and Press Releases.
   * On a new ODE the contact blocks should show correctly.
* There is also an update hook to modify any content blocks that were created in the old way.
   * This really can only be tested in ACSF, and it would only affect any site created after the 9.3 upgrade, so maybe nationalcancerplan.cancer.gov?

Closes #4163

### 4165
This touched the breadcrumbs, and specifically any "crumbs" that do not have an href should not display a broken link. I *think* the best way is to visit `/api-test/b/1/1` and verify that there is not a broken link for `B.1` between `B` and the page title in bread crumbs. Same thing with the URL `/user/login` you should only see home and the page title.

Closes #4165

### 4166
Uh, the moderation side bar should appear on the front end when logged in as an editor? (This was just adding a dependency that was elsewhere before.)
Closes #4166

### 4167
PDQ Content should still load ok
Closes #4167

### 4164
This is not really testable, so lets go with: can you still edit a translation of a piece of content?
Closes #4164

### 4168
This was a change to the yaml content loader. If the content is there, then it did not break. Regressions should take care of this.

Closes #4168