### PR TITLE
(#4758, #3331, #4958) Create dummy purger for local development

### DIFF
--- a/blt/blt.yml
+++ b/blt/blt.yml
@@ -32,7 +32,8 @@ modules:
         dblog,
         devel,
         views_ui,
-        cgov_yaml_content
+        cgov_yaml_content,
+        cgov_dummy_purger
       ]
     uninstall:
       [

--- a/blt/src/Blt/Plugin/Commands/SlevenCommands.php
+++ b/blt/src/Blt/Plugin/Commands/SlevenCommands.php
@@ -57,6 +57,13 @@ class SlevenCommands extends BltTasks {
     ];
 
     $this->invokeCommands($commands);
+
+    // Empty the purge queue at the end.
+    $task = $this->taskDrush()
+      ->drush('p-queue-empty')
+      ->printOutput(TRUE);
+    $result = $task->interactive(FALSE)->run();
+    return $result;
   }
 
   /**

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/CgovPurgeConfigInstaller.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/CgovPurgeConfigInstaller.php
@@ -29,6 +29,7 @@ class CgovPurgeConfigInstaller {
     'acquia_purge' => '8813de186f',
     'akamai_tag' => 'bf950143a3',
     'akamai' => '08153881ce',
+    'cgov_dummy_purger' => '7b9c54ef95',
   ];
 
   /**

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_dummy_purger/cgov_dummy_purger.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_dummy_purger/cgov_dummy_purger.info.yml
@@ -1,0 +1,12 @@
+name: CGov Dummy Purger
+type: module
+description: Dummy purger for local development.
+core_version_requirement: ^10 || ^11
+package: Purge - reverse proxies & CDNs
+dependencies:
+  - purge
+  - purge_drush
+  - purge_processor_cron
+  - purge_processor_lateruntime
+  - purge_queuer_coretags
+  - purge_ui

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_dummy_purger/cgov_dummy_purger.install
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_dummy_purger/cgov_dummy_purger.install
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * @file
+ * Contains cgov_dummy_purger.install.
+ */
+
+use Drupal\cgov_core\CgovPurgeConfigInstaller;
+
+/**
+ * Implements hook_install().
+ */
+function cgov_dummy_purger_install() {
+
+  // Uninstall the cdn modules as those have separate purge configs.
+  \Drupal::service('module_installer')->uninstall(['cgov_caching_cdn']);
+  \Drupal::service('module_installer')->uninstall(['cgov_caching_nocdn']);
+
+  // Set config.
+  $config_factory = \Drupal::service('config.factory');
+  $config_installer = new CgovPurgeConfigInstaller($config_factory);
+  $config_installer->installPurgeConfiguration(['cgov_dummy_purger']);
+}

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_dummy_purger/cgov_dummy_purger.services.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_dummy_purger/cgov_dummy_purger.services.yml
@@ -1,0 +1,5 @@
+services:
+  logger.channel.cgov_dummy_purger:
+    class: Drupal\Core\Logger\LoggerChannel
+    arguments: ['cgov_dummy_purger']
+    factory: ['@logger.factory', 'get']

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_dummy_purger/src/Plugin/Purge/Purger/CgovDummyPurger.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_dummy_purger/src/Plugin/Purge/Purger/CgovDummyPurger.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Drupal\cgov_dummy_purger\Plugin\Purge\Purger;
+
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\purge\Plugin\Purge\Invalidation\InvalidationInterface;
+use Drupal\purge\Plugin\Purge\Purger\PurgerBase;
+use Drupal\purge\Plugin\Purge\Purger\PurgerInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Dummy Purger for tags, urls, and everything. Logs purge requests only.
+ *
+ * @PurgePurger(
+ *   id = "cgov_dummy_purger",
+ *   label = @Translation("CGOV Dummy Purger"),
+ *   description = @Translation("A dummy purger that logs purge requests for tags, urls, and everything."),
+ *   types = {"tag", "url", "everything"},
+ *   multi_instance = FALSE
+ * )
+ */
+class CgovDummyPurger extends PurgerBase implements PurgerInterface, ContainerFactoryPluginInterface {
+
+  /**
+   * Logger for debugging output to not conflict with purge.
+   */
+  protected LoggerInterface $dummyPurgeLogger;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, LoggerInterface $logger) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->dummyPurgeLogger = $logger;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('logger.channel.cgov_dummy_purger')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function routeTypeToMethod($type) {
+    // All types use the invalidate method.
+    return 'invalidate';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function invalidate(array $invalidations): void {
+    if (empty($invalidations)) {
+      return;
+    }
+
+    $type = $invalidations[0]->getPluginId();
+    $expressions = array_map(static function ($inv) {
+      return $inv->getExpression();
+    }, $invalidations);
+
+    $this->dummyPurgeLogger->info(
+      'Received invalidation for {type} with: {expressions}',
+      [
+        'type' => $type,
+        'expressions' => implode(', ', $expressions),
+      ]
+    );
+
+    foreach ($invalidations as $invalidation) {
+      $invalidation->setState(InvalidationInterface::SUCCEEDED);
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function hasRuntimeMeasurement(): bool {
+    return FALSE;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getTimeHint(): float {
+    return 1.0;
+  }
+
+}

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_site_section/cgov_site_section.module
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_site_section/cgov_site_section.module
@@ -353,9 +353,6 @@ function _cgov_site_section_invalidate_section_cache_tag($section_id) {
       'nav_api_section_nav:' . $section_id,
     ];
     Cache::invalidateTags($section_cache_ids);
-    \Drupal::logger('cgov_site_section')
-      ->notice('Invalidated Cache Tag for Site Section with tid: ' .
-        $section_id);
   }
 }
 
@@ -372,9 +369,6 @@ function _cgov_site_section_invalidate_mobile_nav_cache_tag($section_id) {
       'nav_api_mobile_nav:' . $section_id,
     ];
     Cache::invalidateTags($section_cache_ids);
-    \Drupal::logger('cgov_site_section')
-      ->notice('Invalidated Cache Tag for mobile nav with tid: ' .
-        $section_id);
   }
 }
 


### PR DESCRIPTION
Creates the dummy purger and install it on local development:
Closes #4758 

Now that local development supports purging we can clear the purge queue after content install:
Closes #3331 

The dummy purger will log out these purge requests on local development, so we don't need the log statement:
Closes #4958 