### PR TITLE
(#4283) Chart Title Cutoff on PDF Export

### DIFF
--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/601_factbook_pages.content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/601_factbook_pages.content.yml
@@ -277,7 +277,7 @@
         .ui-dialog .ui-dialog-content {padding:0;overflow:hidden; max-width: 100%}
         .no-results-message {margin: 1.25em}
         </style>
-        <div style="min-width: 310px; height: 450px; margin: 0 auto;" id="NCI-Chart__grants-contracts" data-chart-revision="20230307_5"></div>
+        <div style="min-width: 310px; height: 450px; margin: 0 auto;" id="NCI-Chart__grants-contracts" data-chart-revision="20240430_1"></div>
   field_raw_html__ES:
     - format: "raw_html"
       value:

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/data_files/factbook-grants-contracts.json
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/data_files/factbook-grants-contracts.json
@@ -30,10 +30,6 @@
     "mapText":"",
     "mapTextFull":""
   },
-  "exporting":{
-    "sourceWidth":600,
-    "sourceHeight":500
-  },
   "legend":{
     "layout":"horizontal",
     "borderWidth":0,

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/libraries/charts/Chart.js
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/libraries/charts/Chart.js
@@ -180,6 +180,25 @@ Chart.prototype = function () {
                   color: '#62559f'
               }
           },
+          exporting: {
+            chartOptions: {
+              chart: {
+                backgroundColor: '#F0F0FE',
+                spacingLeft: 60,
+                spacingRight: 60
+              },
+              title: {
+                style: {
+                  fontSize: '1em'
+                }
+              },
+              subtitle: {
+                style: {
+                  fontSize: '0.75em'
+                }
+              }
+            }
+          },
           plotOptions: {
               pie: {
                   dataLabels: {
@@ -426,7 +445,6 @@ Chart.prototype = function () {
                   }
               }
           },
-
           legend: {
               layout: 'vertical',
               align: 'right',

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/libraries/charts/library/grants-contracts.js
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/libraries/charts/library/grants-contracts.js
@@ -275,7 +275,6 @@ function initChart(Chart, data, miscData = {}) {
     chart: chartType,
     title: data.chartTitle,
     credits: data.credits,
-    exporting: data.exporting,
     legend: data.legend,
     mapNavigation: data.mapNavigation,
     colorAxis: data.colorAxis,


### PR DESCRIPTION
Closes #4283

* Added `exporting` config to base theme for all charts
* Removed `exporting` config in `grants-contracts.js` and `grants-contracts.json` files
* Updated related yaml content files