### PR TITLE
(#4788, #4790) Glossifier Fixes

### DIFF
--- a/docroot/modules/custom/nci_definition/js/ckeditor5_plugins/glossifier/src/glossifyactioncommand.js
+++ b/docroot/modules/custom/nci_definition/js/ckeditor5_plugins/glossifier/src/glossifyactioncommand.js
@@ -100,8 +100,18 @@ export default class GlossifyActionCommand extends Command {
    * @param {HTMLElement} contents the html of the suggestions
    */
   _setModalContentsToSuggestions(contents) {
+
     this.modalContents.replaceChildren();
-    this.modalContents.appendChild(contents);
+
+    // Why are the contents HTMLElement instead of a string you
+    // might wonder? Well that is because a checkbox's state
+    // of being checked is not serialized as part of innerText.
+    // Because createHtmlFromSuggestions adds a wrapping <div>
+    // to hold all the contents (which could be actually
+    // multiple <p> tags and the like) we need to extract the
+    // child nodes here, or we end up adding extra <div>
+    // elements wrapping the WYSIWYG contents.
+    this.modalContents.replaceChildren(...contents.childNodes);
     this.buttonContents.replaceChildren();
 
     const saveBtn = document.createElement('button')

--- a/docroot/modules/custom/nci_definition/js/ckeditor5_plugins/glossifier/src/glossifyediting.js
+++ b/docroot/modules/custom/nci_definition/js/ckeditor5_plugins/glossifier/src/glossifyediting.js
@@ -19,6 +19,12 @@ export default class GlossifyEditing extends Plugin {
     this._defineDataDowncast(conversion);
     this._preventLinksInDefinitions(conversion);
 
+    // Register nci-definition as an inline object so that <nci-definition>s are
+    // correctly recognized as inline elements in editing pipeline.
+    // This prevents converting spaces around definitions to `&nbsp;`s.
+    this.editor.data.htmlProcessor.domConverter.inlineObjectElements.push('nci-definition');
+    this.editor.editing.view.domConverter.inlineObjectElements.push('nci-definition');
+
     this.editor.commands.add(
       'glossifyAction',
       new GlossifyActionCommand(this.editor),


### PR DESCRIPTION

Biggest thing here is that for #4790 I had to change the return of html as a string instead of HTMLElement, which needed a number of unit test updates. In hindsight, maybe it was a hint that the expected output actually had an additional `<div>` wrapping the contents from the input. 😃 

Other than that, for #4788, the fix was an undocumented thing you need to do with inline widgets that someone else encountered in issue 17275 in https://github.com/ckeditor/ckeditor5/issues. Our fix is to just add the element name to the list of inline elements instead of needing a whole matcher. (`<nci-definition>` only has one use, and it is this, and the tag name is not shared with any other elements.)

Closes #4788 
Closes #4790 