### PR TITLE
(#4946) Update Deployability Test to Use Base

### DIFF
--- a/.github/workflows/test-deployability.yml
+++ b/.github/workflows/test-deployability.yml
@@ -3,15 +3,11 @@ name: Test Ability to Deploy
 on:
   push:
     branches:
-      - master
-      - main
       - develop
       - 'hotfix/**'
       - 'release/**'
       - 'feature/**'
       - 'prototype/**'
-    tags:
-      - '*'
     paths:
       # IMPORTANT: Changes to these file specs must, Must, MUST  be reflected in the file specs
       # for pull_request and the check_for_past_run job.
@@ -58,11 +54,18 @@ jobs:
 
     steps:
 
-      ## Checkout the master branch since that is what is currently on production.
-      - name: Checkout master branch from Github
+      ## Checkout the target branch if a PR, or the master branch if it is a push.
+      ## The idea being that a PR targeting some branch does not need to test all
+      ## of the install hooks in the commits between master and the specific PR.
+      ##
+      ## Really this is a YAML issue as we normally would remove content in the
+      ## same PR that removes the feature. The install from master installs old
+      ## content and then Drupal update hooks prevent the removal of configs
+      ## because they are in use.
+      - name: Checkout target or main branch from Github
         uses: actions/checkout@v3
         with:
-          ref: master
+            ref: ${{ github.event_name == 'pull_request' && github.base_ref || 'master' }}
 
       ## Setup PHP and Composer Caching
       - name: Setup PHP with tools


### PR DESCRIPTION
Closes #4946

Workflow ( this PR ) run that used develop as the base: https://github.com/NCIOCPL/cgov-digital-platform/actions/runs/17590750317/job/49970674538#step:3:472
Workflow ( [prototype/test-4946-check-master](https://github.com/NCIOCPL/cgov-digital-platform/tree/refs/heads/prototype/test-4946-check-master) ) run that used master as the base: https://github.com/NCIOCPL/cgov-digital-platform/actions/runs/17590285123/job/49969154535#step:3:472