### PR TITLE
(#4530,#2937) Fix JS App Modules for D10.3

### DIFF
--- a/docroot/modules/custom/app_module/app_module.module
+++ b/docroot/modules/custom/app_module/app_module.module
@@ -113,10 +113,9 @@ function app_module_path_alias_delete(PathAliasInterface $path) {
  * Implements hook_page_attachments_alter().
  */
 function app_module_page_attachments_alter(array &$attachments) {
-  $request_query = \Drupal::request()->query;
-  $app_module_id = $request_query->get('app_module_id');
-  $app_module_route = $request_query->get('app_module_route');
-  $app_module_data = $request_query->all('app_module_data');
+  $app_module_id = \Drupal::request()->attributes->get('cgov_app_module_id');
+  $app_module_route = \Drupal::request()->attributes->get('cgov_app_module_route');
+  $app_module_data = \Drupal::request()->attributes->all('cgov_app_module_data');
 
   // We are not rendering an app module, so exit.
   if (!$app_module_id) {
@@ -151,9 +150,9 @@ function app_module_page_attachments_alter(array &$attachments) {
  * Implements hook_tokens_alter().
  */
 function app_module_tokens_alter(array &$replacements, array $context, BubbleableMetadata $bubbleable_metadata) {
-  $app_module_id = \Drupal::request()->query->get('app_module_id');
-  $app_module_route = \Drupal::request()->query->get('app_module_route');
-  $app_module_data = \Drupal::request()->query->all('app_module_data');
+  $app_module_id = \Drupal::request()->attributes->get('cgov_app_module_id');
+  $app_module_route = \Drupal::request()->attributes->get('cgov_app_module_route');
+  $app_module_data = \Drupal::request()->attributes->all('cgov_app_module_data');
 
   // We are not rendering an app module, so exit.
   if (!$app_module_id) {

--- a/docroot/modules/custom/app_module/app_module.services.yml
+++ b/docroot/modules/custom/app_module/app_module.services.yml
@@ -15,7 +15,7 @@ services:
       - { name: backend_overridable }
   app_module.path_processor_app_module:
     class: Drupal\app_module\PathProcessor\PathProcessorAppModule
-    arguments: ['@app_module.app_path_manager', '@entity_type.manager']
+    arguments: ['@app_module.app_path_manager', '@entity_type.manager', '@request_stack']
     tags:
       - { name: path_processor_inbound, priority: 101 }
   app_module.route_normalizer_block_request_subscriber:

--- a/docroot/modules/custom/app_module/src/AppModuleRenderArrayBuilder.php
+++ b/docroot/modules/custom/app_module/src/AppModuleRenderArrayBuilder.php
@@ -64,8 +64,8 @@ class AppModuleRenderArrayBuilder implements AppModuleRenderArrayBuilderInterfac
 
     // Determine the path.
     // The path processor will push the app module path into the request
-    // object's query params.
-    $path = $this->requestStack->getCurrentRequest()->query->get('app_module_route') ?? '/';
+    // object's attributes params.
+    $path = $this->requestStack->getCurrentRequest()->attributes->get('cgov_app_module_route') ?? '/';
 
     // Get the specific route id.
     $app_route_id = $plugin->getAppRouteId($path, $options);
@@ -122,9 +122,7 @@ class AppModuleRenderArrayBuilder implements AppModuleRenderArrayBuilderInterfac
     // information.
     $cache_meta = $plugin->getCacheInfoForRoute($path, $options);
 
-    // We must always vary by the app_module_route parameter.
     $route_contexts = Cache::mergeContexts(
-      ['url.query_args:app_module_route'],
       $app_module->getCacheContexts()
     );
 

--- a/docroot/modules/custom/app_module/src/AppPathManagerInterface.php
+++ b/docroot/modules/custom/app_module/src/AppPathManagerInterface.php
@@ -87,6 +87,17 @@ interface AppPathManagerInterface {
   public function getPathByRequest($request_path, $langcode = NULL);
 
   /**
+   * Gets all registered app module paths.
+   *
+   * @param string $app_module_id
+   *   An optional app module id to filter the paths by.
+   *
+   * @return array|null
+   *   An array of app module paths.
+   */
+  public function getAllPaths($app_module_id = NULL);
+
+  /**
    * Clear internal caches in alias manager.
    *
    * @param string $source

--- a/docroot/modules/custom/app_module/src/EventSubscriber/AppModuleRouteNormalizerBlockRequestSubscriber.php
+++ b/docroot/modules/custom/app_module/src/EventSubscriber/AppModuleRouteNormalizerBlockRequestSubscriber.php
@@ -12,7 +12,7 @@ use Symfony\Component\HttpKernel\KernelEvents;
  * The normalization should be disabled by setting the
  * "_disable_route_normalizer" request parameter to TRUE. This should be done
  * before onKernelRequestRedirect() method is executed and only if the
- * "app_module_route" query parameter is present.
+ * "cgov_app_module_route" attribute parameter is present.
  */
 class AppModuleRouteNormalizerBlockRequestSubscriber implements EventSubscriberInterface {
 
@@ -25,7 +25,7 @@ class AppModuleRouteNormalizerBlockRequestSubscriber implements EventSubscriberI
   public function onKernelRequest(RequestEvent $event) {
     $request = $event->getRequest();
 
-    if ($request->query->get('app_module_route')) {
+    if ($request->attributes->get('cgov_app_module_route')) {
       $request->attributes->set('_disable_route_normalizer', TRUE);
     }
   }

--- a/docroot/modules/custom/app_module/tests/src/Functional/AppModuleRenderArrayBuilderTest.php
+++ b/docroot/modules/custom/app_module/tests/src/Functional/AppModuleRenderArrayBuilderTest.php
@@ -113,7 +113,7 @@ class AppModuleRenderArrayBuilderTest extends BrowserTestBase {
         'caching_app_module_plugin',
         'config:app_module.app_module.caching_app_module',
       ],
-      ['url.query_args:app_module_route'],
+      [],
       50
     );
 
@@ -127,7 +127,7 @@ class AppModuleRenderArrayBuilderTest extends BrowserTestBase {
         'caching_app_module_plugin:chicken',
         'config:app_module.app_module.caching_app_module',
       ],
-      ['url.query_args:app_module_route', "url.query_args:chicken_param"],
+      ["url.query_args:chicken_param"],
       100
     );
 
@@ -140,7 +140,7 @@ class AppModuleRenderArrayBuilderTest extends BrowserTestBase {
         'test_multi_route_app_module_plugin',
         'config:app_module.app_module.test_multi_route_app_module',
       ],
-      ['url.query_args:app_module_route'],
+      [],
       50
     );
 
@@ -154,7 +154,7 @@ class AppModuleRenderArrayBuilderTest extends BrowserTestBase {
         'test_multi_route_app_module_plugin:chicken',
         'config:app_module.app_module.test_multi_route_app_module',
       ],
-      ['url.query_args:app_module_route', "url.query_args:chicken_param"],
+      ["url.query_args:chicken_param"],
       100
     );
 
@@ -211,13 +211,8 @@ class AppModuleRenderArrayBuilderTest extends BrowserTestBase {
       []
     );
 
-    // Smush the params together with the app_module_route.
-    $params = array_merge(
-      ['app_module_route' => $route_info['app_module_route']],
-      $route_info['params']
-    );
-
-    $request = Request::create('/foo/bar', 'GET', $params);
+    $request = Request::create('/foo/bar', 'GET', $route_info['params']);
+    $request->attributes->add(['cgov_app_module_route' => $route_info['app_module_route']]);
     $this->stack->push($request);
   }
 
@@ -268,7 +263,7 @@ class AppModuleRenderArrayBuilderTest extends BrowserTestBase {
     $app_module_id,
     $app_route_id,
     $tags,
-    $contexts = ['url.query_args:app_module_route'],
+    $contexts = [],
     $max_age = 0,
   ) {
     // Load the entity.

--- a/docroot/modules/custom/cgov_js_app_module/cgov_js_app_module.module
+++ b/docroot/modules/custom/cgov_js_app_module/cgov_js_app_module.module
@@ -12,78 +12,90 @@ use Drupal\Core\Asset\AttachedAssetsInterface;
  * the CSS in libraries (e.g. Common.css). The issue is that most app modules
  * override syles included in the Common and therefore need to come after.
  *
- * So cool. We just use hook_css_alter and add it right? Wrong. The libraries
- * attachment is cached based on the theme name, and the list of libraries for
- * the request.
- *
- * So cool. We will just use hook_library_info_build and add a library. Wrong.
- * The libraries provided by the module are cached, and so only 1 app module's
- * library/CSS would be added.
- *
- * So cool. We will use hook_library_info_alter to add the library that way.
+ * So cool. We will use hook_library_info_build to add the libraries to this
+ * module.
  * Wrong. Adding the library to the request works, but unfortunately, the
- * assets of that library are being cached by extension.
+ * libraries of a module are always added before a theme.
+ * ---> NOTE: This gets cached and for now, saving an application page will
+ * need to clear the library discovery cache.
  *
- * The final approach is to add an "empty" library to get the cache ID to be
- * different instances. Then use css_alter to add the CSS. This seems to get
- * around extension caching issues.
- *
- * NOTE 1: The library we add in info_alter is also added to the render array's
- * attachments in JsOnlyAppModulePlugin::buildForRoute.
- *
- * NOTE 2: The module that adds the library is the module who's hooks are
- * fired. So if we wanted to follow the pattern we have been where app_module
- * implements the hooks, the base AppModulePluginBase provides a method to
- * provide information to that hook, we cannot. This is because the hooks in
- * app_module would never be called, instead it would be looking for the
- * hooks in the module that implements the actual plugin.
- *
- *  NOTE 3: for the JS we have NONE of these issues.
+ * We use css_alter to change the group/weight of the CSS. This seems to get
+ * around extension ordering issues.
  */
 
 /**
-  * Implements hook_library_info_alter().
-  *
-  */
-function cgov_js_app_module_library_info_alter(array &$libraries, $extension) {
-  if ($extension !== 'cgov_js_app_module') {
-    return;
+ * Implements hook_library_info_build().
+ *
+ * This loads up all app module css files as libraries under `cgov_js_app_module`.
+ * This allows us to attach the libraries to pages using the app modules.
+ * 
+ * This function should only be called once per cache load. New app modules and
+ * updates will need to clear out the library cache tag. (There is a library cache
+ * tag right?)
+ */
+function cgov_js_app_module_library_info_build() {
+  $libraries = [];
+
+  // Get all the application paths (with configs) registered in the system.
+  $app_path_manager = \Drupal::service('app_module.app_path_manager');
+  $app_paths = $app_path_manager->getAllPaths('cgov_js_only_app');
+
+  foreach ($app_paths as $app_path) {
+    $options = $app_path['app_module_data'];
+
+    // Define a custom library to include the CSS file.
+    $css_uri = $options['drupalConfig']['appCssUri'];
+
+    // Add the custom library to the page.
+    if (!isset($libraries[$css_uri])) {
+      $libraries[$css_uri] = [
+        'version' => -1,
+        'license' => [
+          'name' => 'NA',
+        ],
+        'css' => [
+          'theme' => [
+            $css_uri => [
+              'preprocess' => FALSE,
+              'weight' => 1000,
+              'group' => 1000,
+              'type' => 'file',
+              'data' => $options['drupalConfig']['appCssUri'],
+              'version' => -1,
+              'media' => 'all',
+              'browsers' => [
+                'IE' => TRUE,
+                '!IE' => TRUE,
+              ],
+            ],
+          ],
+        ],
+      ];
+    }
   }
 
-  $request_query = \Drupal::request()->query;
-  $app_module_id = $request_query->get('app_module_id');
-
-  // We are not rendering an app module, so exit.
-  if (!$app_module_id || $app_module_id !== 'cgov_js_only_app' ) {
-    return;
-  }
-
-  $options = $request_query->all('app_module_data');
-
-  // Setup Library.
-  $libraries[$options['drupalConfig']['appName']] = [
-    'version' => -1,
-    'license' => [
-      'name' => 'NA',
-    ],
-    'css' => [],
-  ];
-
+  return $libraries;
 }
 
 /**
  * Implements hook_css_alter().
+ *
+ * This is a hack to work around https://www.drupal.org/project/drupal/issues/3046636.
+ * Basically, all module libraries will come before any theme libraries. However, we
+ * want to add these stylesheets after our theme's since the app theme is usually
+ * overriding the styles we define in our global css. This hook is going to reset the
+ * module weight once everything is loaded.
+ * See https://www.drupal.org/project/drupal/issues/3046636#comment-15396857.
  */
 function cgov_js_app_module_css_alter(array &$css, AttachedAssetsInterface $assets) {
-  $request_query = \Drupal::request()->query;
-  $app_module_id = $request_query->get('app_module_id');
+  $app_module_id = \Drupal::request()->attributes->get('cgov_app_module_id');
 
   // We are not rendering an app module, so exit.
   if (!$app_module_id || $app_module_id !== 'cgov_js_only_app' ) {
     return;
   }
 
-  $options = $request_query->all('app_module_data');
+  $options = \Drupal::request()->attributes->all('cgov_app_module_data');
 
   $css[$options['drupalConfig']['appCssUri']] = [
     'preprocess' => FALSE,
@@ -99,4 +111,24 @@ function cgov_js_app_module_css_alter(array &$css, AttachedAssetsInterface $asse
     ],
   ];
 
+}
+
+/**
+ * Implements hook_preprocess_page().
+ */
+function cgov_js_app_module_preprocess_page(array &$variables) {
+  $app_module_id = \Drupal::request()->attributes->get('cgov_app_module_id');
+
+  // We are not rendering an app module, so exit.
+  if (!$app_module_id || $app_module_id !== 'cgov_js_only_app' ) {
+    return;
+  }
+
+  $options = \Drupal::request()->attributes->all('cgov_app_module_data');
+
+  // Define a custom library to include the CSS file.
+  $css_uri = $options['drupalConfig']['appCssUri'];
+
+  // Add the custom library to the page.
+  $variables['#attached']['library'][] = 'cgov_js_app_module/' . $css_uri;
 }

--- a/docroot/modules/custom/cgov_js_app_module/src/Plugin/app_module/JsOnlyAppModulePlugin.php
+++ b/docroot/modules/custom/cgov_js_app_module/src/Plugin/app_module/JsOnlyAppModulePlugin.php
@@ -531,7 +531,7 @@ class JsOnlyAppModulePlugin extends AppModulePluginBase {
 
     // I don't think we need any other cache tags. The parent app module
     // should have the instance of this app module for clearing if the
-    // config is updated. This tag below is a couresy if we need to
+    // config is updated. This tag below is a courtesy if we need to
     // clear ALL js app modules.
     $meta
       ->setCacheTags(['cgov_js_only_app_module_plugin']);

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_application_page/cgov_application_page.module
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_application_page/cgov_application_page.module
@@ -21,6 +21,21 @@ function cgov_application_page_entity_insert(EntityInterface $entity) {
      */
     $app_path_svc = \Drupal::service('app_module.app_path_manager');
     $app_path_svc->updateAppPath($entity);
+
+    // @todo: move to cgov_js_app_module when app_module_path becomes entity.
+    // We need to clear the libraries cache if this is a cgov_js_only_app and its
+    // CSS has never been registered before. Clearing the cache will trigger a
+    // rebuild of the libraries, which will pick up our new CSS.
+    if ($entity->field_application_module->target_id === 'cgov_js_only_app') {
+      $library_discovery = \Drupal::service('library.discovery');
+      $cssUri = $entity->field_application_module->data['drupalConfig']['appCssUri'];
+
+      // Clear the cache if the css file is not already defined in a library.
+      $js_app_libs = $library_discovery->getLibrariesByExtension('cgov_js_app_module');
+      if (!isset($js_app_libs[$cssUri])) {
+        $library_discovery->clearCachedDefinitions();
+      }
+    }
   }
 }
 
@@ -37,6 +52,21 @@ function cgov_application_page_entity_update(EntityInterface $entity) {
      */
     $app_path_svc = \Drupal::service('app_module.app_path_manager');
     $app_path_svc->updateAppPath($entity);
+
+    // @todo: move to cgov_js_app_module when app_module_path becomes entity.
+    // We need to clear the libraries cache if this is a cgov_js_only_app and its
+    // CSS has never been registered before. Clearing the cache will trigger a
+    // rebuild of the libraries, which will pick up our new CSS.
+    if ($entity->field_application_module->target_id === 'cgov_js_only_app') {
+      $library_discovery = \Drupal::service('library.discovery');
+      $cssUri = $entity->field_application_module->data['drupalConfig']['appCssUri'];
+
+      // Clear the cache if the css file is not already defined in a library.
+      $js_app_libs = $library_discovery->getLibrariesByExtension('cgov_js_app_module');
+      if (!isset($js_app_libs[$cssUri])) {
+        $library_discovery->clearCachedDefinitions();
+      }
+    }
   }
 }
 
@@ -150,7 +180,7 @@ function cgov_application_page_preprocess_html(&$variables) {
         // of the metatag module's title tag.
         $token_service = \Drupal::token();
         $title = Html::escape(
-          $token_service->replacePlain(
+          $token_service->replace(
             '[cgov_tokens:cgov-title][cgov_tokens:browser-title-site-name-meta]',
             [
               'node' => $node,


### PR DESCRIPTION
- Change how the JS only css is attached to a page to support D10.3.
- Switched from using $request->query to using $request->attributes. Attributes is meant for adding random things to. Query is actually the query params and acts funky if something is not cleaning up links. (Especial for the app module data when it gets serialized into a query param.)
- Fixed up the App Module's path processor to reduce lookups and get rid of some funkiness when it is called multiple times for app modules. processIncoming actually gets called for many outgoing urls. (It fires off a lot for a single request)
- CSS links seem to update correctly when an application page's css URL is updated. This previously needed a Drupal/ACSF cache clear for CSS changes to take effect.
- Implemented #2937 because moving to request->attributes is NOT query parameters. This will probably cause caching issues for Server-side app modules, which we will probably never do again. (P.S. those app modules can add a cache vary themselves if they really need to.)

Closes #4530
Closes #2937