### PR TITLE
(#3462) Fix Spanish event date localization

### DIFF
--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_event/cgov_event.install
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_event/cgov_event.install
@@ -141,3 +141,25 @@ function cgov_event_update_10001() {
   }
 
 }
+
+/**
+ * Add cgov_event date formats for localized date display.
+ */
+function cgov_event_update_10002() {
+  $formats = [
+    'cgov_event_date_long' => ['label' => 'Cgov Event Date Long', 'pattern' => 'F j, Y'],
+    'cgov_event_date_short' => ['label' => 'Cgov Event Date Short', 'pattern' => 'F j'],
+    'cgov_event_time' => ['label' => 'Cgov Event Time', 'pattern' => 'g:i A'],
+  ];
+
+  $storage = \Drupal::entityTypeManager()->getStorage('date_format');
+  foreach ($formats as $id => $data) {
+    if (!$storage->load($id)) {
+      $storage->create([
+        'id' => $id,
+        'label' => $data['label'],
+        'pattern' => $data['pattern'],
+      ])->save();
+    }
+  }
+}

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_event/config/install/core.date_format.cgov_event_date_long.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_event/config/install/core.date_format.cgov_event_date_long.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+id: cgov_event_date_long
+label: 'Cgov Event Date Long'
+locked: false
+pattern: 'F j, Y'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_event/config/install/core.date_format.cgov_event_date_short.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_event/config/install/core.date_format.cgov_event_date_short.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+id: cgov_event_date_short
+label: 'Cgov Event Date Short'
+locked: false
+pattern: 'F j'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_event/config/install/core.date_format.cgov_event_time.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_event/config/install/core.date_format.cgov_event_time.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+id: cgov_event_time
+label: 'Cgov Event Time'
+locked: false
+pattern: 'g:i A'

--- a/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/ncids_trans.theme
+++ b/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/ncids_trans.theme
@@ -7,6 +7,7 @@
  * This is copied over from cgov_common.
  */
 
+use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Core\Language\LanguageInterface;
 use Drupal\media\Entity\Media;
 use Drupal\node\Entity\Node;
@@ -230,6 +231,34 @@ function ncids_trans_preprocess_node(&$variables) {
   catch (Exception $e) {
     // If the database is not yet available, set the default value.
     $variables['is_front'] = FALSE;
+  }
+
+  // Pre-format event dates using the current interface language so that month
+  // names are localized. Twig's |date() filter always outputs English.
+  if ($variables['node']->getType() === 'cgov_event') {
+    $node = $variables['node'];
+    $langcode = \Drupal::languageManager()->getCurrentLanguage()->getId();
+    /** @var \Drupal\Core\Datetime\DateFormatterInterface $dateFormatter */
+    $dateFormatter = \Drupal::service('date.formatter');
+
+    $startValue = $node->get('field_event_start_date')->value;
+    $endValue = $node->get('field_event_end_date')->value;
+
+    if ($startValue && $endValue) {
+      $startTs = (new DrupalDateTime($startValue, 'UTC'))->getTimestamp();
+      $endTs = (new DrupalDateTime($endValue, 'UTC'))->getTimestamp();
+
+      $variables['event_start_long'] = $dateFormatter->format($startTs, 'cgov_event_date_long', '', NULL, $langcode);
+      $variables['event_start_short'] = $dateFormatter->format($startTs, 'cgov_event_date_short', '', NULL, $langcode);
+      $variables['event_start_time'] = $dateFormatter->format($startTs, 'cgov_event_time', '', NULL, $langcode);
+      $variables['event_start_date'] = $dateFormatter->format($startTs, 'custom', 'Y-m-d', NULL, $langcode);
+      $variables['event_start_year'] = $dateFormatter->format($startTs, 'custom', 'Y', NULL, $langcode);
+      $variables['event_end_long'] = $dateFormatter->format($endTs, 'cgov_event_date_long', '', NULL, $langcode);
+      $variables['event_end_time'] = $dateFormatter->format($endTs, 'cgov_event_time', '', NULL, $langcode);
+      $variables['event_end_date'] = $dateFormatter->format($endTs, 'custom', 'Y-m-d', NULL, $langcode);
+      $variables['event_end_year'] = $dateFormatter->format($endTs, 'custom', 'Y', NULL, $langcode);
+      $variables['is_all_day_event'] = (bool) $node->get('field_all_day_event')->value;
+    }
   }
 }
 

