### PR TITLE
(#4479) Remove double-escaping of application_page titles.

### DIFF
--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_application_page/cgov_application_page.module
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_application_page/cgov_application_page.module
@@ -150,7 +150,7 @@ function cgov_application_page_preprocess_html(&$variables) {
         // of the metatag module's title tag.
         $token_service = \Drupal::token();
         $title = Html::escape(
-          $token_service->replace(
+          $token_service->replacePlain(
             '[cgov_tokens:cgov-title][cgov_tokens:browser-title-site-name-meta]',
             [
               'node' => $node,


### PR DESCRIPTION
Closes #4479 
