### PR TITLE
(#2343) Automated OTP Section Headings

### DIFF
--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/cgov_article.services.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/cgov_article.services.yml
@@ -1,0 +1,6 @@
+services:
+  cgov_article.twig_extensions:
+    class: Drupal\cgov_article\CgovArticleTwigExtensions
+    arguments: ['@language_manager']
+    tags:
+      - { name: twig.extension }

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/src/CgovArticleTwigExtensions.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/src/CgovArticleTwigExtensions.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Drupal\cgov_article;
+
+use Drupal\Component\Transliteration\PhpTransliteration;
+use Drupal\Core\Language\LanguageManagerInterface;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+
+/**
+ * Extend Drupal's AbstractExtension class.
+ */
+class CgovArticleTwigExtensions extends AbstractExtension {
+
+
+  /**
+   * The language manager.
+   *
+   * @var \Drupal\Core\Language\LanguageManagerInterface
+   */
+  protected $languageManager;
+
+  /**
+   * Constructs \Drupal\cgov_article\CgovArticleTwigExtensions.
+   *
+   * @param \Drupal\Core\Language\LanguageManagerInterface $language_manager
+   *   The language manager.
+   */
+  public function __construct(LanguageManagerInterface $language_manager) {
+    $this->languageManager = $language_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getName() {
+    return 'cgov_article.CgovArticleTwigExtensions';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFilters() {
+    return [
+      new TwigFilter('nci_transliterate', [$this, 'transliterate']),
+    ];
+  }
+
+  /**
+   * Replaces non-English characters with their closest equivalent.
+   *
+   * Any character entities are removed.
+   *
+   * @param string $text
+   *   Accented String.
+   *
+   * @return string
+   *   Formatted String.
+   */
+  public function transliterate($text) {
+    $langcode = $this->languageManager->getCurrentLanguage()->getId();
+    $trans = new PHPTransliteration();
+    $text = preg_replace("/&#?[a-z0-9]+;/i", "", $text);
+    $text = $trans->transliterate($text, $langcode);
+    return $text;
+  }
+
+}

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/015_article_cancer_genomics_research.content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/015_article_cancer_genomics_research.content.yml
@@ -104,7 +104,7 @@
       type: "body_section"
       field_body_section_heading:
         - format: "simple"
-          value: "Why Genomics Research Is Critical to Progress against Cancer"
+          value: "Why Genomics Research Is &quot;Critical&quot; to Progress  &amp; against &lt;Cancer&gt;"
       field_body_section_content:
         - format: "full_html"
           value: |
@@ -117,7 +117,7 @@
       type: "body_section"
       field_body_section_heading:
         - format: "simple"
-          value: "Opportunities in Cancer Genomics Research"
+          value: "Opportunities in Cancer Genomics&copy;  Research Σ -φ-ψ-Ω- τ"
       field_body_section_content:
         - format: "full_html"
           value: |
@@ -129,7 +129,7 @@
       type: "body_section"
       field_body_section_heading:
         - format: "simple"
-          value: "Challenges in Cancer Genomics Research"
+          value: "Challenges&deg; in Cancer Genomics Research&euro;"
       field_body_section_content:
         - format: "full_html"
           value: |
@@ -199,7 +199,7 @@
       type: "body_section"
       field_body_section_heading:
         - format: "simple"
-          value: "Data Sharing"
+          value: "ÁÉÍÓÚÑÜ Data Sharing áéíóúñü"
       field_body_section_content:
         - format: "full_html"
           value: |
@@ -227,7 +227,7 @@
       type: "body_section"
       field_body_section_heading:
         - format: "simple"
-          value: "Por qué es crítica la investigación de genómica para el progreso contra el cáncer"
+          value: "Por qué es crítica la investigación & de &#x21A5;&#xbc;&#x34; genómica para el &lt;progreso&gt; contra el cáncer ÁÉÍÓÚÑÜ"
       field_body_section_content:
         - format: "full_html"
           value: |
@@ -240,7 +240,7 @@
       type: "body_section"
       field_body_section_heading:
         - format: "simple"
-          value: "Oportunidades en la investigación de la genómica del cáncer"
+          value: "ÁÉÍÓÚÑÜ Oportunidades &#x211C; en la &quot;investigación&quot; de la genómica del cáncer"
       field_body_section_content:
         - format: "full_html"
           value: |
@@ -253,7 +253,7 @@
       type: "body_section"
       field_body_section_heading:
         - format: "simple"
-          value: "Desafíos en la investigación de genómica del cáncer"
+          value: "áéíóúñü Desafíos en la &nbsp;investigación de &#x20B3; genómica del cáncer"
       field_body_section_content:
         - format: "full_html"
           value: |
@@ -265,7 +265,7 @@
       type: "body_section"
       field_body_section_heading:
         - format: "simple"
-          value: "Papel del NCI en la investigación de la genómica del cáncer"
+          value: "Papel del NCI en la investigación de la &ndash;genómica&mdash; del cáncer áéíóúñü"
       field_body_section_content:
         - format: "full_html"
           value: |
@@ -274,7 +274,7 @@
       type: "body_section"
       field_body_section_heading:
         - format: "simple"
-          value: "Caracterización de los genomas de cáncer"
+          value: "Caracterización de los genomas&copy; de cáncer Σ -φ-ψ-Ω- τ"
       field_body_section_content:
         - format: "full_html"
           value: |
@@ -288,7 +288,7 @@
       type: "body_section"
       field_body_section_heading:
         - format: "simple"
-          value: "Análisis de normas de la atención y de tratamientos novedosos a nivel molecular"
+          value: "Análisis de &reg;normas de la atención y de tratamientos novedosos a nivel molecular"
       field_body_section_content:
         - format: "full_html"
           value: |
@@ -302,7 +302,7 @@
       type: "body_section"
       field_body_section_heading:
         - format: "simple"
-          value: "Modelado de la actividad de los genes de c&aacute;ncer"
+          value: "Modelado de la&asymp; actividad de &#x00397;&#xeB;&#x139;&#x13A;&#x1d560; los genes&trade; de c&aacute;ncer"
       field_body_section_content:
         - format: "full_html"
           value: |
@@ -315,7 +315,7 @@
       type: "body_section"
       field_body_section_heading:
         - format: "simple"
-          value: "Relación de factores de riesgo heredados con la genómica del cáncer"
+          value: "Relación de factores&deg; de riesgo&ne; heredados &euro;con&pound; la genómica del cáncer"
       field_body_section_content:
         - format: "full_html"
           value: |
@@ -328,7 +328,7 @@
       type: "body_section"
       field_body_section_heading:
         - format: "simple"
-          value: "Participación de datos"
+          value: "Participación de datos αβγδεζ -η- -θ- -ι-κ-λ-μ-ν-ξ-ο-π-ρ"
       field_body_section_content:
         - format: "full_html"
           value: |

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/article/field--field-article-body.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/article/field--field-article-body.html.twig
@@ -19,7 +19,7 @@
       {% for item in items %}
         {% if item.content['#paragraph'].field_body_section_heading.value %}
         <li>
-          <a href="#{{ item.content['#paragraph'].field_body_section_heading.value | striptags | clean_id }}">
+          <a href="#{{ item.content['#paragraph'].field_body_section_heading.value | striptags | nci_transliterate | clean_id }}">
             {# We have to apply the raw filter in order to render what is a simple format field as actual markup #}
             {{- item.content['#paragraph'].field_body_section_heading.value|raw -}}</a>
         </li>

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/article/paragraph--body-section.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/article/paragraph--body-section.html.twig
@@ -12,9 +12,9 @@
   {# TODO: Determine how to deal with headings that are H3s #}
   {# Set the id to a clean version of the section heading for OTP links. #}
   {% if schema_org_type %}
-    <h2 id="{{ content.field_body_section_heading['#items'][0].value | striptags | clean_id }}" itemprop="name">
+    <h2 id="{{ content.field_body_section_heading['#items'][0].value | striptags | nci_transliterate | clean_id }}" itemprop="name">
   {% else %}
-    <h2 id="{{ content.field_body_section_heading['#items'][0].value | striptags | clean_id }}">
+    <h2 id="{{ content.field_body_section_heading['#items'][0].value | striptags | nci_transliterate | clean_id }}">
   {% endif %}
     {{- content.field_body_section_heading -}}
   </h2>

--- a/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/templates/content/article/field--field-article-body.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/templates/content/article/field--field-article-body.html.twig
@@ -19,7 +19,7 @@
       {% for item in items %}
         {% if item.content['#paragraph'].field_body_section_heading.value %}
         <li>
-          <a href="#{{ item.content['#paragraph'].field_body_section_heading.value | striptags | clean_id }}">
+          <a href="#{{ item.content['#paragraph'].field_body_section_heading.value | striptags | nci_transliterate | clean_id }}">
             {# We have to apply the raw filter in order to render what is a simple format field as actual markup #}
             {{- item.content['#paragraph'].field_body_section_heading.value|raw -}}</a>
         </li>

--- a/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/templates/content/article/paragraph--body-section.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/templates/content/article/paragraph--body-section.html.twig
@@ -12,9 +12,9 @@
   {# TODO: Determine how to deal with headings that are H3s #}
   {# Set the id to a clean version of the section heading for OTP links. #}
   {% if schema_org_type %}
-    <h2 id="{{ content.field_body_section_heading['#items'][0].value | striptags | clean_id }}" itemprop="name">
+    <h2 id="{{ content.field_body_section_heading['#items'][0].value | striptags | nci_transliterate | clean_id }}" itemprop="name">
   {% else %}
-    <h2 id="{{ content.field_body_section_heading['#items'][0].value | striptags | clean_id }}">
+    <h2 id="{{ content.field_body_section_heading['#items'][0].value | striptags | nci_transliterate | clean_id }}">
   {% endif %}
     {{- content.field_body_section_heading -}}
   </h2>


### PR DESCRIPTION
- created new twig filter for formatting letters with accents and html entities.
- new twig filter applied on ncids_trans & cgov_common templates files which are related to body section in article content type.
- updated content yml for automated testing.

ODE- https://ncigovcdode674.prod.acquia-sites.com/

Closes #2343