### PR TITLE
(#5094) Fix block browser perms on update

### DIFF
--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_embedded_block/cgov_embedded_block.install
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_embedded_block/cgov_embedded_block.install
@@ -6,6 +6,7 @@
  */
 
 use Drupal\cgov_core\CgovCoreTools;
+use Drupal\Core\Entity\Entity\EntityViewMode;
 
 /**
  * Implements hook_install().
@@ -41,9 +42,37 @@ function _cgov_embedded_block_install_permissions(CgovCoreTools $siteHelper) {
 }
 
 /**
- * The most recent update hook.
+ * Add permissions for the new content block browser.
  */
 function cgov_embedded_block_update_10001() {
+
+  // We need to call features to install new content block browser config
+  // in order to grant the permission to admin ui. Unfortunately, we cannot
+  // do that until after the view mode for the legacy highchart block content
+  // type is created. It seems like features/Drupal is not smart enough to
+  // see the dependency in the browser config on the view mode existing and
+  // load it first. So we create the view mode here first.
+  $view_mode = $view_mode = EntityViewMode::create([
+    'id' => 'block_content.legacy_highchart',
+    'targetEntityType' => 'block_content',
+    'label' => 'Legacy Highchart',
+    'status' => TRUE,
+    'cache' => TRUE,
+  ]);
+  $view_mode->save();
+
+  // Just creating and saving is not good enough, we have to clear out caches
+  // or else we STILL get an error.
+  drupal_flush_all_caches();
+
+  // Import the configs to so that the entity browser gets
+  // installed. The permission will not exist until the browser
+  // is installed.
+  $service = \Drupal::service('features.manager');
+  $assigner = \Drupal::service('features_assigner');
+  $assigner->assignConfigPackages();
+  $service->import(['cgov_embedded_block']);
+
   // Get our helper.
   $siteHelper = \Drupal::service('cgov_core.tools');
   $perms = [

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_embedded_block/config/install/embed.button.insert_content_block_content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_embedded_block/config/install/embed.button.insert_content_block_content.yml
@@ -3,6 +3,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.block_content.full
+    - core.entity_view_mode.block_content.legacy_highchart
     - entity_browser.browser.content_block_raw_html_browser
   module:
     - block_content

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_external_link_block/cgov_external_link_block.install
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_external_link_block/cgov_external_link_block.install
@@ -33,9 +33,17 @@ function cgov_external_link_block_install() {
 }
 
 /**
- * The most recent update hook.
+ * Add permissions for the new external link block browser.
  */
-function cgov_external_link_update_10001() {
+function cgov_external_link_block_update_10001() {
+  // Import the configs to so that the entity browser gets
+  // installed. The permission will not exist until the browser
+  // is installed.
+  $service = \Drupal::service('features.manager');
+  $assigner = \Drupal::service('features_assigner');
+  $assigner->assignConfigPackages();
+  $service->import(['cgov_external_link_block']);
+
   // Get our helper.
   $siteHelper = \Drupal::service('cgov_core.tools');
   $perms = [


### PR DESCRIPTION
This one was a PITA. Drupal/Features could not handle the config dependencies for the new view mode for highcharts and the browser for raw html blocks. It took may tries to get it working.

- The browser configs need to be loaded before permissions can be set. So the update hooks for the new content block and external link browsers were updated to install the configs first.
- insert_content_block_content was missing a dependency on the view_mode config for legacy_highcharts..
- cgov_external_link_block update hook was not named correctly.

Closes #5094

**Testing** 

@andyvanavery31 
- Can you insert a new external link
- Can you insert  content block
- Can you edit using the pencil to update an existing piece of content

@NCIOCPL/qa-team 
- Automated tests