### PR TITLE
(#4305) Unblock css and js assets from login protection

### DIFF
--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/EventSubscriber/CmsProtectionSubscriber.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/EventSubscriber/CmsProtectionSubscriber.php
@@ -151,6 +151,8 @@ class CmsProtectionSubscriber implements EventSubscriberInterface {
       'samlauth.saml_controller_acs',
       'system.403',
       'system.401',
+      'system.css_asset',
+      'system.js_asset',
     ];
     return in_array($route_name, $login_routes);
   }

--- a/docroot/sites/settings/cgov_caching.settings.php
+++ b/docroot/sites/settings/cgov_caching.settings.php
@@ -22,13 +22,8 @@ if (file_exists('/var/www/site-php') && isset($_ENV['AH_SITE_ENVIRONMENT'])) {
   $config['system.performance']['js']['gzip'] = TRUE;
 
   switch ($env) {
-    case '01dev':
     case 'dev':
-      // Disable aggregation of CSS and JS on dev.
-      $config['system.performance']['css']['preprocess'] = FALSE;
-      $config['system.performance']['css']['gzip'] = FALSE;
-      $config['system.performance']['js']['preprocess'] = FALSE;
-      $config['system.performance']['js']['gzip'] = FALSE;
+    case '01dev':
     case 'int':
     case '01test':
     case 'test':


### PR DESCRIPTION
I enabled CSS aggregation on all environments. The local.settings.php that ships with Drupal disables it, and that is ok. A dev can enable if they need local troubleshooting. However, if www-dev-ac was also www-cms-dev-ac or something and did not turn off aggregation, we would have encountered this issue MUCH sooner. 

Also locally once aggregation was enabled, it was pretty quick to test www-cms.devbox and verify the routes selected were correct. (Because it was reproducible easily with a `drush cr` and refresh the login page)

Closes #4305