### PR TITLE
(#4880) Update order rules for events

### DIFF
--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_event/config/install/views.view.cgov_events.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_event/config/install/views.view.cgov_events.yml
@@ -627,7 +627,53 @@ display:
             label: ''
             field_identifier: field_event_start_date_value
           exposed: false
+          granularity: minute
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: standard
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
+        created:
+          id: created
+          table: node_field_data
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: created
+          plugin_id: date
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
           granularity: second
+        nid:
+          id: nid
+          table: node_field_data
+          field: nid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: nid
+          plugin_id: standard
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
       filters:
         status:
           id: status
@@ -786,7 +832,53 @@ display:
             label: ''
             field_identifier: field_event_start_date_value
           exposed: false
+          granularity: minute
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: standard
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
+        created:
+          id: created
+          table: node_field_data
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: created
+          plugin_id: date
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
           granularity: second
+        nid:
+          id: nid
+          table: node_field_data
+          field: nid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: nid
+          plugin_id: standard
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
       defaults:
         title: false
         sorts: false
@@ -848,7 +940,53 @@ display:
             label: ''
             field_identifier: field_event_start_date_value
           exposed: false
+          granularity: minute
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: standard
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
+        created:
+          id: created
+          table: node_field_data
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: created
+          plugin_id: date
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
           granularity: second
+        nid:
+          id: nid
+          table: node_field_data
+          field: nid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: nid
+          plugin_id: standard
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
       arguments:
         field_event_group_target_id:
           id: field_event_group_target_id
@@ -1131,7 +1269,53 @@ display:
             label: ''
             field_identifier: field_event_start_date_value
           exposed: false
+          granularity: minute
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: standard
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
+        created:
+          id: created
+          table: node_field_data
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: created
+          plugin_id: date
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
           granularity: second
+        nid:
+          id: nid
+          table: node_field_data
+          field: nid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: nid
+          plugin_id: standard
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
       arguments:
         field_event_group_target_id_1:
           id: field_event_group_target_id_1

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/07000_events_views.content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/07000_events_views.content.yml
@@ -542,9 +542,9 @@
     - value: |
         Group: DCB Series: NCI Event Series
   field_event_start_date:
-    value: '2033-06-15T06:30:00'
+    value: '2040-04-12T06:30:00'
   field_event_end_date:
-    value: '2033-06-15T14:35:00'
+    value: '2040-04-12T14:35:00'
   field_all_day_event: 1
   field_event_group:
     - '#process':


### PR DESCRIPTION
- adds rule to sort alphabetically if dates and times are the same
- adds rule to sort by creation time if dates, times, and titles are all the same
- updates granularity of date / time sort to be to the minute rather than the second for admin user clarity

Closes #4880