### PR TITLE
(#2350) Remove bullets from CTHP inline links.

### DIFF
--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/entrypoints/cthp/CTHP.scss
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/entrypoints/cthp/CTHP.scss
@@ -275,8 +275,7 @@
 
 .more-info-list ul li:before,
 .cthp-pdq-label ul li:before,
-.cardBody ul li:before,
-.cardBody p a:not(.icon-exit-notification):before {
+.cardBody ul li:before {
   content: "\2022";
   display: inline-block;
   position: relative;

--- a/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/front-end/src/entrypoints/cthp/cthp-legacy.scss
+++ b/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/front-end/src/entrypoints/cthp/cthp-legacy.scss
@@ -268,8 +268,7 @@
 
 .more-info-list ul li:before,
 .cthp-pdq-label ul li:before,
-.cardBody ul li:before,
-.cardBody p a:not(.icon-exit-notification):before {
+.cardBody ul li:before {
   content: "\2022";
   display: inline-block;
   position: relative;


### PR DESCRIPTION
Closes #2350