### PR TITLE
R4 Common Features Feedback for Images (#4731, #4735)

### DIFF
--- a/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/front-end/src/entrypoints/article/article-legacy.scss
+++ b/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/front-end/src/entrypoints/article/article-legacy.scss
@@ -6,33 +6,23 @@
 @use 'uswds-core' as *;
 
 /** Legacy mixin things **/
-@import "~Core/styles/environments/percussion";
-@import "../../legacy/styles/variables";
-@import "~Core/styles/mixins";
-@import "~Core/styles/fonts";
+@import '~Core/styles/environments/percussion';
+@import '../../legacy/styles/variables';
+@import '~Core/styles/mixins';
+@import '~Core/styles/fonts';
 @import '../../legacy/styles/breakpoint-mixins';
-@import "~Core/styles/placeholders";
-@import "~Styles/sprites/svg-sprite"; //sprites are sometimes used in *_overrides files
+@import '~Core/styles/placeholders';
+@import '~Styles/sprites/svg-sprite'; //sprites are sometimes used in *_overrides files
 
 // This is for the on this page styling, which will be removed
 // when the OTP update story is done.
 // We needed foundation variables for the on this page styles
-@import "../../legacy/styles/nci-foundation_variables";
+@import '../../legacy/styles/nci-foundation_variables';
 
-@import "~Core/styles/ebookButtons";
-@import "~Core/styles/materials_to_share";
+@import '~Core/styles/ebookButtons';
+@import '~Core/styles/materials_to_share';
 
-// Override .cgdpl paragraph styles for image caption
-// These fonts are overridden by the cgdpl
-// wrapper otherwise
-.cgdp-image__caption {
-	@include u-font('sans', '2xs');
-	line-height: line-height($theme-body-font-family, $theme-body-line-height);
-}
-.cgdp-image__credit {
-	@include u-font('sans', '3xs');
-}
-.cgdp-image__enlarge {
-	@include u-font('sans', '2xs');
-	line-height: line-height($theme-body-font-family, $theme-body-line-height);
-}
+// Override wrapper styles for embedded images
+// (Specifically the figure and caption/credit/enlarge styles
+@import '../../legacy/transition-hacks/inner-page-embed-image-hack';
+

--- a/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/front-end/src/entrypoints/biography/biography-legacy.scss
+++ b/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/front-end/src/entrypoints/biography/biography-legacy.scss
@@ -6,22 +6,11 @@
 // Expose USWDS variables and mixins to our imports.
 @use 'uswds-core' as *;
 
-@import "../../legacy/styles/variables";
+@import '../../legacy/styles/variables';
 @import '../../legacy/styles/breakpoint-mixins';
-@import "~Styles/sprites/svg-sprite";
-@import "~Core/styles/profile-panel";
+@import '~Styles/sprites/svg-sprite';
+@import '~Core/styles/profile-panel';
 
-// Override .cgdpl paragraph styles for image caption
-// These fonts are overridden by the cgdpl
-// wrapper otherwise
-.cgdp-image__caption {
-	@include u-font('sans', '2xs');
-	line-height: line-height($theme-body-font-family, $theme-body-line-height);
-}
-.cgdp-image__credit {
-	@include u-font('sans', '3xs');
-}
-.cgdp-image__enlarge {
-	@include u-font('sans', '2xs');
-	line-height: line-height($theme-body-font-family, $theme-body-line-height);
-}
+// Override wrapper styles for embedded images
+// (Specifically the figure and caption/credit/enlarge styles
+@import '../../legacy/transition-hacks/inner-page-embed-image-hack';

--- a/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/front-end/src/entrypoints/blogs/blogs-legacy.scss
+++ b/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/front-end/src/entrypoints/blogs/blogs-legacy.scss
@@ -2,114 +2,112 @@
 // file should generate markup.
 @forward '../cgdp-required';
 // Expose USWDS variables and mixins to our imports.
-@forward "nci-heading";
-@forward "usa-list";
+@forward 'nci-heading';
+@forward 'usa-list';
 
 @use 'uswds-core' as *;
 
-@import "../../legacy/styles/variables";
-@import "~Core/styles/mixins";
+@import '../../legacy/styles/variables';
+@import '~Core/styles/mixins';
 @import '../../legacy/styles/breakpoint-mixins';
 
 // The following is required so that we can get our heading styles for the blog
 // archive.
-@import "~Core/styles/nci-foundation_mixins";
-@import "../../legacy/styles/nci-foundation_variables";
+@import '~Core/styles/nci-foundation_mixins';
+@import '../../legacy/styles/nci-foundation_variables';
 $include-html-classes: false;
 $include-html-type-classes: false;
-@import "~Core/styles/vendor/foundation/scss/foundation/components/global";
-@import "../../legacy/styles/foundation/components/type";
+@import '~Core/styles/vendor/foundation/scss/foundation/components/global';
+@import '../../legacy/styles/foundation/components/type';
 
-@import "../../legacy/styles/blogs";
-@import "~Core/styles/equalheights";
+@import '../../legacy/styles/blogs';
+@import '~Core/styles/equalheights';
 
 .list.dynamic {
-  .title-and-desc {
-    // I wish we were using BEM
-    a.title {
-      font-size: 1.5em;
-    }
-    a {
-      font-size: 16px;
-    }
-  }
+	.title-and-desc {
+		// I wish we were using BEM
+		a.title {
+			font-size: 1.5em;
+		}
+		a {
+			font-size: 16px;
+		}
+	}
 }
 
 .card {
-  padding: .9375em;
-  margin-bottom: 1em;
-  border: 1px solid $yetAnotherGrey;
-  background-color: $white;
-  box-shadow: 0 0 9px 1px rgba($black,.15);
+	padding: 0.9375em;
+	margin-bottom: 1em;
+	border: 1px solid $yetAnotherGrey;
+	background-color: $white;
+	box-shadow: 0 0 9px 1px rgba($black, 0.15);
 }
 
 .feature-card {
+	h3 {
+		margin-top: 0;
+		font-weight: normal;
+		color: $color-link;
+		font-size: 0.95em;
+		line-height: 1.272;
+	}
+	div {
+		margin-bottom: 1em;
+	}
+	a {
+		display: inline-block;
 
-  h3 {
-    margin-top: 0;
-    font-weight: normal;
-    color: $color-link;
-    font-size: 0.95em;
-    line-height: 1.272;
-  }
-  div {
-    margin-bottom: 1em;
-  }
-  a {
-    display: inline-block;
-
-    &:hover {
-      text-decoration: none;
-      .image-hover img {
-        opacity: .8;
-      }
-    }
-  }
-  p {
-    line-height: 1.375;
-    font-size: 0.9em;
-    color: #757575;
-    &:last-child {
-      margin-bottom: 0;
-    }
-  }
-
-  .image-hover {
-		position: relative;
+		&:hover {
+			text-decoration: none;
+			.image-hover img {
+				opacity: 0.8;
+			}
+		}
+	}
+	p {
+		line-height: 1.375;
+		font-size: 0.9em;
+		color: #757575;
+		&:last-child {
+			margin-bottom: 0;
+		}
 	}
 
+	.image-hover {
+		position: relative;
+	}
 }
 
 #cgov-blog-post-pagination {
-  margin-top: 3em;
+	margin-top: 3em;
 }
 
 // #2179: there were some styles scoped specifically to embedded images.  Fixed so that styles are properly applied for all the embeddeds
 .cgvblogpost {
-  // wrapped specifically to this content type so that it doesn't cause side effects elsewhere on the site
-  .embedded-entity{
-    &.align-center,
-      &.align-left,
-      &.align-right {
-        margin: 0 0 2.5em 0;
-      }
+	// wrapped specifically to this content type so that it doesn't cause side effects elsewhere on the site
+	.embedded-entity {
+		&.align-center,
+		&.align-left,
+		&.align-right {
+			margin: 0 0 2.5em 0;
+		}
 
-    &.align-left {
-      margin-right: 2.5em;
-    }
+		&.align-left {
+			margin-right: 2.5em;
+		}
 
-    &.align-center {
-      margin: 2.5em auto;
-    }
+		&.align-center {
+			margin: 2.5em auto;
+		}
 
-    figure.image-medium {
-      background-color: transparent;
-    }
-  }
+		figure.image-medium {
+			background-color: transparent;
+		}
+	}
 }
 @include bp(medium-up) {
 	.cgvblogpost {
-		.embedded-entity{
+		.embedded-entity {
 			&.align-right {
 				margin-left: 2.5em;
 			}
@@ -119,15 +117,15 @@ $include-html-type-classes: false;
 
 @include bp(medium-up) {
 	// set width of blog intro text for tablet and desktop, depending on size of image
-	.embedded-entity[data-entity-embed-display*="_medium"] + .blog-intro-text {
+	.embedded-entity[data-entity-embed-display*='_medium'] + .blog-intro-text {
 		width: 60%;
 	}
-	.embedded-entity[data-entity-embed-display*="_small"] + .blog-intro-text {
+	.embedded-entity[data-entity-embed-display*='_small'] + .blog-intro-text {
 		width: 75%;
 	}
 }
 
-@include bp(large-up){
+@include bp(large-up) {
 	.row.hero-slot {
 		max-width: 1350px;
 	}
@@ -141,20 +139,20 @@ $include-html-type-classes: false;
 	}
 	.row .gutter:first-child {
 		margin-left: 0;
-  }
-  .contentzone:last-child {
-    width:100%;
-  }
+	}
+	.contentzone:last-child {
+		width: 100%;
+	}
 }
 
 @include bp(small) {
-  // remove extra padding (used for intro text on desktop/tablet only)
-  .cgvblogpost{
-    .embedded-entity {
-      float: none;
-      margin: 0;
-    }
-  }
+	// remove extra padding (used for intro text on desktop/tablet only)
+	.cgvblogpost {
+		.embedded-entity {
+			float: none;
+			margin: 0;
+		}
+	}
 }
 
 // TODO:
@@ -217,18 +215,6 @@ $include-html-type-classes: false;
 	@include u-margin-bottom(2);
 }
 
-// Override .cgdpl paragraph styles for image caption
-// These fonts are overridden by the cgdpl
-// wrapper otherwise
-.cgdp-image__caption {
-	@include u-font('sans', '2xs');
-	line-height: line-height($theme-body-font-family, $theme-body-line-height);
-}
-.cgdp-image__credit {
-	@include u-font('sans', '3xs');
-}
-.cgdp-image__enlarge {
-	@include u-font('sans', '2xs');
-	line-height: line-height($theme-body-font-family, $theme-body-line-height);
-}
-
+// Override wrapper styles for embedded images
+// (Specifically the figure and caption/credit/enlarge styles
+@import '../../legacy/transition-hacks/inner-page-embed-image-hack';

--- a/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/front-end/src/entrypoints/cancer-center/cancer-center-legacy.scss
+++ b/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/front-end/src/entrypoints/cancer-center/cancer-center-legacy.scss
@@ -6,22 +6,11 @@
 // Expose USWDS variables and mixins to our imports.
 @use 'uswds-core' as *;
 
-@import "../../legacy/styles/variables";
+@import '../../legacy/styles/variables';
 @import '../../legacy/styles/breakpoint-mixins';
-@import "~Styles/sprites/svg-sprite";
-@import "~Core/styles/profile-panel";
+@import '~Styles/sprites/svg-sprite';
+@import '~Core/styles/profile-panel';
 
-// Override .cgdpl paragraph styles for image caption
-// These fonts are overridden by the cgdpl
-// wrapper otherwise
-.cgdp-image__caption {
-	@include u-font('sans', '2xs');
-	line-height: line-height($theme-body-font-family, $theme-body-line-height);
-}
-.cgdp-image__credit {
-	@include u-font('sans', '3xs');
-}
-.cgdp-image__enlarge {
-	@include u-font('sans', '2xs');
-	line-height: line-height($theme-body-font-family, $theme-body-line-height);
-}
+// Override wrapper styles for embedded images
+// (Specifically the figure and caption/credit/enlarge styles
+@import '../../legacy/transition-hacks/inner-page-embed-image-hack';

--- a/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/front-end/src/entrypoints/cancer-research/cancer-research-legacy.scss
+++ b/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/front-end/src/entrypoints/cancer-research/cancer-research-legacy.scss
@@ -6,17 +6,6 @@
 // Expose USWDS variables and mixins to our imports.
 @use 'uswds-core' as *;
 
-// Override .cgdpl paragraph styles for image caption
-// These fonts are overridden by the cgdpl
-// wrapper otherwise
-.cgdp-image__caption {
-	@include u-font('sans', '2xs');
-	line-height: line-height($theme-body-font-family, $theme-body-line-height);
-}
-.cgdp-image__credit {
-	@include u-font('sans', '3xs');
-}
-.cgdp-image__enlarge {
-	@include u-font('sans', '2xs');
-	line-height: line-height($theme-body-font-family, $theme-body-line-height);
-}
+// Override wrapper styles for embedded images
+// (Specifically the figure and caption/credit/enlarge styles
+@import '../../legacy/transition-hacks/inner-page-embed-image-hack';

--- a/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/front-end/src/entrypoints/event/event-legacy.scss
+++ b/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/front-end/src/entrypoints/event/event-legacy.scss
@@ -8,18 +8,6 @@
 
 @import '../../legacy/styles/_events.scss';
 
-// Override .cgdpl paragraph styles for image caption
-// These fonts are overridden by the cgdpl
-// wrapper otherwise
-.cgdp-image__caption {
-	@include u-font('sans', '2xs');
-	line-height: line-height($theme-body-font-family, $theme-body-line-height);
-}
-.cgdp-image__credit {
-	@include u-font('sans', '3xs');
-}
-.cgdp-image__enlarge {
-	@include u-font('sans', '2xs');
-	line-height: line-height($theme-body-font-family, $theme-body-line-height);
-}
-
+// Override wrapper styles for embedded images
+// (Specifically the figure and caption/credit/enlarge styles
+@import '../../legacy/transition-hacks/inner-page-embed-image-hack';

--- a/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/front-end/src/entrypoints/infographic/infographic-legacy.scss
+++ b/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/front-end/src/entrypoints/infographic/infographic-legacy.scss
@@ -5,21 +5,9 @@
 // Expose USWDS variables and mixins to our imports.
 @use 'uswds-core' as *;
 
-@import "../../legacy/styles/variables";
+@import '../../legacy/styles/variables';
 @import '../../legacy/styles/breakpoint-mixins';
 
-// Override .cgdpl paragraph styles for image caption
-// These fonts are overridden by the cgdpl
-// wrapper otherwise
-.cgdp-image__caption {
-	@include u-font('sans', '2xs');
-	line-height: line-height($theme-body-font-family, $theme-body-line-height);
-}
-.cgdp-image__credit {
-	@include u-font('sans', '3xs');
-}
-.cgdp-image__enlarge {
-	@include u-font('sans', '2xs');
-	line-height: line-height($theme-body-font-family, $theme-body-line-height);
-}
-
+// Override wrapper styles for embedded images
+// (Specifically the figure and caption/credit/enlarge styles
+@import '../../legacy/transition-hacks/inner-page-embed-image-hack';

--- a/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/front-end/src/entrypoints/mini-landing/mini-landing-legacy.scss
+++ b/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/front-end/src/entrypoints/mini-landing/mini-landing-legacy.scss
@@ -4,24 +4,24 @@
 // Expose USWDS variables and mixins to our imports.
 @use 'uswds-core' as *;
 
-@import "~Core/styles/environments/percussion";
-@import "../../legacy/styles/variables";
-@import "~Core/styles/mixins";
-@import "~Core/styles/fonts";
+@import '~Core/styles/environments/percussion';
+@import '../../legacy/styles/variables';
+@import '~Core/styles/mixins';
+@import '~Core/styles/fonts';
 @import '../../legacy/styles/breakpoint-mixins';
-@import "~Core/styles/placeholders";
-@import "~Styles/sprites/svg-sprite";
-@import "~Core/styles/nci-foundation_mixins";
-@import "../../legacy/styles/nci-foundation_variables";
-@import "~Core/styles/thumbnailcards";
-@import "~Core/styles/institutions";
+@import '~Core/styles/placeholders';
+@import '~Styles/sprites/svg-sprite';
+@import '~Core/styles/nci-foundation_mixins';
+@import '../../legacy/styles/nci-foundation_variables';
+@import '~Core/styles/thumbnailcards';
+@import '~Core/styles/institutions';
 
 // We need to make sure that foundation does not generate any markup that would
 // be in Common.scss. This is for borderless cards.
 $include-html-classes: false;
 $include-html-button-classes: false;
-@import "~Core/styles/vendor/foundation/scss/foundation/components/global";
-@import "~Core/styles/vendor/foundation/scss/foundation/components/buttons";
+@import '~Core/styles/vendor/foundation/scss/foundation/components/global';
+@import '~Core/styles/vendor/foundation/scss/foundation/components/buttons';
 
 @import '~Core/styles/borderless-cards';
 @import '~Core/styles/alternating-lists';
@@ -30,241 +30,229 @@ $include-html-button-classes: false;
 @import '../../legacy/styles/events';
 
 .feature-primary {
-  .card {
-    padding: 0;
-  }
+	.card {
+		padding: 0;
+	}
 }
 
 div.row.feature-primary.flex-columns {
-  display: flex;
-  float: none;
+	display: flex;
+	float: none;
 }
 .feature-card {
-  div {
-    margin-bottom: 1em;
-  }
-
-  a {
-    &:hover {
-      text-decoration: none;
-    }
-  }
-
-  p {
-    &:last-child {
-      margin-bottom: 0;
-    }
-  }
-
-  .image-hover {
-    position: relative;
-    img {
-      width: 100%;
-    }
+	div {
+		margin-bottom: 1em;
 	}
 
+	a {
+		&:hover {
+			text-decoration: none;
+		}
+	}
+
+	p {
+		&:last-child {
+			margin-bottom: 0;
+		}
+	}
+
+	.image-hover {
+		position: relative;
+		img {
+			width: 100%;
+		}
+	}
 }
 
 .infographic {
-  position: relative;
-  /* allows for appearance of equal height cards on home page */
-  background: $white;
+	position: relative;
+	/* allows for appearance of equal height cards on home page */
+	background: $white;
 
-  figcaption {
-    padding: 0.5em 1em;
-  }
+	figcaption {
+		padding: 0.5em 1em;
+	}
 }
 
 .infographic-enlarge {
-  position: absolute;
-  top: 0;
-  right: 0;
-  color: $white;
+	position: absolute;
+	top: 0;
+	right: 0;
+	color: $white;
 
-  a {
-    position: relative;
-    color: $white;
-    padding: 1em 2em 1em 1em;
-    display: block;
-    /* TODO: add this image to the sprite */
-    background-color: #403f3f;
-    @extend %card-link-hover;
+	a {
+		position: relative;
+		color: $white;
+		padding: 1em 2em 1em 1em;
+		display: block;
+		/* TODO: add this image to the sprite */
+		background-color: #403f3f;
+		@extend %card-link-hover;
 
-    &::before {
-      @include svg-sprite(chevron-white);
-      content: "";
-      position: absolute;
-      top: 50%;
-      right: .6em;
-      transform: translateY(-50%) rotate(90deg);
-    }
-  }
+		&::before {
+			@include svg-sprite(chevron-white);
+			content: '';
+			position: absolute;
+			top: 50%;
+			right: 0.6em;
+			transform: translateY(-50%) rotate(90deg);
+		}
+	}
 }
 
 @include bp(small) {
-  .feature-primary {
-    flex-direction: column;
-    .card {
-      margin: 1.25em 0;
-      background: $white;
-    }
-  }
-  .feature-card {
-
-    a {
-      padding-top: 15px;
-      padding-bottom: 15px;
-    }
-    .image-hover {
-      float: left;
-      width: 30%;
-    }
-    h3, p {
-      float: right;
-      width: 68%;
-    }
-  }
-  .card-thumbnail img {
-    display: none;
-  }
+	.feature-primary {
+		flex-direction: column;
+		.card {
+			margin: 1.25em 0;
+			background: $white;
+		}
+	}
+	.feature-card {
+		a {
+			padding-top: 15px;
+			padding-bottom: 15px;
+		}
+		.image-hover {
+			float: left;
+			width: 30%;
+		}
+		h3,
+		p {
+			float: right;
+			width: 68%;
+		}
+	}
+	.card-thumbnail img {
+		display: none;
+	}
 }
 
 @include bp(medium-up) {
-  // moved over from _hacks.scss
-  .card-thumbnail .small-2 {
+	// moved over from _hacks.scss
+	.card-thumbnail .small-2 {
 		width: 25%;
 	}
 	.card-thumbnail .small-10 {
 		width: 75%;
-  }
+	}
 
-  // moved over from TopicPage.scss
-  .card-thumbnail-image {
-    padding-left: 0;
-  }
-  .card-thumbnail .small-10.card-thumbnail-text > h3 {
-    margin-top: .5em;
-  }
+	// moved over from TopicPage.scss
+	.card-thumbnail-image {
+		padding-left: 0;
+	}
+	.card-thumbnail .small-10.card-thumbnail-text > h3 {
+		margin-top: 0.5em;
+	}
 }
 
 @include bp(large-up) {
-
-  /* equal height cards for desktop, visually push a div to the bottom of it's container */
-  .equalheight {
-    overflow: hidden;
-  }
-
-  .equalheight .push-to-bottom-desktop {
-    height: 100%;
+	/* equal height cards for desktop, visually push a div to the bottom of it's container */
+	.equalheight {
+		overflow: hidden;
 	}
 
-  .row {
-    .gutter {
-      &.large-4 {
-        width: 32%;
-        margin-left: 2%;
-      }
-      &.large-6{
-        width: 48.5%;
-        margin-left: 3%;
-      }
-      &:first-child {
-        margin-left: 0;
-      }
-    }
-  }
+	.equalheight .push-to-bottom-desktop {
+		height: 100%;
+	}
+
+	.row {
+		.gutter {
+			&.large-4 {
+				width: 32%;
+				margin-left: 2%;
+			}
+			&.large-6 {
+				width: 48.5%;
+				margin-left: 3%;
+			}
+			&:first-child {
+				margin-left: 0;
+			}
+		}
+	}
 }
 
 // PDQ summary list styling ported from InnerPage.scss
 .contentzone {
-  .PDQ-list {
-    padding-left: 0;
+	.PDQ-list {
+		padding-left: 0;
 
-    li {
-      background-image: none;
-      margin-left: 0;
-      padding-left: 0;
+		li {
+			background-image: none;
+			margin-left: 0;
+			padding-left: 0;
 
-      &::before {
-        content: none;
-      }
-    }
+			&::before {
+				content: none;
+			}
+		}
 
-    ul {
-      margin-left: 0;
-      margin-top: 3px;
-      padding-left: 20px;
+		ul {
+			margin-left: 0;
+			margin-top: 3px;
+			padding-left: 20px;
 
-      > li {
-        display: inline;
+			> li {
+				display: inline;
 
-        &::before {
-          content: "|";
-          float: none;
-          padding-left: 20px;
-          padding-right: 5px;
-          top: 0;
-        }
+				&::before {
+					content: '|';
+					float: none;
+					padding-left: 20px;
+					padding-right: 5px;
+					top: 0;
+				}
 
-        &:first-child::before {
-          content: none;
-          display: none;
-        }
-      }
-    }
-  }
+				&:first-child::before {
+					content: none;
+					display: none;
+				}
+			}
+		}
+	}
 }
 
 // controls spacing of images on the nci organization page. Mark Cramer [OCEPROJECT-3322]
 .nci-organization {
-  .large-5 figure {
-    margin: 1.25em auto;
-  }
+	.large-5 figure {
+		margin: 1.25em auto;
+	}
 
-  .nci-organization__pattern {
-    display: flex;
-    height: 230px;
+	.nci-organization__pattern {
+		display: flex;
+		height: 230px;
 
-    &:hover, &:active, &:focus {
-      text-decoration: none;
-    }
+		&:hover,
+		&:active,
+		&:focus {
+			text-decoration: none;
+		}
 
-    span {
-      margin: 20px;
-      font-size: 1.8rem;
-      font-weight: bold;
-      line-height: 1.3em;
-      color: #fff;
-      font-family: $montserrat-font-stack;
-    }
+		span {
+			margin: 20px;
+			font-size: 1.8rem;
+			font-weight: bold;
+			line-height: 1.3em;
+			color: #fff;
+			font-family: $montserrat-font-stack;
+		}
 
-    @include bp(small) {
-      span {
-        font-size: 2.1em;
-      }
-    }
+		@include bp(small) {
+			span {
+				font-size: 2.1em;
+			}
+		}
 
-    @include bp(xtra-small) {
-
-      span {
-        font-size: 8vw;
-      }
-    }
-  }
+		@include bp(xtra-small) {
+			span {
+				font-size: 8vw;
+			}
+		}
+	}
 }
 /********************* END Mini Landing Page Styles ******************************************/
 
-// Override .cgdpl paragraph styles for image caption
-// These fonts are overridden by the cgdpl
-// wrapper otherwise
-.cgdp-image__caption {
-	@include u-font('sans', '2xs');
-	line-height: line-height($theme-body-font-family, $theme-body-line-height);
-}
-.cgdp-image__credit {
-	@include u-font('sans', '3xs');
-}
-.cgdp-image__enlarge {
-	@include u-font('sans', '2xs');
-	line-height: line-height($theme-body-font-family, $theme-body-line-height);
-}
+// Override wrapper styles for embedded images
+// (Specifically the figure and caption/credit/enlarge styles
+@import '../../legacy/transition-hacks/inner-page-embed-image-hack';

--- a/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/front-end/src/entrypoints/press-release/press-release-legacy.scss
+++ b/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/front-end/src/entrypoints/press-release/press-release-legacy.scss
@@ -6,22 +6,10 @@
 // Expose USWDS variables and mixins to our imports.
 @use 'uswds-core' as *;
 
-@import "../../legacy/styles/variables";
+@import '../../legacy/styles/variables';
 @import '../../legacy/styles/breakpoint-mixins';
-@import "~Styles/sprites/svg-sprite";
+@import '~Styles/sprites/svg-sprite';
 
-// Override .cgdpl paragraph styles for image caption
-// These fonts are overridden by the cgdpl
-// wrapper otherwise
-.cgdp-image__caption {
-	@include u-font('sans', '2xs');
-	line-height: line-height($theme-body-font-family, $theme-body-line-height);
-}
-.cgdp-image__credit {
-	@include u-font('sans', '3xs');
-}
-.cgdp-image__enlarge {
-	@include u-font('sans', '2xs');
-	line-height: line-height($theme-body-font-family, $theme-body-line-height);
-}
-
+// Override wrapper styles for embedded images
+// (Specifically the figure and caption/credit/enlarge styles
+@import '../../legacy/transition-hacks/inner-page-embed-image-hack';

--- a/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/front-end/src/entrypoints/video/video-legacy.scss
+++ b/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/front-end/src/entrypoints/video/video-legacy.scss
@@ -5,20 +5,9 @@
 // Expose USWDS variables and mixins to our imports.
 @use 'uswds-core' as *;
 
-@import "../../legacy/styles/variables";
+@import '../../legacy/styles/variables';
 @import '../../legacy/styles/breakpoint-mixins';
 
-// Override .cgdpl paragraph styles for image caption
-// These fonts are overridden by the cgdpl
-// wrapper otherwise
-.cgdp-image__caption {
-	@include u-font('sans', '2xs');
-	line-height: line-height($theme-body-font-family, $theme-body-line-height);
-}
-.cgdp-image__credit {
-	@include u-font('sans', '3xs');
-}
-.cgdp-image__enlarge {
-	@include u-font('sans', '2xs');
-	line-height: line-height($theme-body-font-family, $theme-body-line-height);
-}
+// Override wrapper styles for embedded images
+// (Specifically the figure and caption/credit/enlarge styles
+@import '../../legacy/transition-hacks/inner-page-embed-image-hack';

--- a/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/front-end/src/legacy/transition-hacks/_inner-page-embed-image-hack.scss
+++ b/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/front-end/src/legacy/transition-hacks/_inner-page-embed-image-hack.scss
@@ -1,0 +1,51 @@
+// Override .cgdpl paragraph styles for image caption
+// These fonts are overridden by the cgdpl
+// wrapper otherwise
+.cgdp-image figure {
+	@include u-margin(0);
+}
+.cgdp-image__caption {
+	@include u-font('sans', '2xs');
+	line-height: line-height($theme-body-font-family, $theme-body-line-height);
+}
+.cgdp-image__credit {
+	@include u-font('sans', '3xs');
+	@include u-margin-y(0);
+	&:not(:only-child) {
+		@include u-margin-top(1);
+	}
+}
+.cgdp-image__credit:only-child() {
+	@include u-margin-top(0);
+}
+.cgdp-image__enlarge {
+	@include u-font('sans', '2xs');
+	line-height: line-height($theme-body-font-family, $theme-body-line-height);
+}
+
+@mixin ImageAlignment() {
+	&.align-right {
+		margin: 0 0 2.5em 2.5em;
+	}
+	&.align-left {
+		margin: 0 2.5em 2.5em 0;
+	}
+	&.align-center {
+		margin: 2.5em auto;
+	}
+}
+
+@media only screen and (min-width: 640px) {
+	.embedded-entity[data-entity-embed-display*='image_display_article_large'] {
+		width: 75% !important;
+		@include ImageAlignment();
+	}
+	.embedded-entity[data-entity-embed-display*='image_display_article_medium'] {
+		width: 40% !important;
+		@include ImageAlignment();
+	}
+	.embedded-entity[data-entity-embed-display*='image_display_article_small'] {
+		width: 25% !important;
+		@include ImageAlignment();
+	}
+}

--- a/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/front-end/src/lib/components/cgdp-field-image-article/index.scss
+++ b/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/front-end/src/lib/components/cgdp-field-image-article/index.scss
@@ -10,4 +10,7 @@
 		@include u-margin-left(4);
 		@include u-margin-bottom(4);
 	}
+	.cgdp-image {
+		@include u-margin-bottom(0);
+	}
 }

--- a/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/front-end/src/lib/components/cgdp-image/index.scss
+++ b/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/front-end/src/lib/components/cgdp-image/index.scss
@@ -16,7 +16,11 @@
 	overflow: hidden;
 	@include u-display('block');
 	@include u-margin-x(0);
-	@include u-margin-y(0);
+	@include u-margin-top(0);
+	@include u-margin-bottom(3);
+	@include at-media('tablet') {
+		@include u-margin-bottom(0);
+	}
 
 	// Image Styles
 	img {


### PR DESCRIPTION
- Updates spacing below embedded images on mobile to be 24px (previously there was no space on mobile)
- Updates lead/embedded image captions to have consistent spacing between caption, credit, and enlarge button for both lead images as well as embedded images (previously there was bonus spacing below credits for embedded images)

- Closes #4731 
- Closes #4735  