### PR TITLE
(#3997) Extraneous bullet appears next to High Chart graphs

### DIFF
--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/libraries/charts/chart.scss
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/libraries/charts/chart.scss
@@ -1,0 +1,9 @@
+// Bugfix #3997 (Remove stray bullet added by legacy styling)
+
+.highcharts-container {
+  .highcharts-a11y-proxy-group-legend {
+    ul > li:before {
+      content: "";
+    }
+  }
+}

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/libraries/charts/index.js
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/libraries/charts/index.js
@@ -1,3 +1,4 @@
+import "./chart.scss";
 import axios from 'axios';
 import Chart from './Chart';
 import rules from './rules';


### PR DESCRIPTION
* Added styling to remove extraneous bullet left on from legacy styling

Closes #3997