### PR TITLE
(#4634) Remove cgov common from build

### DIFF
--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_saml_auth_config/tests/src/Functional/CgovSamlAuthConfigTest.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_saml_auth_config/tests/src/Functional/CgovSamlAuthConfigTest.php
@@ -25,7 +25,7 @@ class CgovSamlAuthConfigTest extends BrowserTestBase {
    *
    * @var string
    */
-  protected $defaultTheme = 'cgov_common';
+  protected $defaultTheme = 'cgov_admin';
 
   /**
    * An admin user for testing.

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_site_section/tests/src/Functional/CgovSiteSectionNavApiTest.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_site_section/tests/src/Functional/CgovSiteSectionNavApiTest.php
@@ -35,7 +35,7 @@ class CgovSiteSectionNavApiTest extends BrowserTestBase {
   /**
    * {@inheritdoc}
    */
-  protected $defaultTheme = 'cgov_common';
+  protected $defaultTheme = 'stark';
 
   /**
    * {@inheritdoc}

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/tests/src/Functional/ApiTest.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/tests/src/Functional/ApiTest.php
@@ -20,11 +20,11 @@ class ApiTest extends BrowserTestBase {
   protected $profile = 'cgov_site';
 
   /**
-   * The theme to use with this test.
+   * This test requires output from a front-end theme.
    *
    * @var string
    */
-  protected $defaultTheme = 'cgov_common';
+  protected $defaultTheme = 'ncids_trans';
 
   /**
    * Basic authentication credentials.

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_drug_information_summary/tests/src/Functional/ApiTest.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_drug_information_summary/tests/src/Functional/ApiTest.php
@@ -19,11 +19,11 @@ class ApiTest extends BrowserTestBase {
   protected $profile = 'cgov_site';
 
   /**
-   * The theme to use with this test.
+   * Requires frontend theme.
    *
    * @var string
    */
-  protected $defaultTheme = 'cgov_common';
+  protected $defaultTheme = 'ncids_trans';
 
   /**
    * Basic authentication credentials.

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_glossifier/tests/src/Functional/ApiTest.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_glossifier/tests/src/Functional/ApiTest.php
@@ -23,7 +23,7 @@ class ApiTest extends BrowserTestBase {
    *
    * @var string
    */
-  protected $defaultTheme = 'cgov_common';
+  protected $defaultTheme = 'stark';
 
   /**
    * Basic authentication credentials.

--- a/docroot/profiles/custom/cgov_site/tests/src/Functional/CgovSiteTest.php
+++ b/docroot/profiles/custom/cgov_site/tests/src/Functional/CgovSiteTest.php
@@ -29,7 +29,7 @@ class CgovSiteTest extends BrowserTestBase {
    *
    * @var string
    */
-  protected $defaultTheme = 'cgov_common';
+  protected $defaultTheme = 'stark';
 
   /**
    * The admin user.

--- a/docroot/profiles/custom/cgov_site/tests/src/Functional/PdqNodeTypeTest.php
+++ b/docroot/profiles/custom/cgov_site/tests/src/Functional/PdqNodeTypeTest.php
@@ -29,7 +29,7 @@ class PdqNodeTypeTest extends NodeTestBase {
    *
    * @var string
    */
-  protected $defaultTheme = 'cgov_common';
+  protected $defaultTheme = 'stark';
 
   /**
    * Modules to enable.

--- a/scripts/blt/custom/frontend-assets.sh
+++ b/scripts/blt/custom/frontend-assets.sh
@@ -9,11 +9,6 @@ pushd themes/custom/ncids_trans/front-end
 npm run build:prod
 popd
 
-## Install cgov_common packages
-pushd themes/custom/cgov/cgov_common
-npm run build
-popd
-
 ## Build pdq_glossifier packages
 pushd modules/custom/pdq_glossifier
 npm run build

--- a/scripts/blt/custom/frontend-reqs.sh
+++ b/scripts/blt/custom/frontend-reqs.sh
@@ -10,12 +10,6 @@ pushd themes/custom/ncids_trans/front-end
 npm ci
 popd
 
-## Install cgov_common packages
-echo "Installing cgov_common packages"
-pushd themes/custom/cgov/cgov_common
-npm ci
-popd
-
 ## Install pdq_glossifier packages
 pushd modules/custom/pdq_glossifier
 npm ci

--- a/scripts/blt/custom/frontend-test.sh
+++ b/scripts/blt/custom/frontend-test.sh
@@ -10,6 +10,4 @@ npm run lint
 npm run test
 popd
 
-# There are no tests for cgov_common :(
-
 # There are no tests for pdq_glossifier :(


### PR DESCRIPTION
- Replace use of cgov_common in tests
  - Use stark where possible
  - Use ncids_trans when a front-end theme is required.

Closes #4634 