### PR TITLE
(#4815) Fix PDQ phpstan issues

### DIFF
--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/src/OrphanCleanup.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/src/OrphanCleanup.php
@@ -4,6 +4,7 @@ namespace Drupal\pdq_cancer_information_summary;
 
 use Drupal\Core\Database\Connection;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Entity\RevisionableStorageInterface;
 
 /**
  * Service for clearing out orphan summary sections.
@@ -73,6 +74,9 @@ class OrphanCleanup {
 
     // Find orphaned paragraph entities.
     $storage = $this->entityTypeManager->getStorage('paragraph');
+    if (!$storage instanceof RevisionableStorageInterface) {
+      throw new \LogicException('Paragraph storage must implement RevisionableStorageInterface.');
+    }
     $query = $this->connection->select('paragraphs_item', 'p');
     $query->fields('p', ['id']);
     $query->condition('p.type', 'pdq_summary_section');
@@ -123,7 +127,6 @@ class OrphanCleanup {
       }
       $results = $query->execute();
       foreach ($results as $result) {
-        $entity = $storage->load($paragraph_id);
         $storage->deleteRevision($result->revision_id);
         $dropped[$result->id][] = (int) $result->revision_id;
       }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -41,8 +41,6 @@ parameters:
     - docroot/profiles/custom/cgov_site/modules/custom/cgov_site_section/src/Controller/CgovNavTreeController.php
     - docroot/profiles/custom/cgov_site/modules/custom/cgov_vocab_manager/src/Form/CgovVocabManagerForm.php
     - docroot/profiles/custom/cgov_site/modules/custom/cgov_vocab_manager/src/Manager/CgovVocabManager.php
-      # To be remediated as part of https://github.com/nciocpl/cgov-digital-platform/issues/4815
-    - docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/src/OrphanCleanup.php
 
   ignoreErrors:
     ## NOTE: Each rule needs reportUnmatched so that PHPStan does not report unmatched rules


### PR DESCRIPTION
In pdq_cancer_information_summary/src/OrphanCleanup.php:
 - remove line of code inadvertently copied from another method
 - reassure PHP (and phpstan) that we have the the right interface for invoking deleteRevision()

Closes #4815