### PR TITLE
(#4223) Initial Cancer Types Landing Page YAML

### DIFF
--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.module
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.module
@@ -8,6 +8,7 @@
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
+use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Render\Element;
 use Drupal\Core\Session\AccountInterface;
@@ -680,4 +681,57 @@ function cgov_core_entity_build_defaults_alter(array &$build, EntityInterface $e
  */
 function cgov_core_field_widget_single_element_link_default_form_alter(&$element, FormStateInterface $form_state, $context) {
   $element['uri']['#description'] = t('Enter the full URL starting with https://');
+}
+
+/**
+ * Implements hook_page_attachments().
+ */
+function cgov_core_page_attachments(array &$attachments) {
+  $route_match = \Drupal::routeMatch();
+  $node = $route_match->getParameter('node');
+  if ($node && $node->field_additional_library != NULL && $route_match->getRouteName() === 'entity.node.canonical') {
+    $lib = $node->field_additional_library->value;
+    $front_end_theme = \Drupal::service('theme_handler')->getDefault();
+    $theme_libs = \Drupal::service('library.discovery')->getLibrariesByExtension($front_end_theme);
+    if ($lib !== 'None' && array_key_exists($lib, $theme_libs)) {
+      $attachments['#attached']['library'][] = $front_end_theme . '/' . $lib;
+    }
+  }
+}
+
+/**
+ * Set dynamic allowed libraries for the additional library field.
+ *
+ * @param \Drupal\Core\Entity\EntityInterface $entity
+ *   The entity being created.
+ *
+ * @return array
+ *   An array of additional libraries within ncids_trans theme.
+ */
+function cgov_addl_lib_allowed_values_function(EntityInterface $entity) {
+  $front_end_theme = \Drupal::service('theme_handler')->getDefault();
+  $libs = \Drupal::service('library.discovery')->getLibrariesByExtension($front_end_theme);
+  // Filters out all libraries that don't start with "addl-"
+  // and adds in the default value "None".
+  $options = array_reduce(
+    array_filter(array_keys($libs), fn($key) => str_starts_with($key, 'addl-')),
+    fn($carry, $key) => [...$carry, $key => $key],
+    ['none' => 'None']
+  );
+  return $options;
+}
+
+/**
+ * @param \Drupal\Core\Entity\EntityInterface $entity
+ *   The entity being created.
+ * @param \Drupal\Core\Field\FieldDefinitionInterface $definition
+ *   The field definition.
+ *
+ * @return array
+ *   An array of default value keys with each entry keyed with the "value" key.
+ */
+function cgov_addl_lib_default_value_function(EntityInterface $entity, FieldDefinitionInterface $definition) {
+  return [
+    ['value' => 'None'],
+  ];
 }

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/config/install/field.storage.node.field_additional_library.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/config/install/field.storage.node.field_additional_library.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - options
+id: node.field_additional_library
+field_name: field_additional_library
+entity_type: node
+type: list_string
+settings:
+  allowed_values: { }
+  allowed_values_function: cgov_addl_lib_allowed_values_function
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/cgov_home_landing.module
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/cgov_home_landing.module
@@ -7,6 +7,8 @@
 
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Field\FieldDefinition;
+use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Session\AccountInterface;
 
  /**
@@ -59,4 +61,31 @@ function cgov_home_landing_paragraph_access(EntityInterface $entity, $operation,
 
   // We have no skin in the game.
   return AccessResult::neutral();
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter()
+ *
+ * Creates a group to be added in the advanced section.
+ * We are then able to add the additional library field to the group.
+ */
+function cgov_home_landing_form_node_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $form_state, $form_id) {
+  $form['additional_library'] = [
+    '#type' => 'details',
+    '#title' => 'Additional Front-End Library',
+    '#group' => 'advanced',
+    '#attributes' => [
+      'class' => ['node-form-options']
+    ],
+    '#attached' => [
+      'library' => ['node/drupal.node'],
+    ],
+    '#weight' => 100,
+    '#optional' => TRUE,
+    '#open' => FALSE,
+  ];
+
+  $form['field_additional_library']['#group'] = 'additional_library';
+
+  return $form;
 }

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/config/install/core.entity_form_display.node.cgov_home_landing.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/config/install/core.entity_form_display.node.cgov_home_landing.default.yml
@@ -3,6 +3,7 @@ status: true
 dependencies:
   config:
     - entity_browser.browser.cgov_site_section_browser
+    - field.field.node.cgov_home_landing.field_additional_library
     - field.field.node.cgov_home_landing.field_browser_title
     - field.field.node.cgov_home_landing.field_card_title
     - field.field.node.cgov_home_landing.field_date_display_mode
@@ -37,6 +38,12 @@ content:
   created:
     type: datetime_timestamp
     weight: 21
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_additional_library:
+    type: options_select
+    weight: 26
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -213,9 +220,9 @@ content:
     third_party_settings: {  }
   simple_sitemap:
     weight: 10
+    region: content
     settings: {  }
     third_party_settings: {  }
-    region: content
   status:
     type: boolean_checkbox
     weight: 23

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/config/install/core.entity_view_display.node.cgov_home_landing.borderless_card_image.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/config/install/core.entity_view_display.node.cgov_home_landing.borderless_card_image.yml
@@ -3,6 +3,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.borderless_card_image
+    - field.field.node.cgov_home_landing.field_additional_library
     - field.field.node.cgov_home_landing.field_browser_title
     - field.field.node.cgov_home_landing.field_card_title
     - field.field.node.cgov_home_landing.field_date_display_mode
@@ -40,6 +41,7 @@ content:
     region: content
 hidden:
   content_moderation_control: true
+  field_additional_library: true
   field_browser_title: true
   field_card_title: true
   field_date_display_mode: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/config/install/core.entity_view_display.node.cgov_home_landing.default.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/config/install/core.entity_view_display.node.cgov_home_landing.default.yml
@@ -2,6 +2,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.node.cgov_home_landing.field_additional_library
     - field.field.node.cgov_home_landing.field_browser_title
     - field.field.node.cgov_home_landing.field_card_title
     - field.field.node.cgov_home_landing.field_date_display_mode
@@ -35,6 +36,13 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: -20
+    region: content
+  field_additional_library:
+    type: list_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 117
     region: content
   field_browser_title:
     type: string

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/config/install/core.entity_view_display.node.cgov_home_landing.embedded_feature_card.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/config/install/core.entity_view_display.node.cgov_home_landing.embedded_feature_card.yml
@@ -3,6 +3,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.embedded_feature_card
+    - field.field.node.cgov_home_landing.field_additional_library
     - field.field.node.cgov_home_landing.field_browser_title
     - field.field.node.cgov_home_landing.field_card_title
     - field.field.node.cgov_home_landing.field_date_display_mode
@@ -64,6 +65,7 @@ content:
     region: content
 hidden:
   content_moderation_control: true
+  field_additional_library: true
   field_date_display_mode: true
   field_date_posted: true
   field_date_reviewed: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/config/install/core.entity_view_display.node.cgov_home_landing.embedded_feature_card_no_image.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/config/install/core.entity_view_display.node.cgov_home_landing.embedded_feature_card_no_image.yml
@@ -3,6 +3,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.embedded_feature_card_no_image
+    - field.field.node.cgov_home_landing.field_additional_library
     - field.field.node.cgov_home_landing.field_browser_title
     - field.field.node.cgov_home_landing.field_card_title
     - field.field.node.cgov_home_landing.field_date_display_mode
@@ -55,6 +56,7 @@ content:
     region: content
 hidden:
   content_moderation_control: true
+  field_additional_library: true
   field_date_display_mode: true
   field_date_posted: true
   field_date_reviewed: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/config/install/core.entity_view_display.node.cgov_home_landing.feature_card_image.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/config/install/core.entity_view_display.node.cgov_home_landing.feature_card_image.yml
@@ -3,6 +3,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.feature_card_image
+    - field.field.node.cgov_home_landing.field_additional_library
     - field.field.node.cgov_home_landing.field_browser_title
     - field.field.node.cgov_home_landing.field_card_title
     - field.field.node.cgov_home_landing.field_date_display_mode
@@ -40,6 +41,7 @@ content:
     region: content
 hidden:
   content_moderation_control: true
+  field_additional_library: true
   field_browser_title: true
   field_card_title: true
   field_date_display_mode: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/config/install/core.entity_view_display.node.cgov_home_landing.full.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/config/install/core.entity_view_display.node.cgov_home_landing.full.yml
@@ -3,6 +3,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.full
+    - field.field.node.cgov_home_landing.field_additional_library
     - field.field.node.cgov_home_landing.field_browser_title
     - field.field.node.cgov_home_landing.field_card_title
     - field.field.node.cgov_home_landing.field_date_display_mode
@@ -58,6 +59,7 @@ content:
     region: content
 hidden:
   content_moderation_control: true
+  field_additional_library: true
   field_browser_title: true
   field_card_title: true
   field_date_display_mode: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/config/install/core.entity_view_display.node.cgov_home_landing.link.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/config/install/core.entity_view_display.node.cgov_home_landing.link.yml
@@ -3,6 +3,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.link
+    - field.field.node.cgov_home_landing.field_additional_library
     - field.field.node.cgov_home_landing.field_browser_title
     - field.field.node.cgov_home_landing.field_card_title
     - field.field.node.cgov_home_landing.field_date_display_mode
@@ -54,6 +55,7 @@ content:
     region: content
 hidden:
   content_moderation_control: true
+  field_additional_library: true
   field_card_title: true
   field_date_display_mode: true
   field_date_posted: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/config/install/core.entity_view_display.node.cgov_home_landing.ncids_feature_card_image.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/config/install/core.entity_view_display.node.cgov_home_landing.ncids_feature_card_image.yml
@@ -3,6 +3,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.ncids_feature_card_image
+    - field.field.node.cgov_home_landing.field_additional_library
     - field.field.node.cgov_home_landing.field_browser_title
     - field.field.node.cgov_home_landing.field_card_title
     - field.field.node.cgov_home_landing.field_date_display_mode
@@ -40,6 +41,7 @@ content:
     region: content
 hidden:
   content_moderation_control: true
+  field_additional_library: true
   field_browser_title: true
   field_card_title: true
   field_date_display_mode: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/config/install/core.entity_view_display.node.cgov_home_landing.ncids_promo_block_image.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/config/install/core.entity_view_display.node.cgov_home_landing.ncids_promo_block_image.yml
@@ -3,6 +3,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.ncids_promo_block_image
+    - field.field.node.cgov_home_landing.field_additional_library
     - field.field.node.cgov_home_landing.field_browser_title
     - field.field.node.cgov_home_landing.field_card_title
     - field.field.node.cgov_home_landing.field_date_display_mode
@@ -40,6 +41,7 @@ content:
     region: content
 hidden:
   content_moderation_control: true
+  field_additional_library: true
   field_browser_title: true
   field_card_title: true
   field_date_display_mode: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/config/install/core.entity_view_display.node.cgov_home_landing.panoramic_image.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/config/install/core.entity_view_display.node.cgov_home_landing.panoramic_image.yml
@@ -3,6 +3,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.panoramic_image
+    - field.field.node.cgov_home_landing.field_additional_library
     - field.field.node.cgov_home_landing.field_browser_title
     - field.field.node.cgov_home_landing.field_card_title
     - field.field.node.cgov_home_landing.field_date_display_mode
@@ -40,6 +41,7 @@ content:
     region: content
 hidden:
   content_moderation_control: true
+  field_additional_library: true
   field_browser_title: true
   field_card_title: true
   field_date_display_mode: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/config/install/core.entity_view_display.node.cgov_home_landing.teaser.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/config/install/core.entity_view_display.node.cgov_home_landing.teaser.yml
@@ -3,6 +3,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.teaser
+    - field.field.node.cgov_home_landing.field_additional_library
     - field.field.node.cgov_home_landing.field_browser_title
     - field.field.node.cgov_home_landing.field_card_title
     - field.field.node.cgov_home_landing.field_date_display_mode
@@ -40,6 +41,7 @@ content:
     weight: 100
     region: content
 hidden:
+  field_additional_library: true
   field_browser_title: true
   field_card_title: true
   field_date_display_mode: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/config/install/core.entity_view_display.node.cgov_home_landing.thumbnail_card_image.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/config/install/core.entity_view_display.node.cgov_home_landing.thumbnail_card_image.yml
@@ -3,6 +3,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.thumbnail_card_image
+    - field.field.node.cgov_home_landing.field_additional_library
     - field.field.node.cgov_home_landing.field_browser_title
     - field.field.node.cgov_home_landing.field_card_title
     - field.field.node.cgov_home_landing.field_date_display_mode
@@ -40,6 +41,7 @@ content:
     region: content
 hidden:
   content_moderation_control: true
+  field_additional_library: true
   field_browser_title: true
   field_card_title: true
   field_date_display_mode: true

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/config/install/field.field.node.cgov_home_landing.field_additional_library.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/config/install/field.field.node.cgov_home_landing.field_additional_library.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_additional_library
+    - node.type.cgov_home_landing
+  module:
+    - options
+id: node.cgov_home_landing.field_additional_library
+field_name: field_additional_library
+entity_type: node
+bundle: cgov_home_landing
+label: 'Additional Front-End Library'
+description: 'Use to add additional JS/CSS to a page. Do not do this unless you are a Drupal Admin.'
+required: true
+translatable: true
+default_value: { }
+default_value_callback: cgov_addl_lib_default_value_function
+settings: {  }
+field_type: list_string

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/099_types.content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/099_types.content.yml
@@ -4,9 +4,9 @@
   status: 1
   moderation_state:
     value: 'published'
-  title: "Cancer Types"
+  title: "CGDPL Cancer Types"
   title__ES:
-      value: "Tipos de cáncer"
+      value: "CGDPL Tipos de cáncer"
   field_page_description:
     value: "A to Z list of cancer types, with links to disease-specific and general information about treatment, supportive care, screening, prevention, clinical trials, and other topics."
   field_page_description__ES:
@@ -19,6 +19,10 @@
     value: "A to Z List of Cancer Types"
   field_browser_title__ES:
     value: "Tipos de cáncer"
+  field_pretty_url:
+    value: "cgdpl"
+  field_pretty_url__ES:
+    value: "cgdpl"
   field_site_section:
     - '#process':
         callback: 'reference'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/999_addl_library.content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/999_addl_library.content.yml
@@ -1,0 +1,193 @@
+- entity: "node"
+  type: "cgov_home_landing"
+  langcode: en
+  status: 1
+  moderation_state:
+    value: 'published'
+  title: "Landing Page Library Test"
+  title__ES:
+      value: "Spanish Landing Page Library Test"
+  field_page_description:
+    value: "Accurate, up-to-date, comprehensive cancer information from the U.S. government's principal agency for cancer research."
+  field_page_description__ES:
+    value: "Información del Instituto Nacional del Cáncer sobre el tratamiento, la prevención, los exámenes de detección, la genética y las causas del cáncer, así como formas de hacer frente a la enfermedad."
+  field_browser_title:
+    value: "Landing Page Library Test - Browser Title"
+  field_browser_title__ES:
+    value: "Spanish Landing Page Library Test - Browser Title"
+  field_pretty_url:
+    value: "landing-page-library-test"
+  field_site_section:
+    - '#process':
+        callback: 'reference'
+        args:
+          - 'taxonomy_term'
+          - vid: 'cgov_site_sections'
+            computed_path: '/test'
+            langcode: 'en'
+  field_site_section__ES:
+    - '#process':
+        callback: 'reference'
+        args:
+          - 'taxonomy_term'
+          - vid: 'cgov_site_sections'
+            computed_path: '/test-es'
+            langcode: 'es'
+  field_page_style:
+    value: "ncids_with_title"
+  field_additional_library:
+    value: "addl-lib-test"
+  ### English Contents
+  field_landing_contents:
+    ######## Begin Feature Row ###########
+    - entity: 'paragraph'
+      type: "ncids_hero"
+      field_ncids_theme:
+        - value: 'light'
+      field_tagline:
+        - value: 'NCI is the nation''s leader in cancer research'
+      field_widescreen_hero:
+        - '#process':
+            callback: 'file'
+            args:
+              - 'image'
+              - type: 'module'
+                filename: 'widescreen.jpg'
+      field_desktop_hero:
+        - '#process':
+            callback: 'file'
+            args:
+              - 'image'
+              - type: 'module'
+                filename: 'desktop.jpg'
+      field_tablet_large_hero:
+        - '#process':
+            callback: 'file'
+            args:
+              - 'image'
+              - type: 'module'
+                filename: 'tablet_large.jpg'
+      field_tablet_hero:
+        - '#process':
+            callback: 'file'
+            args:
+              - 'image'
+              - type: 'module'
+                filename: 'tablet.jpg'
+      field_mobile_large_hero:
+        - '#process':
+            callback: 'file'
+            args:
+              - 'image'
+              - type: 'module'
+                filename: 'mobile_large.jpg'
+      field_mobile_hero:
+        - '#process':
+            callback: 'file'
+            args:
+              - 'image'
+              - type: 'module'
+                filename: 'mobile.jpg'
+    - entity: 'paragraph'
+      type: "ncids_3_feature_card_row"
+      field_container_heading:
+        - value: "Latest News and Initiatives"
+      field_row_cards:
+        - entity: 'paragraph'
+          type: "ncids_feature_card_external"
+          field_featured_url:
+            - uri: 'https://www.google.com'
+          field_override_card_title:
+            - value: 'Inside Cancer Careers Podcast'
+          field_override_card_description:
+            - value: 'Listen to the Center for Cancer Training''s New Podcast.'
+          field_override_image_promotional:
+            - target_type: 'media'
+              '#process':
+                callback: 'reference'
+                args:
+                  - 'media'
+                  - bundle: 'cgov_image'
+                    name: 'Override Placeholder'
+        - entity: 'paragraph'
+          type: "ncids_feature_card_external"
+          field_featured_url:
+            - uri: 'https://www.google.com'
+          field_override_card_title:
+            - value: 'National Cancer Plan'
+          field_override_card_description:
+            - value: 'Qorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc vulputate libero et velit'
+          field_override_image_promotional:
+            - target_type: 'media'
+              '#process':
+                callback: 'reference'
+                args:
+                  - 'media'
+                  - bundle: 'cgov_image'
+                    name: 'Feature Card Cat'
+        - entity: 'paragraph'
+          type: "ncids_feature_card_internal"
+          field_override_card_title:
+            - value: 'NCI Funds more research grants thanks to congress'
+          field_override_card_description:
+            - value: 'Dr. Bertagnolli discusses how NCI will increase support for cancer research in FY 2023.'
+          field_featured_item:
+            - target_type: 'node'
+              '#process':
+                callback: 'reference'
+                args:
+                  - 'node'
+                  - type: 'cgov_article'
+                    title: 'Internal Feature Card Test - 4x3 Override'
+  ## SPANISH CONTENTS HERE
+  field_landing_contents__ES:
+    ######## Placeholder ############
+    - entity: 'paragraph'
+      type: "ncids_hero"
+      field_ncids_theme:
+        - value: 'light'
+      field_tagline:
+        - value: 'El NCI es el líder nacional de investigación del cáncer'
+      field_widescreen_hero:
+        - '#process':
+            callback: 'file'
+            args:
+              - 'image'
+              - type: 'module'
+                filename: 'widescreen.jpg'
+      field_desktop_hero:
+        - '#process':
+            callback: 'file'
+            args:
+              - 'image'
+              - type: 'module'
+                filename: 'desktop.jpg'
+      field_tablet_large_hero:
+        - '#process':
+            callback: 'file'
+            args:
+              - 'image'
+              - type: 'module'
+                filename: 'tablet_large.jpg'
+      field_tablet_hero:
+        - '#process':
+            callback: 'file'
+            args:
+              - 'image'
+              - type: 'module'
+                filename: 'tablet.jpg'
+      field_mobile_large_hero:
+        - '#process':
+            callback: 'file'
+            args:
+              - 'image'
+              - type: 'module'
+                filename: 'mobile_large.jpg'
+      field_mobile_hero:
+        - '#process':
+            callback: 'file'
+            args:
+              - 'image'
+              - type: 'module'
+                filename: 'mobile.jpg'
+    ######## End Placeholder ############

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/999_cancer_types_landing_page.content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/999_cancer_types_landing_page.content.yml
@@ -1,0 +1,35 @@
+- entity: "node"
+  type: "cgov_home_landing"
+  langcode: en
+  status: 1
+  moderation_state:
+    value: 'published'
+  title: "Cancer Types"
+  title__ES:
+      value: "Tipos de cáncer"
+  field_page_description:
+    value: "A to Z list of cancer types, with links to disease-specific and general information about treatment, supportive care, screening, prevention, clinical trials, and other topics."
+  field_page_description__ES:
+    value: "Lista alfabética de todos los tipos de cáncer con enlaces a enfermedades específicas e información general sobre tratamiento, cuidados de apoyo, exámenes de detección, prevención, estudios clínicos y otros temas."
+  field_browser_title:
+    value: "A to Z List of Cancer Types"
+  field_browser_title__ES:
+    value: "Tipos de cáncer"
+  field_site_section:
+    - '#process':
+        callback: 'reference'
+        args:
+          - 'taxonomy_term'
+          - vid: 'cgov_site_sections'
+            computed_path: '/types'
+  field_site_section__ES:
+    - '#process':
+        callback: 'reference'
+        args:
+          - 'taxonomy_term'
+          - vid: 'cgov_site_sections'
+            computed_path: '/tipos'
+  field_page_style:
+    value: "ncids_with_title"
+  field_additional_library:
+    value: "addl-cancer-types-landing-page"

--- a/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/front-end/src/entrypoints/addl-cancer-types-landing-page/addl-cancer-types-landing-page.scss
+++ b/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/front-end/src/entrypoints/addl-cancer-types-landing-page/addl-cancer-types-landing-page.scss
@@ -1,0 +1,4 @@
+// File is empty in preperation for the DS package bump.
+// After the DS package bump for the accordion and combo box
+// we will add in the imports for the styling and JS.
+@use 'uswds-core' as *;

--- a/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/front-end/src/entrypoints/addl-cancer-types-landing-page/addl-cancer-types-landing-page.ts
+++ b/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/front-end/src/entrypoints/addl-cancer-types-landing-page/addl-cancer-types-landing-page.ts
@@ -1,0 +1,1 @@
+import './addl-cancer-types-landing-page.scss';

--- a/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/front-end/src/entrypoints/addl-lib-test/addl-lib-test.scss
+++ b/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/front-end/src/entrypoints/addl-lib-test/addl-lib-test.scss
@@ -1,0 +1,5 @@
+@use 'uswds-core' as *;
+
+.nci-hero__cta-tagline {
+	color: blue;
+}

--- a/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/front-end/src/entrypoints/addl-lib-test/addl-lib-test.ts
+++ b/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/front-end/src/entrypoints/addl-lib-test/addl-lib-test.ts
@@ -1,0 +1,7 @@
+import './addl-lib-test.scss';
+
+const onDOMContentLoaded = () => {
+	console.log('Hello World');
+};
+
+window.addEventListener('DOMContentLoaded', onDOMContentLoaded);

--- a/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/front-end/webpack.entries.js
+++ b/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/front-end/webpack.entries.js
@@ -46,4 +46,5 @@ module.exports = {
 		__dirname,
 		'src/entrypoints/app-module/app-module.ts'
 	),
+	'addl-lib-test': path.resolve(__dirname, 'src/entrypoints/addl-lib-test/addl-lib-test.ts'),
 };

