### PR TITLE
(#5144) Temporary Fix for oversized response headers

### DIFF
--- a/docroot/sites/default/settings/default.local.settings.php
+++ b/docroot/sites/default/settings/default.local.settings.php
@@ -17,6 +17,7 @@ use Acquia\Drupal\RecommendedSettings\Helpers\EnvironmentDetector;
 
 // Use development service parameters.
 $settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/development.services.yml';
+$settings['container_yamls'][] = EnvironmentDetector::getRepoRoot() . '/docroot/sites/nci.development.services.yml';
 
 // Allow access to update.php.
 $settings['update_free_access'] = TRUE;

--- a/docroot/sites/nci.development.services.yml
+++ b/docroot/sites/nci.development.services.yml
@@ -1,0 +1,20 @@
+# Local development services.
+#
+# The development.services.yml file allows the developer to override
+# container parameters for debugging.
+#
+# To activate this feature, follow the instructions at the top of the
+# 'example.settings.local.php' file, which sits next to this file.
+#
+# Be aware that in Drupal's configuration system, all the files that
+# provide container definitions are merged using a shallow merge approach
+# within \Drupal\Core\DependencyInjection\YamlFileLoader.
+# This means that if you want to override any value of a parameter, the
+# whole parameter array needs to be copied from
+# sites/default/default.services.yml or from core/core.services.yml file.
+parameters:
+  http.response.debug_cacheability_headers: false
+  twig.config:
+    debug: true
+    auto_reload: true
+    cache: false


### PR DESCRIPTION
Closes #5144

Testing Steps:
- checkout this branch
- Copy `default.local.settings.php` to your `local.settings.php` ([teams message](https://teams.microsoft.com/l/message/19:e6cc84fe036a4bbb8d9253d250b9ccf6@thread.tacv2/1771532556441?tenantId=14b77578-9773-42d5-8507-251ca2dc2b06&groupId=3191b19c-2b21-434c-b3cb-a59199f6b174&parentMessageId=1771429159823&teamName=NCI-OCPL%20PS%20Team&channelName=DP%20Development&createdTime=1771532556441) for more detailed steps)
- `drush cr`
- Should be able to visit the links below without a HTTP 500 error


Testing Links:
- http://cgdp-ddev.ddev.site/admin/structure/types/manage/cgov_application_page/fields
- http://cgdp-ddev.ddev.site/admin/structure/types/manage/cgov_article/fields
- http://cgdp-ddev.ddev.site/admin/structure/types/manage/cgov_biography/fields
- http://cgdp-ddev.ddev.site/admin/structure/types/manage/cgov_blog_post/fields
- http://cgdp-ddev.ddev.site/admin/structure/types/manage/cgov_blog_series/fields
- http://cgdp-ddev.ddev.site/admin/structure/types/manage/cgov_cancer_center/fields
- http://cgdp-ddev.ddev.site/admin/structure/types/manage/cgov_cancer_research/fields
- http://cgdp-ddev.ddev.site/admin/structure/types/manage/cgov_cthp/fields
- http://cgdp-ddev.ddev.site/admin/structure/types/manage/cgov_event/fields
- http://cgdp-ddev.ddev.site/admin/structure/types/manage/cgov_home_landing/fields
- http://cgdp-ddev.ddev.site/admin/structure/types/manage/cgov_mini_landing/fields
- http://cgdp-ddev.ddev.site/admin/structure/types/manage/pdq_cancer_information_summary/fields
- http://cgdp-ddev.ddev.site/admin/structure/types/manage/cgov_press_release/fields