### PR TITLE
(#4759) phpstan fixes for cgov_core and utilities.

### DIFF
--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.module
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.module
@@ -27,7 +27,9 @@ use Drupal\field\Entity\FieldConfig;
 use Drupal\node\NodeInterface;
 use Drupal\path_alias\PathAliasInterface;
 use Drupal\redirect\Entity\Redirect;
+use Drupal\user\UserInterface;
 use Drupal\views\Plugin\views\query\QueryPluginBase;
+use Drupal\views\Plugin\views\query\Sql;
 use Drupal\views\ViewExecutable;
 
 /**
@@ -119,6 +121,7 @@ function cgov_core_node_access(NodeInterface $node, $op, AccountInterface $accou
       $entityTypeManager = \Drupal::service('entity_type.manager');
       $workflows = $entityTypeManager->getStorage('workflow')->loadMultiple();
       $workflow = $workflows['editorial_workflow'];
+      /** @var \Drupal\content_moderation\Plugin\WorkflowType\ContentModerationInterface */
       $typePlugin = $workflow->getTypePlugin();
       if (!$typePlugin->appliesToEntityTypeAndBundle('node', $node->bundle())) {
         break;
@@ -219,7 +222,7 @@ function _cgov_core_text_filter_modify($form_element) {
  * When a user is initially created, default the preferred
  * language for the UI pages to English.
  */
-function cgov_core_user_presave(EntityInterface $entity) {
+function cgov_core_user_presave(UserInterface $entity) {
   if ($entity->isNew() && empty($entity->preferred_admin_langcode->value)) {
     $entity->set('preferred_admin_langcode', 'en');
   }
@@ -322,7 +325,10 @@ function cgov_core_media_view_alter(array &$build, EntityInterface $entity, Enti
  */
 function cgov_core_views_query_alter(ViewExecutable $view, QueryPluginBase $query) {
   $view_id = $view->id();
-  if ($view_id === 'moderated_media') {
+  if (
+    $view_id === 'moderated_media' &&
+    $query instanceof Sql
+  ) {
     foreach ($query->where as &$condition_group) {
       foreach ($condition_group['conditions'] as &$condition) {
         if ($condition['field'] === '.bundle') {
@@ -452,7 +458,7 @@ function cgov_core_language_switch_links_alter(array &$links, $type, Url $url) {
 
   foreach ($remaining_langs as $lang) {
     $translation = $entity->getTranslation($lang);
-    if (!$translation->isPublished()) {
+    if ($translation instanceof EntityPublishedInterface && !$translation->isPublished()) {
       unset($links[$lang]);
     }
   }
@@ -814,6 +820,7 @@ function cgov_core_taxonomy_term_access($entity, $operation, $account) {
  */
 function _cgov_core_get_term_refs_from_field($tid, $vid) {
   $entities = [];
+  $map = [];
 
   $entity_reference_fields = [];
   $field_map = \Drupal::service('entity_field.manager')->getFieldMap();

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.services.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.services.yml
@@ -48,6 +48,7 @@ services:
       - { name: path_processor_outbound, priority: 600 }
   cgov_core.config_overrider:
     class: Drupal\cgov_core\CgovConfigOverrider
+    arguments: [!service_closure '@entity_type.bundle.info']
     tags:
       - {name: config.factory.override, priority: 5}
   cgov_core.route_subscriber:

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/CgovConfigOverrider.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/CgovConfigOverrider.php
@@ -5,11 +5,33 @@ namespace Drupal\cgov_core;
 use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Config\ConfigFactoryOverrideInterface;
 use Drupal\Core\Config\StorageInterface;
+use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * CgovConfigOverrider - Overrides configurations for cgov_core.
  */
 class CgovConfigOverrider implements ConfigFactoryOverrideInterface {
+
+  /**
+   * The container for accessing needed services.
+   */
+  protected ContainerInterface $serviceContainer;
+
+  /**
+   * Closure for getting the entity type bundle info service.
+   */
+  protected \Closure $entityTypeBundleInfo;
+
+  /**
+   * Constructs a new CgovConfigOverrider.
+   *
+   * @param \Closure $entityTypeBundleInfo
+   *   Closure for getting the entity type bundle info service.
+   */
+  public function __construct(\Closure $entityTypeBundleInfo) {
+    $this->entityTypeBundleInfo = $entityTypeBundleInfo;
+  }
 
   /**
    * {@inheritdoc}
@@ -18,38 +40,31 @@ class CgovConfigOverrider implements ConfigFactoryOverrideInterface {
     $overrides = [];
     // Editorial Workflow for all node types & non-image media items.
     if (in_array('workflows.workflow.editorial_workflow', $names)) {
-      // phpcs:disable
-      $content_types = \Drupal::service('entity_type.bundle.info')->getBundleInfo('node');
-      // phpcs:enable
+      $content_types = $this->getBundleInfoService()->getBundleInfo('node');
       foreach ($content_types as $type => $info) {
         if (strpos($type, 'cgov_') !== FALSE) {
           $overrides['workflows.workflow.editorial_workflow']['type_settings']['entity_types']['node'][] = $type;
         }
       }
 
-      // phpcs:disable
-      $media_types = \Drupal::service('entity_type.bundle.info')->getBundleInfo('media');
-      // phpcs:enable
+      $media_types = $this->getBundleInfoService()->getBundleInfo('media');
       foreach ($media_types as $type => $info) {
         if (strpos($type, 'cgov_') !== FALSE && strpos($type, '_image') === FALSE) {
           $overrides['workflows.workflow.editorial_workflow']['type_settings']['entity_types']['media'][] = $type;
         }
       }
     }
+
     // Simple Workflow is only for Custom Block Types and Images.
     if (in_array('workflows.workflow.simple_workflow', $names)) {
-      // phpcs:disable
-      $custom_block_types = \Drupal::service('entity_type.bundle.info')->getBundleInfo('block_content');
-      // phpcs:enable
+      $custom_block_types = $this->getBundleInfoService()->getBundleInfo('block_content');
       foreach ($custom_block_types as $type => $info) {
         // Do not check for a prefix for block content as all block_content
         // should follow the simple workflow.
         $overrides['workflows.workflow.simple_workflow']['type_settings']['entity_types']['block_content'][] = $type;
       }
 
-      // phpcs:disable
-      $media_types = \Drupal::service('entity_type.bundle.info')->getBundleInfo('media');
-      // phpcs:enable
+      $media_types = $this->getBundleInfoService()->getBundleInfo('media');
       foreach ($media_types as $type => $info) {
         // Only check for image media items.
         if (strpos($type, 'cgov_') !== FALSE && strpos($type, '_image') !== FALSE) {
@@ -79,6 +94,19 @@ class CgovConfigOverrider implements ConfigFactoryOverrideInterface {
    */
   public function createConfigObject($name, $collection = StorageInterface::DEFAULT_COLLECTION) {
     return NULL;
+  }
+
+  /**
+   * Wrapper for retrieving the entity type bundle info service.
+   *
+   * This isn't strictly necessary, but it gets us a bit more declared type
+   * information versus using the closure directly.
+   *
+   * @return \Drupal\Core\Entity\EntityTypeBundleInfoInterface
+   *   The entity type bundle info service.
+   */
+  protected function getBundleInfoService() : EntityTypeBundleInfoInterface {
+    return ($this->entityTypeBundleInfo)();
   }
 
 }

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_event/src/Controller/ICalendarController.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_event/src/Controller/ICalendarController.php
@@ -98,14 +98,18 @@ class ICalendarController extends ControllerBase {
     $end_date = NULL;
 
     if ($node->hasField('field_event_start_date') && !empty($node->get('field_event_start_date')->first())) {
-      // Convert the date to the Timezone of the user requesting.
-      $start_date = $node->field_event_start_date->date->format(
+      // Retrieve date value and convert to the necessary format.
+      /** @var \Drupal\Core\TypedData\Plugin\DataType\DateTimeIso8601 */
+      $date_value = $node->get('field_event_start_date')->first()->get('value');
+      $start_date = $date_value->getDateTime()->format(
         'Y-m-d H:i:s'
       );
     }
 
     if ($node->hasField('field_event_end_date') && !empty($node->get('field_event_end_date')->first())) {
-      $end_date = $node->field_event_end_date->date->format(
+      /** @var \Drupal\Core\TypedData\Plugin\DataType\DateTimeIso8601 */
+      $date_value = $node->get('field_event_end_date')->first()->get('value');
+      $end_date = $date_value->getDateTime()->format(
         'Y-m-d H:i:s'
       );
     }
@@ -124,8 +128,8 @@ class ICalendarController extends ControllerBase {
       ->setDtStart(new \DateTime($start_date, new \DateTimeZone('UTC')))
       ->setDtEnd(new \DateTime($end_date, new \DateTimeZone('UTC')))
       ->setSummary($node->getTitle())
-      ->setLocation($node->field_city_state->value)
-      ->setDescription($node->field_page_description->value);
+      ->setLocation($node->get('field_city_state')->value)
+      ->setDescription($node->get('field_page_description')->value);
 
     // 4. Add Event to Calendar.
     $vCalendar->addComponent($vEvent);

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_mail/src/Controller/MailAPIController.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_mail/src/Controller/MailAPIController.php
@@ -8,7 +8,9 @@ namespace Drupal\cgov_mail\Controller;
  */
 
 use Drupal\Component\Utility\EmailValidatorInterface;
+use Drupal\Core\Config\Config;
 use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\ImmutableConfig;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Mail\MailManagerInterface;
 use Drupal\Core\Messenger\MessengerTrait;
@@ -28,38 +30,28 @@ class MailAPIController extends ControllerBase {
 
   /**
    * The email validator service.
-   *
-   * @var \Drupal\Component\Utility\EmailValidatorInterface
    */
-  protected $emailValidator;
+  protected EmailValidatorInterface $emailValidator;
 
   /**
    * The mail manager service.
-   *
-   * @var \Drupal\Core\Mail\MailManagerInterface
    */
-  protected $mailManager;
+  protected MailManagerInterface $mailManager;
 
   /**
    * Configuration object for cgov_mail.settings.
-   *
-   * @var \Drupal\Core\Config\EditableConfigInterface
    */
-  protected $cgovMailConfig;
+  protected ImmutableConfig $cgovMailConfig;
 
   /**
    * The current user account.
-   *
-   * @var \Drupal\Core\Session\AccountInterface
    */
-  protected $account;
+  protected AccountInterface $account;
 
   /**
    * The mail plugin.
-   *
-   * @var \Drupal\Core\Config\EditableConfigInterface
    */
-  protected $mailPlugin;
+  protected Config $mailPlugin;
 
   /**
    * {@inheritdoc}
@@ -109,6 +101,7 @@ class MailAPIController extends ControllerBase {
     $error_p = FALSE;
 
     $data = $request->request->all();
+    $recaptchaResponseField = '';
     foreach ($data as $key => $value) {
       switch ($key) {
         case 'submit.x':

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_site_section/src/Controller/CgovMegaMenuController.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_site_section/src/Controller/CgovMegaMenuController.php
@@ -62,8 +62,8 @@ class CgovMegaMenuController extends ControllerBase {
   public function getMegaMenu(?TermInterface $taxonomy_term = NULL) {
     $field_yaml_content = [];
     // Make sure the field_ncids_mega_menu_contents is not empty.
-    if ($taxonomy_term->field_ncids_mega_menu_contents->target_id) {
-      $field_ncids_mega_menu_block_id = $taxonomy_term->field_ncids_mega_menu_contents->target_id;
+    if ($taxonomy_term->get('field_ncids_mega_menu_contents')->target_id) {
+      $field_ncids_mega_menu_block_id = $taxonomy_term->get('field_ncids_mega_menu_contents')->target_id;
       $field_ncids_mega_menu_block = $this->entityTypeManager->getStorage('block_content')->load($field_ncids_mega_menu_block_id);
 
       // Make sure the field_ncids_mega_menu_block is published.

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -16,9 +16,6 @@ parameters:
     ## The following paths should be removed as each module is remediated
     ### custom modules
     ### cgov_site Profile Modules
-    - docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.module
-    - docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/CgovConfigOverrider.php
-    - docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/CgovCoreTools.php
     - docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Controller/CgovMediaController.php
     - docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/NavItem.php
     - docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Plugin/Block/Breadcrumb.php
@@ -26,16 +23,13 @@ parameters:
     - docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Plugin/Block/MainNav.php
     - docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Plugin/Block/SectionNav.php
     - docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Services/CgovNavigationManager.php
-    - docroot/profiles/custom/cgov_site/modules/custom/cgov_event/src/Controller/ICalendarController.php
     - docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/cgov_home_landing.module
     - docroot/profiles/custom/cgov_site/modules/custom/cgov_image/cgov_image.module
     - docroot/profiles/custom/cgov_site/modules/custom/cgov_infographic/cgov_infographic.module
     - docroot/profiles/custom/cgov_site/modules/custom/cgov_list/cgov_list.module
-    - docroot/profiles/custom/cgov_site/modules/custom/cgov_mail/src/Controller/MailAPIController.php
     - docroot/profiles/custom/cgov_site/modules/custom/cgov_schema_org/cgov_schema_org.module
     - docroot/profiles/custom/cgov_site/modules/custom/cgov_schema_org/src/Plugin/Field/FieldType/CgovSchemaOrgFieldItem.php
     - docroot/profiles/custom/cgov_site/modules/custom/cgov_schema_org/src/Plugin/Field/FieldWidget/CgovSchemaOrgWidget.php
-    - docroot/profiles/custom/cgov_site/modules/custom/cgov_site_section/src/Controller/CgovMegaMenuController.php
       # To be remediated as part of https://github.com/nciocpl/cgov-digital-platform/issues/4815
     - docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/src/OrphanCleanup.php
 
@@ -82,8 +76,15 @@ parameters:
       ## This ignore is for the deprecated CacheDecoratorInterface module.
       message: "#Usage of deprecated trait Symfony\\\\Component\\\\DependencyInjection\\\\ContainerAwareTrait in class#"
       reportUnmatched: false
+    -
+      # This ignore is for the specific weirdness in CgovVocabManagerForm.php where properties are set in
+      # loadTermsByStubs() that are not part of TermInterface.
+      message: "#Access to an undefined property Drupal\\\\taxonomy\\\\TermInterface::\\$(parents|depth)#"
+      reportUnmatched: false
+      paths:
+        - docroot/profiles/custom/cgov_site/modules/custom/cgov_vocab_manager/src/Form/CgovVocabManagerForm.php
 
-    ## With php 8.2+, various magic properties are reported as errors; that aren't reported with php 8.1.
+    ## With php 8.2+, some magic properties are reported as errors that aren't reported with php 8.1.
     ## phpstan complains when a line is marked to be ignored but doesn't cause an error, so we have
     ## to ignore them here and make appropriate changes when we get to php 8.4 / Drupal 11.
     -
@@ -92,14 +93,13 @@ parameters:
       paths:
         - docroot/modules/custom/app_module/src/AppPathManager.php
     -
-      message: "#Access to an undefined property Drupal\\\\node\\\\NodeInterface::\\$moderation_state.#"
+      message: "#Access to an undefined property Drupal\\\\node\\\\NodeInterface::\\$moderation_state#"
       reportUnmatched: false
       paths:
         - docroot/profiles/custom/cgov_site/modules/custom/pdq_core/src/Plugin/rest/resource/PDQResource.php
+        - docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.module
     -
-      # This is for the specific weirdness in CgovVocabManagerForm.php where properties are set in
-      # loadTermsByStubs() that are not part of TermInterface.
-      message: "#Access to an undefined property Drupal\\\\taxonomy\\\\TermInterface::\\$(parents|depth)#"
+      message: "#Access to an undefined property Drupal\\\\user\\\\UserInterface::\\$preferred_admin_langcode.#"
       reportUnmatched: false
       paths:
-        - docroot/profiles/custom/cgov_site/modules/custom/cgov_vocab_manager/src/Form/CgovVocabManagerForm.php
+        - docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.module


### PR DESCRIPTION
- cgov_core.module
  - Add type hints and checks.
  - More specific type on cgov_core_user_presave
  - Initialize variables.
- CgovConfigOverrider.php
  - Refactor to use dependency injection.
- CgovCoreTools.php
  - Add type hints.
- ICalendarController.php
  - Replace magic properties with explicit methods.
  - Refactor date retrieval to allow type hinting of the DateTimeIso8601 plugin.
  - Fix date "conversion" comment to say what it actually does.
- MailAPIController
  - Fix type declarations to  use real types.
  - Replace property type annotations with declarations.
  - Guarantee variable initialization.
- CgovMegaMenuController
  - Replace magic properties with explicit methods.

Closes #4759 