--- a/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/front-end/webpack.entries.js
+++ b/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/front-end/webpack.entries.js
@@ -47,4 +47,11 @@ module.exports = {
 		'src/entrypoints/app-module/app-module.ts'
 	),
 	'addl-lib-test': path.resolve(__dirname, 'src/entrypoints/addl-lib-test/addl-lib-test.ts'),
+	// addl-cancer-types-landing-page is an additional library
+	// that can be added to a Home and Landing Page that contains
+	// the CSS and JS that will be used on the Cancer Types Landing Page
+	'addl-cancer-types-landing-page': path.resolve(
+		__dirname,
+		'src/entrypoints/addl-cancer-types-landing-page/addl-cancer-types-landing-page.ts'
+	),
 };

--- a/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/ncids_trans.libraries.yml
+++ b/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/ncids_trans.libraries.yml
@@ -151,3 +151,12 @@ app-module:
     dist/js/app-module.js: { preprocess: false }
   dependencies:
     - ncids_trans/ncids-global
+
+addl-lib-test:
+  css:
+    theme:
+      dist/css/addl-lib-test.css: { preprocess: true }
+  js:
+    dist/js/addl-lib-test.js: { preprocess: true }
+  dependencies:
+    - ncids_trans/ncids-home-landing

--- a/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/ncids_trans.libraries.yml
+++ b/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/ncids_trans.libraries.yml
@@ -160,3 +160,12 @@ addl-lib-test:
     dist/js/addl-lib-test.js: { preprocess: true }
   dependencies:
     - ncids_trans/ncids-home-landing
+
+addl-cancer-types-landing-page:
+  css:
+    theme:
+      dist/css/addl-cancer-types-landing-page.css: { preprocess: true }
+  js:
+    dist/js/addl-cancer-types-landing-page.js: { preprocess: true }
+  dependencies:
+    - ncids_trans/ncids-home-landing


### PR DESCRIPTION
Closes #4223

*This PR is currently rebased off of #4263*

PR Notes:

- Created a new library called `addl-types-landing-page` which is currently empty and is importing USWDS
- We will need to add the imports for the accordion and combo box once we bump the DS package
- This branch is currently rebased off of #4263 