### PR TITLE
(#4346) Factbook: Extra Space Between Title And Download Button

### DIFF
--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/libraries/charts/chart.scss
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/src/libraries/charts/chart.scss
@@ -25,3 +25,15 @@
     font-weight: normal !important
   }
 }
+
+@media only screen and (max-width: 768px) {
+  #awards {
+    .cgdpl {
+      .clearfix:after,
+      .clearfix:before {
+        content: "";
+        display: none;
+      }
+    }
+  }
+}


### PR DESCRIPTION
Closes #4346

* Added styling to remove `clearfix` added by legacy styling