### PR TITLE
(#4211) Enabler: Block Admin in cgov:user:load-all

### DIFF
--- a/blt/src/Blt/Plugin/Commands/CgovAcsfCommands.php
+++ b/blt/src/Blt/Plugin/Commands/CgovAcsfCommands.php
@@ -24,7 +24,6 @@ class CgovAcsfCommands extends BltTasks {
   public function postInstall() {
     $commands = [
       'cgov:locales:translate' => [],
-      'cgov:acsf:block-admin' => [],
       'cgov:user:load-all' => [],
     ];
 

--- a/cgov-drupal-users.yml
+++ b/cgov-drupal-users.yml
@@ -4,6 +4,7 @@
 admin:
   username: 'admin'
   password: 'password123'
+  enabled: true
 additional_users:
   - username: 'author'
     password: 'password123'


### PR DESCRIPTION
- block the admin user using key in loadUsers function.
- updated the post-install hook as we are handling block-admin in loadUsers function.

Closes #4211