### PR TITLE
(#3054) Force re-import of cgov translations

### DIFF
--- a/blt/src/Blt/Plugin/Commands/TranslateCommands.php
+++ b/blt/src/Blt/Plugin/Commands/TranslateCommands.php
@@ -49,8 +49,11 @@ class TranslateCommands extends BltTasks {
     $this->say("=== Update all available locales! ===");
     $this->say("=====================================");
     /** @var \Acquia\Blt\Robo\Tasks\DrushTask $task */
+    $docroot = $this->getConfigValue('docroot');
     $task = $this->taskDrush()
       ->drush('locale:update')
+      // Force a re-import of our translations.
+      ->drush("locale:import es {$docroot}/profiles/custom/cgov_site/translations/cgov_site.es.po")
       ->drush('cr')
       ->printOutput(TRUE);
     $result = $task->interactive($this->input()->isInteractive())->run();


### PR DESCRIPTION
Translations are only re-imported if they change. If the core Drupal translations change but ours don't, then the core translations overwrite our month names. This forces a re-import of our translations every time we deploy.

Closes #3054

This PR should change nothing about the site. It only fixes an intermittent bug (that is never seen on lower tiers?).