### PR TITLE
(#4761) phpstan fixes for taxonomy and site sections.

### DIFF
--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_site_section/cgov_site_section.module
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_site_section/cgov_site_section.module
@@ -5,12 +5,14 @@
  * The Cgov Site Section module file.
  */
 
+use Drupal\block_content\Entity\BlockContent;
 use Drupal\cgov_site_section\FieldStorageDefinition;
 use Drupal\Core\Cache\Cache;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Field\FieldDefinition;
 use Drupal\Core\Url;
+use Drupal\node\Entity\Node;
 use Drupal\taxonomy\Entity\Term;
 
 /**
@@ -45,7 +47,7 @@ function cgov_site_section_entity_bundle_field_info(EntityTypeInterface $entity_
  * field 'computed_path'. 'computed_path' consists of the parents terms path
  *  and this terms Pretty URL Field.
  */
-function cgov_site_section_taxonomy_term_presave(EntityInterface $entity) {
+function cgov_site_section_taxonomy_term_presave(Term $entity) {
   // Only do the following for site sections.
   if ($entity->bundle() !== 'cgov_site_sections') {
     return;
@@ -100,25 +102,26 @@ function cgov_site_section_taxonomy_term_presave(EntityInterface $entity) {
 }
 
 /**
- * Implements hook_ENTITY_TYPE_update().
+ * Implements hook_entity_update().
  */
 function cgov_site_section_entity_update(EntityInterface $entity) {
   /*
-   * If this is a node or media item and has changed its section parent or
+   * If this is a node and has changed its section parent or
    * alias, if it displays in navigation, cascade those changes
    *  to any subsections and pages within those subsections.
    *
    */
-  if (
-    $entity->getEntityTypeId() === 'node' &&
-    $entity->hasField('field_site_section')
-  ) {
+  if ($entity instanceof Node && $entity->hasField('field_site_section')) {
     // Check for moderation state AFTER determining its a node instead
     // of before due to https://www.drupal.org/project/wbm2cm/issues/3042445.
     $current_entity_lang = $entity->get('langcode')->value;
     $translated_entity = $entity->getTranslation($current_entity_lang);
     $current_state = $translated_entity->get('moderation_state')->value;
-    $justArchived = ($current_state === "archived" && ($current_state != $translated_entity->original->moderation_state->value));
+
+    // Stupid hack because phpstan doesn't know the translation is a node.
+    /** @var \Drupal\node\Entity\Node */
+    $originalTranslation = $translated_entity->original;
+    $justArchived = ($current_state === "archived" && ($current_state != $originalTranslation->moderation_state->value));
     if (($justArchived) || ($current_state === 'published' && _cgov_site_section_will_trigger_cache_tag_invalidation($entity))) {
       // Find the Sections where this node is a landing page.
       // Invalidate their cache to account for the nodes new alias.
@@ -184,17 +187,20 @@ function cgov_site_section_entity_update(EntityInterface $entity) {
  * If a mega menu block is updated then clean out the
  * mega-menu-block cache tag.
  */
-function cgov_site_section_block_content_update(EntityInterface $entity) {
+function cgov_site_section_block_content_update(BlockContent $entity) {
 
   if ($entity->bundle() !== 'ncids_mega_menu_content') {
     return;
   }
 
+  // Stupid hack because phpstan doesn't know the original's type.
+  /** @var \Drupal\block_content\Entity\BlockContent */
+  $original = $entity->original;
   // Make sure to clear out the mega-menu-block cache tag
   // if the block status is updated OR
   // if the field_yaml_content data is updated.
-  if (($entity->original->status->value !== $entity->status->value) ||
-    ($entity->original->field_yaml_content->value !== $entity->field_yaml_content->value)) {
+  if (($original->status->value !== $entity->status->value) ||
+    ($entity->original->get('field_yaml_content')->value !== $entity->get('field_yaml_content')->value)) {
     // Clear out the mega-menu-block cache tag.
     Cache::invalidateTags(['mega-menu-block:' . $entity->id()]);
   }
@@ -208,7 +214,7 @@ function cgov_site_section_block_content_update(EntityInterface $entity) {
  * then we need to cascade those changes to any subsections and
  * pages within those subsections.
  */
-function cgov_site_section_taxonomy_term_update(EntityInterface $entity) {
+function cgov_site_section_taxonomy_term_update(Term $entity) {
 
   // Only do this for site sections. In the future if there is
   // a vocabulary in which we attach site_section for managing its node's
@@ -277,7 +283,7 @@ function cgov_site_section_taxonomy_term_update(EntityInterface $entity) {
 
   // Make sure to clear out the mega-menu-section cache tag
   // if the field_ncids_mega_menu_contents data is updated.
-  if ($entity->original->field_ncids_mega_menu_contents->target_id !== $entity->field_ncids_mega_menu_contents->target_id) {
+  if ($entity->original->get('field_ncids_mega_menu_contents')->target_id !== $entity->get('field_ncids_mega_menu_contents')->target_id) {
     Cache::invalidateTags(['mega-menu-section:' . $entity->id()]);
   }
 
@@ -296,8 +302,14 @@ function cgov_site_section_taxonomy_term_update(EntityInterface $entity) {
  *   The sections IDs to cache tag clear.
  */
 function _cgov_site_section_get_sections_to_clear(EntityInterface $section_entity) {
+
+  // Exit early if called for anything other than a node or taxonomy term.
+  if (!$section_entity instanceof Node && !$section_entity instanceof Term) {
+    return [];
+  }
+
   // Get the current set of section IDs that display this item.
-  // Includes this term itself if its a nav root.
+  // Includes this term itself if it's a nav root.
   $sectionsToClear = _cgov_site_section_get_rendering_sections($section_entity);
 
   // If this section changed parents, or visibility, invalidate
@@ -315,47 +327,10 @@ function _cgov_site_section_get_sections_to_clear(EntityInterface $section_entit
   // If this section changed from being a section nav root to not,
   // we need to invalidate pages having its old section nav root ID.
   if (isset($section_entity->original)) {
-    if ($section_entity->field_section_nav_root->value == 0 &&
-      $section_entity->original->field_section_nav_root->value == 1) {
+    if ($section_entity->get('field_section_nav_root')->value == 0 &&
+      $section_entity->original->get('field_section_nav_root')->value == 1) {
       $sectionsToClear[] = $section_entity->id();
     }
-  }
-
-  // De-dupe the IDs.
-  $sectionsToClear = array_unique($sectionsToClear);
-
-  return $sectionsToClear;
-}
-
-/**
- * Returns the set of sections IDs to clear for a given mpbile nav update.
- *
- * @param \Drupal\Core\Entity\EntityInterface $section_entity
- *   The section being updated.
- *
- * @return array
- *   The mobile nav IDs to cache tag clear.
- */
-function _cgov_site_section_get_mobile_nav_to_clear(EntityInterface $section_entity) {
-  // Get the current set of section IDs that display this item.
-  // Includes this term itself if its a nav root.
-  $sectionsToClear = _cgov_site_section_get_rendering_sections($section_entity);
-
-  // If this section changed parents, or visibility, invalidate
-  // the cache tags for the original rendering sections as well.
-  if (_cgov_site_section_entity_fields_modified([
-    'parent',
-    'field_navigation_display_options',
-  ], $section_entity)) {
-    $originalRenderingSections = _cgov_site_section_get_rendering_sections($section_entity->original);
-    $sectionsToClear = array_merge($sectionsToClear, $originalRenderingSections);
-  }
-
-  // If this section changed from being a section nav root to not,
-  // we need to invalidate pages having its old section nav root ID.
-  if ($section_entity->field_main_nav_root->value == 0 &&
-    $section_entity->original->field_main_nav_root->value == 1) {
-    $sectionsToClear[] = $section_entity->id();
   }
 
   // De-dupe the IDs.
@@ -466,16 +441,9 @@ function _cgov_site_section_will_trigger_save_children(EntityInterface $updated_
  */
 function _cgov_site_section_will_trigger_cache_tag_invalidation(EntityInterface $updated_entity) {
 
-  $entityType = $updated_entity->getEntityTypeId();
-
-  // Exit early for Media items.
-  if ($entityType === 'media') {
-    return FALSE;
-  }
-
   $values = [];
   // Invalidation check for Nodes.
-  if ($entityType === 'node') {
+  if ($updated_entity instanceof Node) {
     // Exit early if this entity doesn't have site sections.
     if (!$updated_entity->hasField('field_site_section')|| empty($updated_entity->get('field_site_section')->first())) {
       return FALSE;
@@ -517,11 +485,13 @@ function _cgov_site_section_will_trigger_cache_tag_invalidation(EntityInterface 
   }
 
   // Invalidation Check for Site Sections.
-  if ($entityType === 'taxonomy_term' &&
-    $updated_entity->bundle() == 'cgov_site_sections') {
+  if ($updated_entity instanceof Term && $updated_entity->bundle() === 'cgov_site_sections') {
 
+    // Stupid hack because phpstan doesn't know the original's type.
+    /** @var Drupal\taxonomy\Entity\Term */
+    $originalTerm = $updated_entity->original;
     // Early exit. Yes,trigger a cache invalidation if weight modified.
-    $weightModified = $updated_entity->original->getWeight() !== $updated_entity->getWeight();
+    $weightModified = $originalTerm->getWeight() !== $updated_entity->getWeight();
     if ($weightModified) {
       return TRUE;
     }
@@ -534,13 +504,13 @@ function _cgov_site_section_will_trigger_cache_tag_invalidation(EntityInterface 
 
     // Exit early if this section was previously and is currently hidden.
     // Get the display options for this entity.
-    $displayOptions = $updated_entity->field_navigation_display_options->getValue();
+    $displayOptions = $updated_entity->get('field_navigation_display_options')->getValue();
     $displayOptions = array_column($displayOptions, 'value');
     $isHidden = !empty($displayOptions) ?
       in_array('hide_in_section_nav', $displayOptions) : FALSE;
 
     // Get the display options for the original entity.
-    $originalOptions = $updated_entity->original->field_navigation_display_options->getValue();
+    $originalOptions = $updated_entity->original->get('field_navigation_display_options')->getValue();
     $originalOptions = array_column($originalOptions, 'value');
     $originalIsHidden = !empty($originalOptions)
       ? in_array('hide_in_section_nav', $originalOptions) : FALSE;
@@ -586,33 +556,41 @@ function _cgov_site_section_will_trigger_cache_tag_invalidation(EntityInterface 
  */
 function _cgov_site_section_should_invalidate_mobile_nav(EntityInterface $updated_entity) {
 
+  if (!$updated_entity instanceof Term) {
+    return FALSE;
+  }
+
   $entityType = $updated_entity->getEntityTypeId();
 
   // Invalidation Check for Site Sections.
+  $values = [];
   if ($entityType === 'taxonomy_term' &&
-    $updated_entity->bundle() == 'cgov_site_sections') {
+    $updated_entity->bundle() === 'cgov_site_sections') {
 
+    // Stupid hack because phpstan doesn't know the original's type.
+    /** @var Drupal\taxonomy\Entity\Term */
+    $originalTerm = $updated_entity->original;
     // Early exit. Yes,trigger a cache invalidation if weight modified.
-    $weightModified = $updated_entity->original->getWeight() !== $updated_entity->getWeight();
+    $weightModified = $originalTerm->getWeight() !== $updated_entity->getWeight();
     if ($weightModified) {
       return TRUE;
     }
 
     // Get the field main nav root value.
     $main_nav_root = TRUE;
-    if ($updated_entity->field_main_nav_root->value) {
+    if ($updated_entity->get('field_main_nav_root')->value) {
       $main_nav_root = FALSE;
     }
 
     // Exit early if this section was previously and is currently hidden.
     // Get the display options for this entity.
-    $displayOptions = $updated_entity->field_navigation_display_options->getValue();
+    $displayOptions = $updated_entity->get('field_navigation_display_options')->getValue();
     $displayOptions = array_column($displayOptions, 'value');
     $isHidden = !empty($displayOptions) ?
       in_array('hide_in_mobile_nav', $displayOptions) : FALSE;
 
     // Get the display options for the original entity.
-    $originalOptions = $updated_entity->original->field_navigation_display_options->getValue();
+    $originalOptions = $updated_entity->original->get('field_navigation_display_options')->getValue();
     $originalOptions = array_column($originalOptions, 'value');
     $originalIsHidden = !empty($originalOptions)
       ? in_array('hide_in_mobile_nav', $originalOptions) : FALSE;
@@ -649,6 +627,10 @@ function _cgov_site_section_should_invalidate_mobile_nav(EntityInterface $update
  *   A TRUE or FALSE as to whether the fields were modified.
  */
 function _cgov_site_section_entity_fields_modified(array $fields, EntityInterface $entity) {
+  if (!$entity instanceof Term && !$entity instanceof Node) {
+    // If the entity is not a Term or Node, we cannot check for fields.
+    return FALSE;
+  }
 
   // Exit early if no fields were passed.
   if (empty($fields)) {
@@ -657,10 +639,10 @@ function _cgov_site_section_entity_fields_modified(array $fields, EntityInterfac
   // Store the original entity for comparison.
   $original = $entity->original;
   // If entity status has been modified exit and return true.
-  if (isset($entity->original) && ($entity->status->getString() !== $entity->original->status->getString())) {
+  if ($original !== NULL && ($entity->get('status')->getString() !== $original->get('status')->getString())) {
     return TRUE;
   }
-  if ($entity->original == NULL && $entity->status->getString() == "1") {
+  if ($original === NULL && $entity->get('status')->getString() == "1") {
     return TRUE;
   }
   // Setup closures for comparison functions.
@@ -698,10 +680,11 @@ function _cgov_site_section_entity_fields_modified(array $fields, EntityInterfac
 /**
  * Set the front page if conditions are right.
  *
- * @param \Drupal\Core\Entity\EntityInterface $site_section
+ * @param \Drupal\taxonomy\Entity\Term $site_section
  *   The site section.
  */
-function _cgov_site_section_attempt_set_front_page(EntityInterface $site_section) {
+function _cgov_site_section_attempt_set_front_page(Term $site_section) {
+
   /*
    * If it has no landing page, then we need to exit.
    *
@@ -713,14 +696,14 @@ function _cgov_site_section_attempt_set_front_page(EntityInterface $site_section
    * have an update hook for node checking if it is a landing then updating
    * the section. That is too convoluted.
    */
-  $home_page_id = $site_section->field_landing_page->target_id;
+  $home_page_id = $site_section->get('field_landing_page')->target_id;
   if ($home_page_id === NULL) {
     return;
   }
 
   // Set the front page.
   $config = \Drupal::configFactory()->getEditable('system.site');
-  $front_page = "/node/${home_page_id}";
+  $front_page = "/node/$home_page_id";
   // Only save if we need to change it.
   if ($front_page !== $config->get('page.front')) {
     $config->set('page.front', $front_page)->save();
@@ -838,42 +821,6 @@ function cgov_site_section_views_data() {
   ];
 
   return $data;
-}
-
-/**
- * Returns the Root Nav Section.
- *
- * @param mixed $term
- *   The section term or NULL.
- *
- * @return bool|mixed
- *   The root term or False.
- *
- * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
- * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
- */
-function _cgov_site_section_get_root_nav_section($term) {
-  // Base Case.
-  if (!$term) {
-    return FALSE;
-  }
-
-  // Get the parent, return it if it's the root.
-  $parent = _cgov_site_section_get_section_parent($term);
-  if ($parent) {
-    // Get section nav root value.
-    $isRoot_section_nav = $parent->field_section_nav_root->value ? (int) $parent->field_section_nav_root->value : FALSE;
-    // Get main nav root value.
-    $isRoot_main_nav = $parent->field_main_nav_root->value ? (int) $parent->field_main_nav_root->value : FALSE;
-    if ($isRoot_section_nav || $isRoot_main_nav) {
-      return $parent;
-    }
-  }
-  else {
-    return FALSE;
-  }
-  // If its not the root, recursively call this function.
-  return _cgov_site_section_get_root_nav_section($parent);
 }
 
 /**
@@ -1039,7 +986,8 @@ function cgov_site_section_link_alter(&$variables) {
 /**
  * Implements hook_ENTITY_TYPE_presave().
  */
-function cgov_site_section_block_content_presave(EntityInterface $entity) {
+function cgov_site_section_block_content_presave(BlockContent $entity) {
+  // Limit to the NCIDS Mega Menu Content block type.
   if ($entity->bundle() !== 'ncids_mega_menu_content') {
     return;
   }

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_site_section/cgov_site_section.module.md
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_site_section/cgov_site_section.module.md
@@ -1,0 +1,72 @@
+Call tree for the hooks and their helpers.
+
+
+```mermaid
+graph LR
+  cgov_site_section_entity_field_storage_info
+
+  cgov_site_section_entity_bundle_field_info-->cgov_site_section_entity_field_storage_info
+
+  cgov_site_section_taxonomy_term_presave
+
+  cgov_site_section_entity_update-->_cgov_site_section_will_trigger_cache_tag_invalidation
+  cgov_site_section_entity_update-->_cgov_site_section_get_sections_to_clear
+  cgov_site_section_entity_update-->_cgov_site_section_get_rendering_sections_for_mobile
+  cgov_site_section_entity_update-->_cgov_site_section_invalidate_section_cache_tag
+  cgov_site_section_entity_update-->_cgov_site_section_invalidate_mobile_nav_cache_tag
+
+  cgov_site_section_block_content_update
+
+  cgov_site_section_taxonomy_term_update-->_cgov_site_section_attempt_set_front_page
+  cgov_site_section_taxonomy_term_update-->_cgov_site_section_will_trigger_save_children
+  cgov_site_section_taxonomy_term_update-->_cgov_site_section_save_term_children
+  cgov_site_section_taxonomy_term_update-->_cgov_site_section_will_trigger_cache_tag_invalidation
+  cgov_site_section_taxonomy_term_update-->_cgov_site_section_get_sections_to_clear
+  cgov_site_section_taxonomy_term_update-->_cgov_site_section_invalidate_section_cache_tag
+  cgov_site_section_taxonomy_term_update-->_cgov_site_section_should_invalidate_mobile_nav
+  cgov_site_section_taxonomy_term_update-->_cgov_site_section_get_rendering_sections_for_mobile
+  cgov_site_section_taxonomy_term_update-->_cgov_site_section_invalidate_mobile_nav_cache_tag
+
+
+  _cgov_site_section_get_sections_to_clear-->_cgov_site_section_get_rendering_sections
+  _cgov_site_section_get_sections_to_clear-->_cgov_site_section_entity_fields_modified
+
+  _cgov_site_section_invalidate_section_cache_tag
+
+  _cgov_site_section_invalidate_mobile_nav_cache_tag
+
+  _cgov_site_section_save_term_children
+
+  _cgov_site_section_will_trigger_save_children-->_cgov_site_section_entity_fields_modified
+
+  _cgov_site_section_will_trigger_cache_tag_invalidation-->_cgov_site_section_entity_fields_modified
+
+  _cgov_site_section_should_invalidate_mobile_nav-->_cgov_site_section_entity_fields_modified
+
+  _cgov_site_section_entity_fields_modified
+
+  _cgov_site_section_attempt_set_front_page
+
+  cgov_site_section_entity_presave
+
+  cgov_site_section_entity_type_build
+
+  cgov_site_section_entity_bundle_field_info_alter
+
+  cgov_site_section_views_data
+
+  _cgov_site_section_get_rendering_sections-->_cgov_site_section_get_term_tree
+
+  _cgov_site_section_get_rendering_sections_for_mobile-->_cgov_site_section_get_term_tree
+
+  _cgov_site_section_get_term_tree-->_cgov_site_section_get_section_parent
+
+  _cgov_site_section_get_section_parent
+
+  cgov_site_section_link_alter
+
+  cgov_site_section_block_content_presave
+
+
+
+```

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_site_section/cgov_site_section.tokens.inc
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_site_section/cgov_site_section.tokens.inc
@@ -64,6 +64,7 @@ function cgov_site_section_tokens($type, $tokens, array $data, array $options, B
         }
 
         if (!empty($entity->get('field_site_section')->first())) {
+          $tid = NULL;
           try {
             $tid = $entity->get('field_site_section')->first()->getValue()['target_id'];
             $term = Term::load($tid);
@@ -166,7 +167,7 @@ function _get_taxonomy_field_token(array $data, $fieldname) {
  *   Node object.
  */
 function _get_valid_parent($alias) {
-  if (!isset($alias) || trim($alias) === '') {
+  if ($alias === NULL || trim($alias) === '') {
     return NULL;
   }
 

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_site_section/src/Controller/CgovNavTreeController.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_site_section/src/Controller/CgovNavTreeController.php
@@ -51,12 +51,12 @@ class CgovNavTreeController extends ControllerBase {
 
     // If this is not a section nav root we need to return a 400.
     // We do this check here to avoid any more data fetches for an error.
-    if (!$taxonomy_term->field_section_nav_root->value) {
+    if (!$taxonomy_term->get('field_section_nav_root')->value) {
       return $this->getEmpty400Response();
     }
 
     // Fetch the tree.
-    $depth = $taxonomy_term->field_levels_to_display->value ?? 5;
+    $depth = $taxonomy_term->get('field_levels_to_display')->value ?? 5;
     $tree_root = $this->getNavData($taxonomy_term, $menu_type, $depth);
 
     if ($tree_root !== NULL) {
@@ -78,7 +78,7 @@ class CgovNavTreeController extends ControllerBase {
 
     // If this is not a main nav root we need to return a 400.
     // We do this check here to avoid any more data fetches for an error.
-    if (!$taxonomy_term->field_main_nav_root->value) {
+    if (!$taxonomy_term->get('field_main_nav_root')->value) {
       return $this->getEmpty400Response();
     }
 
@@ -153,7 +153,7 @@ class CgovNavTreeController extends ControllerBase {
 
     // Note: this just loads the entity in the default language.
     /** @var \Drupal\node\NodeInterface */
-    $landing_page = $term->field_landing_page->entity;
+    $landing_page = $term->get('field_landing_page')->entity;
 
     if ($landing_page) {
       $langcode = $this->languageManager()->getCurrentLanguage()->getId();
@@ -218,7 +218,7 @@ class CgovNavTreeController extends ControllerBase {
       'id' => $pruned_parent_branch[0]->id(),
       // So we prefer main nav over section, and if we have a node then it must
       // be one of the two. So the ternary works here.
-      'menu_type' => $pruned_parent_branch[0]->field_main_nav_root->value ? 'mobile-nav' : 'section-nav',
+      'menu_type' => $pruned_parent_branch[0]->get('field_main_nav_root')->value ? 'mobile-nav' : 'section-nav',
     ];
 
     $closest_node = $pruned_parent_branch[array_key_last($pruned_parent_branch) ?? 0];
@@ -240,13 +240,13 @@ class CgovNavTreeController extends ControllerBase {
     // 4. Make the nav item.
     $parent_link_nav_item = [
       'id' => $parent_link_node->id(),
-      'langcode' => $parent_link_node->langcode->value,
-      'label' => $parent_link_node->field_navigation_label->value ?? $parent_link_node->getName(),
-      'weight' => $parent_link_node->weight->value,
+      'langcode' => $parent_link_node->get('langcode')->value,
+      'label' => $parent_link_node->get('field_navigation_label')->value ?? $parent_link_node->getName(),
+      'weight' => $parent_link_node->get('weight')->value,
       'path' => $path,
       'navigation_display_options' => $display_options,
-      'is_section_nav_root' => (bool) $parent_link_node->field_section_nav_root->value ?? FALSE,
-      'is_main_nav_root' => (bool) $parent_link_node->field_main_nav_root->value ?? FALSE,
+      'is_section_nav_root' => (bool) $parent_link_node->get('field_section_nav_root')->value ?? FALSE,
+      'is_main_nav_root' => (bool) $parent_link_node->get('field_main_nav_root')->value ?? FALSE,
       'children' => [],
     ];
 
@@ -291,13 +291,13 @@ class CgovNavTreeController extends ControllerBase {
     // Make the NavItem data for the parent term.
     $nav_item = [
       'id' => $taxonomy_term->id(),
-      'langcode' => $taxonomy_term->langcode->value,
-      'label' => $taxonomy_term->field_navigation_label->value ?? $taxonomy_term->getName(),
-      'weight' => $taxonomy_term->weight->value,
+      'langcode' => $taxonomy_term->get('langcode')->value,
+      'label' => $taxonomy_term->get('field_navigation_label')->value ?? $taxonomy_term->getName(),
+      'weight' => $taxonomy_term->get('weight')->value,
       'path' => $path,
       'navigation_display_options' => $this->getNavigationDisplayOptions($taxonomy_term),
-      'is_section_nav_root' => (bool) $taxonomy_term->field_section_nav_root->value ?? FALSE,
-      'is_main_nav_root' => (bool) $taxonomy_term->field_main_nav_root->value ?? FALSE,
+      'is_section_nav_root' => (bool) $taxonomy_term->get('field_section_nav_root')->value ?? FALSE,
+      'is_main_nav_root' => (bool) $taxonomy_term->get('field_main_nav_root')->value ?? FALSE,
       'children' => $children,
     ];
 
@@ -348,13 +348,13 @@ class CgovNavTreeController extends ControllerBase {
       // 4. Make the nav item.
       $nav_item = [
         'id' => $child_term->id(),
-        'langcode' => $child_term->langcode->value,
-        'label' => $child_term->field_navigation_label->value ?? $child_term->getName(),
-        'weight' => $child_term->weight->value,
+        'langcode' => $child_term->get('langcode')->value,
+        'label' => $child_term->get('field_navigation_label')->value ?? $child_term->getName(),
+        'weight' => $child_term->get('weight')->value,
         'path' => $path,
         'navigation_display_options' => $display_options,
-        'is_section_nav_root' => (bool) $child_term->field_section_nav_root->value ?? FALSE,
-        'is_main_nav_root' => (bool) $child_term->field_main_nav_root->value ?? FALSE,
+        'is_section_nav_root' => (bool) $child_term->get('field_section_nav_root')->value ?? FALSE,
+        'is_main_nav_root' => (bool) $child_term->get('field_main_nav_root')->value ?? FALSE,
         'children' => $children,
       ];
 
@@ -385,7 +385,7 @@ class CgovNavTreeController extends ControllerBase {
     $parent_term = $this->getParentTerm($term);
     while ($parent_term !== NULL) {
       $ancestry[] = $parent_term;
-      $isNavRoot = ($parent_term->field_main_nav_root->value || $parent_term->field_section_nav_root->value);
+      $isNavRoot = ($parent_term->get('field_main_nav_root')->value || $parent_term->get('field_section_nav_root')->value);
       // If we found the next nav root, then stop fetching.
       $parent_term = $isNavRoot ? NULL : $this->getParentTerm($parent_term);
     }
@@ -395,7 +395,7 @@ class CgovNavTreeController extends ControllerBase {
 
     if (
       $branch[0] === $term ||
-      !($branch[0]->field_main_nav_root->value || $branch[0]->field_section_nav_root->value)
+      !($branch[0]->get('field_main_nav_root')->value || $branch[0]->get('field_section_nav_root')->value)
     ) {
       // Basically, there is no other term in the ancestry that is the root.
       return [];
@@ -405,12 +405,12 @@ class CgovNavTreeController extends ControllerBase {
 
     // No term *should* be a main nav root and a section nav root. When they
     // are, the mobile nav takes precedence.
-    if ($branch[0]->field_main_nav_root->value) {
+    if ($branch[0]->get('field_main_nav_root')->value) {
       $max_depth = (theme_get_setting('mobile_levels_to_display', 'cgov_common') ?? 4) + 1;
       $pruned_branch = $this->pruneBranch($branch, 'mobile_nav', $max_depth);
     }
-    elseif ($branch[0]->field_section_nav_root->value) {
-      $max_depth = $branch[0]->field_levels_to_display->value ?? 5;
+    elseif ($branch[0]->get('field_section_nav_root')->value) {
+      $max_depth = $branch[0]->get('field_levels_to_display')->value ?? 5;
       $pruned_branch = $this->pruneBranch($branch, 'section_nav', $max_depth);
     }
 
@@ -479,6 +479,8 @@ class CgovNavTreeController extends ControllerBase {
       /** @var \Drupal\taxonomy\TermInterface */
       return $parents[array_keys($parents)[0]];
     }
+
+    return NULL;
   }
 
 }

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_vocab_manager/src/Manager/CgovVocabManager.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_vocab_manager/src/Manager/CgovVocabManager.php
@@ -22,8 +22,8 @@ class CgovVocabManager {
   /**
    * Generates a rendered breadcrumb that print taxonomy hiererchy levels.
    */
-  public function getTaxonomyBreadcrumb(int $parent_tid, TermStorageInterface $storageController, RendererInterface $renderer) {
-    if (!isset($parent_tid) || !$parent_tid) {
+  public function getTaxonomyBreadcrumb(?int $parent_tid, TermStorageInterface $storageController, RendererInterface $renderer) {
+    if ($parent_tid === NULL) {
       return;
     }
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -35,12 +35,7 @@ parameters:
     - docroot/profiles/custom/cgov_site/modules/custom/cgov_schema_org/cgov_schema_org.module
     - docroot/profiles/custom/cgov_site/modules/custom/cgov_schema_org/src/Plugin/Field/FieldType/CgovSchemaOrgFieldItem.php
     - docroot/profiles/custom/cgov_site/modules/custom/cgov_schema_org/src/Plugin/Field/FieldWidget/CgovSchemaOrgWidget.php
-    - docroot/profiles/custom/cgov_site/modules/custom/cgov_site_section/cgov_site_section.module
-    - docroot/profiles/custom/cgov_site/modules/custom/cgov_site_section/cgov_site_section.tokens.inc
     - docroot/profiles/custom/cgov_site/modules/custom/cgov_site_section/src/Controller/CgovMegaMenuController.php
-    - docroot/profiles/custom/cgov_site/modules/custom/cgov_site_section/src/Controller/CgovNavTreeController.php
-    - docroot/profiles/custom/cgov_site/modules/custom/cgov_vocab_manager/src/Form/CgovVocabManagerForm.php
-    - docroot/profiles/custom/cgov_site/modules/custom/cgov_vocab_manager/src/Manager/CgovVocabManager.php
       # To be remediated as part of https://github.com/nciocpl/cgov-digital-platform/issues/4815
     - docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/src/OrphanCleanup.php
 
@@ -88,7 +83,7 @@ parameters:
       message: "#Usage of deprecated trait Symfony\\\\Component\\\\DependencyInjection\\\\ContainerAwareTrait in class#"
       reportUnmatched: false
 
-    ## With php 8.2+, various magic properties are reported as errors; this doesn't occur with php 8.1.
+    ## With php 8.2+, various magic properties are reported as errors; that aren't reported with php 8.1.
     ## phpstan complains when a line is marked to be ignored but doesn't cause an error, so we have
     ## to ignore them here and make appropriate changes when we get to php 8.4 / Drupal 11.
     -
@@ -101,3 +96,10 @@ parameters:
       reportUnmatched: false
       paths:
         - docroot/profiles/custom/cgov_site/modules/custom/pdq_core/src/Plugin/rest/resource/PDQResource.php
+    -
+      # This is for the specific weirdness in CgovVocabManagerForm.php where properties are set in
+      # loadTermsByStubs() that are not part of TermInterface.
+      message: "#Access to an undefined property Drupal\\\\taxonomy\\\\TermInterface::\\$(parents|depth)#"
+      reportUnmatched: false
+      paths:
+        - docroot/profiles/custom/cgov_site/modules/custom/cgov_vocab_manager/src/Form/CgovVocabManagerForm.php


### PR DESCRIPTION
- CgovNaveTreeController.php
  - Replace magic properties with get().
- CgovVocabManager.php
  - Make parent_id nullable in getTaxonomyBreadcrumb(), to match caller.
- CgovVocabManagerForm.php
  - Enable phpcs scanning.
  - Populate docblock for getTreeArgs().
  - buildForm(), define $complete_tree and do simple TRUE/FALSE vs. isset().
  - Numerous formatting changes.
- CgovVocabManagerForm
  - Reorder constructor parameters to put optional parameters at the end.
  - buildForm(): make parameters explicitly nullable.
  - @phpstan-ignore for properties added to TermInterface when objects are loaded.
- getParentNavInfo.php
  - Retrieve fields via explicit get().
  - Specify NULL return from getParentTerm() when no parent found.
- cgov_site_section.tokens.inc
  - Initialize variable regardless of path.
  - Replace isset() for required variable with explicit NULL check.
- cgov_site_section.module
  - Create a call tree document (cgov_site_section.module.md)
  - Add type checks to bundle checks.
  - Replace magic properties with get().
  - Assure variables initialized on all paths.
  - Remove unused functions
    - _cgov_site_section_get_mobile_nav_to_clear
    - _cgov_site_section_get_root_nav_section

Closes #4761