--- a/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/templates/content/event/node--cgov-event--event-list-item.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/templates/content/event/node--cgov-event--event-list-item.html.twig
@@ -1,10 +1,8 @@
 {% import '@ncids_trans/content_page_macros.twig' as contentPageMacros %}
 <!-- ********************************* BEGIN Page Content ********************************** -->
 
-{% set eventStart = content.field_event_start_date[0]['#attributes']["datetime"] %}
-{% set eventEnd = content.field_event_end_date[0]['#attributes']["datetime"] %}
-{% set isValidEventDate = eventStart|date('Y-m-d') < eventEnd|date('Y-m-d') %}
-{% set isMultiYearEvent = eventStart|date('Y') <  eventEnd|date('Y') %}
+{% set isValidEventDate = event_start_date < event_end_date %}
+{% set isMultiYearEvent = event_start_year < event_end_year %}
 
 <div class="event-list-item">
     {# Title #}
@@ -25,21 +23,21 @@
         <div class="event-date-time">
             {% if isValidEventDate %}
                 {% if isMultiYearEvent %}
-                    {{ eventStart|date('F j, Y') }}
+                    {{ event_start_long }}
                     &ndash;
-                    {{ eventEnd|date('F j, Y') }}
+                    {{ event_end_long }}
                 {% else %}
-                    {{ eventStart|date('F j') }}
+                    {{ event_start_short }}
                     &ndash;
-                    {{ eventEnd|date('F j, Y') }}
+                    {{ event_end_long }}
                 {% endif %}
             {% else %}
-                {{ eventStart|date('F j, Y') }}
-                {% if content.field_all_day_event[0]['#markup'] == "Off" %}
+                {{ event_start_long }}
+                {% if not is_all_day_event %}
                     &vert;
-                    {{ eventStart|date('g:i A') }}
+                    {{ event_start_time }}
                     &ndash;
-                    {{ eventEnd|date('g:i A') }}
+                    {{ event_end_time }}
                 {% endif %}
             {% endif %}
         </div>

--- a/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/templates/content/event/node--cgov-event--event-ncids-collection-condensed.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/templates/content/event/node--cgov-event--event-ncids-collection-condensed.html.twig
@@ -1,4 +1,4 @@
 {% import '@ncids_trans/listing/ncids_list_item_macros.twig' as listItemMacros %}
 
 {## Render List Item ##}
-{{ listItemMacros.ncids_dynamic_list_event_macro(label, content.field_event_start_date, content.field_event_end_date, content.field_list_description, url, content.field_event_series, content.field_all_day_event[0]['#markup'], content.field_venue, content.field_room, content.field_city_state) }}
+{{ listItemMacros.ncids_dynamic_list_event_macro(label, content.field_event_start_date, content.field_event_end_date, content.field_list_description, url, content.field_event_series, is_all_day_event, content.field_venue, content.field_room, content.field_city_state, event_start_long, event_start_short, event_start_time, event_start_date, event_start_year, event_end_long, event_end_time, event_end_date, event_end_year) }}

--- a/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/templates/content/event/node--cgov-event--full.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/templates/content/event/node--cgov-event--full.html.twig
@@ -1,10 +1,8 @@
 {{ attach_library('ncids_trans/event') }}
 {% import '@ncids_trans/content_page_macros.twig' as contentPageMacros %}
 <!-- ********************************* BEGIN Page Content ********************************** -->
-{% set eventStart = content.field_event_start_date[0]['#attributes']["datetime"] %}
-{% set eventEnd = content.field_event_end_date[0]['#attributes']["datetime"] %}
-{% set isValidEventDate = eventStart|date('Y-m-d') < eventEnd|date('Y-m-d') %}
-{% set isMultiYearEvent = eventStart|date('Y') <  eventEnd|date('Y') %}
+{% set isValidEventDate = event_start_date < event_end_date %}
+{% set isMultiYearEvent = event_start_year < event_end_year %}
 
 <article>
 	<h1 class="nci-heading-h1">{{ node.label }}</h1>
@@ -15,21 +13,21 @@
 			<p class="cgdp-event-info__date-time">
 				{% if isValidEventDate %}
 					{% if isMultiYearEvent %}
-						{{ eventStart|date('F j, Y') }}
+						{{ event_start_long }}
 						&ndash;
-						{{ eventEnd|date('F j, Y') }}
+						{{ event_end_long }}
 					{% else %}
-						{{ eventStart|date('F j') }}
+						{{ event_start_short }}
 						&ndash;
-						{{ eventEnd|date('F j, Y') }}
+						{{ event_end_long }}
 					{% endif %}
 				{% else %}
-					{{ eventStart|date('F j, Y') }}
-					{% if content.field_all_day_event[0]['#markup'] == "Off" %}
+					{{ event_start_long }}
+					{% if not is_all_day_event %}
 						&vert;
-						{{ eventStart|date('g:i A') }}
+						{{ event_start_time }}
 						&ndash;
-						{{ eventEnd|date('g:i A') }}
+						{{ event_end_time }}
 					{% endif %}
 				{% endif %}
 			</p>

--- a/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/templates/listing/ncids_list_item_macros.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/templates/listing/ncids_list_item_macros.twig
@@ -66,11 +66,9 @@
   </li>
 {% endmacro %}
 
-{% macro ncids_dynamic_list_event_macro(title, startDate, endDate, description = '', url, series = '', allDay = '', venue = '', room = '', cityState = '') %}
-  {% set eventStart = startDate[0]['#attributes']["datetime"] %}
-  {% set eventEnd = endDate[0]['#attributes']["datetime"] %}
-  {% set isMultiDayEvent = eventStart|date('Y-m-d') < eventEnd|date('Y-m-d') %}
-  {% set isMultiYearEvent = eventStart|date('Y') <  eventEnd|date('Y') %}
+{% macro ncids_dynamic_list_event_macro(title, startDate, endDate, description = '', url, series = '', isAllDay = false, venue = '', room = '', cityState = '', eventStartLong = '', eventStartShort = '', eventStartTime = '', eventStartDate = '', eventStartYear = '', eventEndLong = '', eventEndTime = '', eventEndDate = '', eventEndYear = '') %}
+  {% set isMultiDayEvent = eventStartDate < eventEndDate %}
+  {% set isMultiYearEvent = eventStartYear < eventEndYear %}
   <li class="usa-collection__item">
     <div class="usa-collection__body">
       {# Title #}
@@ -89,21 +87,21 @@
           {# Date/time range #}
           {% if isMultiDayEvent %}
             {% if isMultiYearEvent %}
-              {{ eventStart|date('F j, Y') }}
+              {{ eventStartLong }}
               &ndash;
-              {{ eventEnd|date('F j, Y') }}
+              {{ eventEndLong }}
             {% else %}
-              {{ eventStart|date('F j') }}
+              {{ eventStartShort }}
               &ndash;
-              {{ eventEnd|date('F j, Y') }}
+              {{ eventEndLong }}
             {% endif %}
           {% else %}
-            {{ eventStart|date('F j, Y') }}
-            {% if allDay != "On" %}
+            {{ eventStartLong }}
+            {% if not isAllDay %}
               &vert;
-              {{ eventStart|date('g:i A') }}
+              {{ eventStartTime }}
               &ndash;
-              {{ eventEnd|date('g:i A') }}
+              {{ eventEndTime }}
             {% endif %}
           {% endif %}
           <br />

--- a/docroot/profiles/custom/cgov_site/translations/cgov_site.es.po
+++ b/docroot/profiles/custom/cgov_site/translations/cgov_site.es.po
@@ -14,6 +14,14 @@ msgctxt "PHP date format"
 msgid "F j, Y"
 msgstr "j \\d\\e F \\d\\e Y"
 
+msgctxt "PHP date format"
+msgid "F j"
+msgstr "j \\d\\e F"
+
+msgctxt "PHP date format"
+msgid "g:i A"
+msgstr "g:i A"
+
 msgid "Spanish"
 msgstr "Español"
 


### PR DESCRIPTION
Twig's `|date()` filter always outputs month names in English regardless of the node's language. Pre-format event dates in preprocess using `DateFormatter::format() `with the node's langcode so month names are correctly localized.

Because the fix here is in preprocess_node which runs for all view modes of event content type, once the localized variables became available it wouldn't have been right to not fix the other templates that were using date() so this PR fixes the date issue everywhere event dates are rendered:

- **Full node view:** .node—cgov-event—full.html.twig
- **Event list view mode:** node—cgov-event—event-list-item.html.twig
- **NCIDS condensed collection:** node—cgov-event—event-ncids-collection-condensed-html.twig via the macros

**SCREENSHOT OF SPANISH EVENT DATE**
<img width="488" height="380" alt="image" src="https://github.com/user-attachments/assets/42df251c-faa8-425e-ac24-c60393374cf1" />

Closes #3462