### PR TITLE
(#5208) Remove drupal/acsf module and references

### DIFF
--- a/blt/blt.yml
+++ b/blt/blt.yml
@@ -41,7 +41,6 @@ modules:
         syslog,
         acquia_connector,
         shield,
-        acsf,
         seckit,
         cgov_https_config,
         cgov_caching_nocdn,
@@ -152,7 +151,6 @@ modules:
       ]
     uninstall:
       [
-        acsf,
         cgov_caching_nocdn,
       ]
   meostage:
@@ -169,7 +167,6 @@ modules:
       ]
     uninstall:
       [
-        acsf,
         cgov_caching_nocdn,
       ]
   meoprod:
@@ -185,7 +182,6 @@ modules:
       ]
     uninstall:
       [
-        acsf,
         dblog,
         cgov_caching_nocdn,
       ]

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,6 @@
         "cweagans/composer-patches": "^1.7",
         "drupal/acquia_connector": "^4.0",
         "drupal/acquia_purge": "^1.3",
-        "drupal/acsf": "^2.77",
         "drupal/address": "2.0.4",
         "drupal/admin_toolbar": "^3.4",
         "drupal/akamai": "^5.0@RC",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "98a6c323dcc63c303a664ff5ffc9970a",
+    "content-hash": "c570c6e8c5792b3acb9175c67fdfbd09",
     "packages": [
         {
             "name": "acquia/acsf-tools",
@@ -2358,19 +2358,20 @@
         },
         {
             "name": "doctrine/persistence",
-            "version": "4.1.1",
+            "version": "4.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/persistence.git",
-                "reference": "b9c49ad3558bb77ef973f4e173f2e9c2eca9be09"
+                "reference": "49ab73e0d3e2ac8d1f5ecda3dd8acd5503781e8b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/persistence/zipball/b9c49ad3558bb77ef973f4e173f2e9c2eca9be09",
-                "reference": "b9c49ad3558bb77ef973f4e173f2e9c2eca9be09",
+                "url": "https://api.github.com/repos/doctrine/persistence/zipball/49ab73e0d3e2ac8d1f5ecda3dd8acd5503781e8b",
+                "reference": "49ab73e0d3e2ac8d1f5ecda3dd8acd5503781e8b",
                 "shasum": ""
             },
             "require": {
+                "doctrine/deprecations": "^1",
                 "doctrine/event-manager": "^1 || ^2",
                 "php": "^8.1",
                 "psr/cache": "^1.0 || ^2.0 || ^3.0"
@@ -2381,13 +2382,13 @@
                 "phpstan/phpstan-phpunit": "^2",
                 "phpstan/phpstan-strict-rules": "^2",
                 "phpunit/phpunit": "^10.5.58 || ^12",
-                "symfony/cache": "^4.4 || ^5.4 || ^6.0 || ^7.0",
-                "symfony/finder": "^4.4 || ^5.4 || ^6.0 || ^7.0"
+                "symfony/cache": "^4.4 || ^5.4 || ^6.0 || ^7.0 || ^8.0",
+                "symfony/finder": "^4.4 || ^5.4 || ^6.0 || ^7.0 || ^8.0"
             },
             "type": "library",
             "autoload": {
                 "psr-4": {
-                    "Doctrine\\Persistence\\": "src/Persistence"
+                    "Doctrine\\Persistence\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -2431,7 +2432,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/persistence/issues",
-                "source": "https://github.com/doctrine/persistence/tree/4.1.1"
+                "source": "https://github.com/doctrine/persistence/tree/4.2.0"
             },
             "funding": [
                 {
@@ -2447,7 +2448,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-10-16T20:13:18+00:00"
+            "time": "2026-04-26T12:12:52+00:00"
         },
         {
             "name": "dompdf/php-font-lib",
@@ -2634,247 +2635,6 @@
             "homepage": "https://www.drupal.org/project/acquia_purge",
             "support": {
                 "source": "https://git.drupalcode.org/project/acquia_purge"
-            }
-        },
-        {
-            "name": "drupal/acsf",
-            "version": "2.83.0",
-            "source": {
-                "type": "git",
-                "url": "https://git.drupalcode.org/project/acsf.git",
-                "reference": "8.x-2.83"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/acsf-8.x-2.83.zip",
-                "reference": "8.x-2.83",
-                "shasum": "e439720325482196eed2cc4ec16f7cd0c9d07f66"
-            },
-            "require": {
-                "drupal/acsf_theme": "*",
-                "drupal/acsf_variables": "*",
-                "drupal/core": "^8 || ^9 || ^10 || ^11",
-                "ext-json": "*",
-                "symfony/process": "^4|^5|^6|^7.1"
-            },
-            "require-dev": {
-                "acquia/coding-standards": "^1.0",
-                "drupal/acsf_variables": "*",
-                "drupal/samlauth": "^3.3",
-                "phpunit/phpunit": "^9.6.13|^10.5.19",
-                "rector/rector": "dev-main"
-            },
-            "type": "drupal-module",
-            "extra": {
-                "drupal": {
-                    "version": "8.x-2.83",
-                    "datestamp": "1761730072",
-                    "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
-                    }
-                },
-                "branch-alias": {
-                    "dev-8.x-2.x": "2.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Drupal\\acsf\\": "src/"
-                }
-            },
-            "notification-url": "https://packages.drupal.org/8/downloads",
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "Acquia",
-                    "homepage": "https://www.drupal.org/user/1231722",
-                    "email": "support@acquia.com"
-                },
-                {
-                    "name": "acquia.sf.ci",
-                    "homepage": "https://www.drupal.org/user/3285763"
-                },
-                {
-                    "name": "Alan Evans",
-                    "homepage": "https://www.drupal.org/user/14023"
-                },
-                {
-                    "name": "attila.fekete",
-                    "homepage": "https://www.drupal.org/user/762986"
-                },
-                {
-                    "name": "drabik",
-                    "homepage": "https://www.drupal.org/user/928682"
-                },
-                {
-                    "name": "glitchinfinity",
-                    "homepage": "https://www.drupal.org/user/3603140"
-                },
-                {
-                    "name": "nikgregory",
-                    "homepage": "https://www.drupal.org/user/419643"
-                },
-                {
-                    "name": "nishat.baig",
-                    "homepage": "https://www.drupal.org/user/3729641"
-                },
-                {
-                    "name": "roderik",
-                    "homepage": "https://www.drupal.org/user/8841"
-                },
-                {
-                    "name": "Rok Žlender",
-                    "homepage": "https://www.drupal.org/user/61873"
-                }
-            ],
-            "description": "Connects a site with Acquia Cloud Site Factory.",
-            "homepage": "https://www.drupal.org/project/acsf",
-            "support": {
-                "source": "https://git.drupalcode.org/project/acsf"
-            }
-        },
-        {
-            "name": "drupal/acsf_theme",
-            "version": "2.83.0",
-            "require": {
-                "drupal/acsf": "^2",
-                "drupal/acsf_variables": "*",
-                "drupal/core": "^8 || ^9 || ^10 || ^11"
-            },
-            "type": "metapackage",
-            "extra": {
-                "drupal": {
-                    "version": "8.x-2.83",
-                    "datestamp": "1761730072",
-                    "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
-                    }
-                }
-            },
-            "notification-url": "https://packages.drupal.org/8/downloads",
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "acquia",
-                    "homepage": "https://www.drupal.org/user/1231722"
-                },
-                {
-                    "name": "acquia.sf.ci",
-                    "homepage": "https://www.drupal.org/user/3285763"
-                },
-                {
-                    "name": "Alan Evans",
-                    "homepage": "https://www.drupal.org/user/14023"
-                },
-                {
-                    "name": "attila.fekete",
-                    "homepage": "https://www.drupal.org/user/762986"
-                },
-                {
-                    "name": "drabik",
-                    "homepage": "https://www.drupal.org/user/928682"
-                },
-                {
-                    "name": "glitchinfinity",
-                    "homepage": "https://www.drupal.org/user/3603140"
-                },
-                {
-                    "name": "nikgregory",
-                    "homepage": "https://www.drupal.org/user/419643"
-                },
-                {
-                    "name": "nishat.baig",
-                    "homepage": "https://www.drupal.org/user/3729641"
-                },
-                {
-                    "name": "roderik",
-                    "homepage": "https://www.drupal.org/user/8841"
-                },
-                {
-                    "name": "Rok Žlender",
-                    "homepage": "https://www.drupal.org/user/61873"
-                }
-            ],
-            "description": "Handles VCS-based themes on Acquia Cloud Site Factory.",
-            "homepage": "https://www.drupal.org/project/acsf",
-            "support": {
-                "source": "https://git.drupalcode.org/project/acsf"
-            }
-        },
-        {
-            "name": "drupal/acsf_variables",
-            "version": "2.83.0",
-            "require": {
-                "drupal/acsf": "^2",
-                "drupal/core": "^8 || ^9 || ^10 || ^11"
-            },
-            "type": "metapackage",
-            "extra": {
-                "drupal": {
-                    "version": "8.x-2.83",
-                    "datestamp": "1761730072",
-                    "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
-                    }
-                }
-            },
-            "notification-url": "https://packages.drupal.org/8/downloads",
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "acquia",
-                    "homepage": "https://www.drupal.org/user/1231722"
-                },
-                {
-                    "name": "acquia.sf.ci",
-                    "homepage": "https://www.drupal.org/user/3285763"
-                },
-                {
-                    "name": "Alan Evans",
-                    "homepage": "https://www.drupal.org/user/14023"
-                },
-                {
-                    "name": "attila.fekete",
-                    "homepage": "https://www.drupal.org/user/762986"
-                },
-                {
-                    "name": "drabik",
-                    "homepage": "https://www.drupal.org/user/928682"
-                },
-                {
-                    "name": "glitchinfinity",
-                    "homepage": "https://www.drupal.org/user/3603140"
-                },
-                {
-                    "name": "nikgregory",
-                    "homepage": "https://www.drupal.org/user/419643"
-                },
-                {
-                    "name": "nishat.baig",
-                    "homepage": "https://www.drupal.org/user/3729641"
-                },
-                {
-                    "name": "roderik",
-                    "homepage": "https://www.drupal.org/user/8841"
-                },
-                {
-                    "name": "Rok Žlender",
-                    "homepage": "https://www.drupal.org/user/61873"
-                }
-            ],
-            "description": "Stores sensitive variables in a single place for easy scrubbing.",
-            "homepage": "https://www.drupal.org/project/acsf",
-            "support": {
-                "source": "https://git.drupalcode.org/project/acsf"
             }
         },
         {
@@ -7754,16 +7514,16 @@
         },
         {
             "name": "mck89/peast",
-            "version": "v1.17.5",
+            "version": "v1.17.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mck89/peast.git",
-                "reference": "e19a8bd896b7f04941a38fd38a140c9a6531c84f"
+                "reference": "b8b4184b1e6912669f9af155caef9050509d9f18"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mck89/peast/zipball/e19a8bd896b7f04941a38fd38a140c9a6531c84f",
-                "reference": "e19a8bd896b7f04941a38fd38a140c9a6531c84f",
+                "url": "https://api.github.com/repos/mck89/peast/zipball/b8b4184b1e6912669f9af155caef9050509d9f18",
+                "reference": "b8b4184b1e6912669f9af155caef9050509d9f18",
                 "shasum": ""
             },
             "require": {
@@ -7776,7 +7536,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.17.5-dev"
+                    "dev-master": "1.17.6-dev"
                 }
             },
             "autoload": {
@@ -7797,9 +7557,9 @@
             "description": "Peast is PHP library that generates AST for JavaScript code",
             "support": {
                 "issues": "https://github.com/mck89/peast/issues",
-                "source": "https://github.com/mck89/peast/tree/v1.17.5"
+                "source": "https://github.com/mck89/peast/tree/v1.17.6"
             },
-            "time": "2026-03-15T10:47:07+00:00"
+            "time": "2026-04-24T08:04:05+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -11183,16 +10943,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v6.4.36",
+            "version": "v6.4.37",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "9f481cfb580db8bcecc9b2d4c63f3e13df022ad5"
+                "reference": "7bbcaf3fdb1e18fa42a7f0b84a10d091c10548f5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/9f481cfb580db8bcecc9b2d4c63f3e13df022ad5",
-                "reference": "9f481cfb580db8bcecc9b2d4c63f3e13df022ad5",
+                "url": "https://api.github.com/repos/symfony/console/zipball/7bbcaf3fdb1e18fa42a7f0b84a10d091c10548f5",
+                "reference": "7bbcaf3fdb1e18fa42a7f0b84a10d091c10548f5",
                 "shasum": ""
             },
             "require": {
@@ -11257,7 +11017,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v6.4.36"
+                "source": "https://github.com/symfony/console/tree/v6.4.37"
             },
             "funding": [
                 {
@@ -11277,7 +11037,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-27T15:30:51+00:00"
+            "time": "2026-04-13T15:27:04+00:00"
         },
         {
             "name": "symfony/css-selector",
@@ -11350,16 +11110,16 @@
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v6.4.36",
+            "version": "v6.4.37",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "cd7881a6dc84b780411199cd0584e1a53a3b9ba7"
+                "reference": "4f66d607578c9d0546b1750262a6140e552e346d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/cd7881a6dc84b780411199cd0584e1a53a3b9ba7",
-                "reference": "cd7881a6dc84b780411199cd0584e1a53a3b9ba7",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/4f66d607578c9d0546b1750262a6140e552e346d",
+                "reference": "4f66d607578c9d0546b1750262a6140e552e346d",
                 "shasum": ""
             },
             "require": {
@@ -11411,7 +11171,7 @@
             "description": "Allows you to standardize and centralize the way objects are constructed in your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/dependency-injection/tree/v6.4.36"
+                "source": "https://github.com/symfony/dependency-injection/tree/v6.4.37"
             },
             "funding": [
                 {
@@ -11431,7 +11191,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-30T16:39:36+00:00"
+            "time": "2026-04-30T17:50:20+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -11581,16 +11341,16 @@
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v6.4.36",
+            "version": "v6.4.37",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "fc828863e26ceec86e2513b5e46aa0b149d76b69"
+                "reference": "2e3bf817ba9347341ab15926700fb6320367c0e1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/fc828863e26ceec86e2513b5e46aa0b149d76b69",
-                "reference": "fc828863e26ceec86e2513b5e46aa0b149d76b69",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/2e3bf817ba9347341ab15926700fb6320367c0e1",
+                "reference": "2e3bf817ba9347341ab15926700fb6320367c0e1",
                 "shasum": ""
             },
             "require": {
@@ -11641,7 +11401,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v6.4.36"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v6.4.37"
             },
             "funding": [
                 {
@@ -11661,7 +11421,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-30T11:18:01+00:00"
+            "time": "2026-04-13T14:11:12+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
@@ -12162,16 +11922,16 @@
         },
         {
             "name": "symfony/mime",
-            "version": "v6.4.36",
+            "version": "v6.4.37",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mime.git",
-                "reference": "9c31726137c70798f815fb98293ffb8a2a47694c"
+                "reference": "330077bc7fbe314758aff62834b758d06ac6d260"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mime/zipball/9c31726137c70798f815fb98293ffb8a2a47694c",
-                "reference": "9c31726137c70798f815fb98293ffb8a2a47694c",
+                "url": "https://api.github.com/repos/symfony/mime/zipball/330077bc7fbe314758aff62834b758d06ac6d260",
+                "reference": "330077bc7fbe314758aff62834b758d06ac6d260",
                 "shasum": ""
             },
             "require": {
@@ -12227,7 +11987,7 @@
                 "mime-type"
             ],
             "support": {
-                "source": "https://github.com/symfony/mime/tree/v6.4.36"
+                "source": "https://github.com/symfony/mime/tree/v6.4.37"
             },
             "funding": [
                 {
@@ -12247,7 +12007,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-30T09:31:23+00:00"
+            "time": "2026-04-29T09:53:28+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -12757,7 +12517,7 @@
         },
         {
             "name": "symfony/polyfill-php81",
-            "version": "v1.36.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php81.git",
@@ -12813,7 +12573,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php81/tree/v1.36.0"
+                "source": "https://github.com/symfony/polyfill-php81/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -12917,7 +12677,7 @@
         },
         {
             "name": "symfony/polyfill-php84",
-            "version": "v1.36.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php84.git",
@@ -12973,7 +12733,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php84/tree/v1.36.0"
+                "source": "https://github.com/symfony/polyfill-php84/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -13149,16 +12909,16 @@
         },
         {
             "name": "symfony/routing",
-            "version": "v6.4.34",
+            "version": "v6.4.37",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "5ab3a3e1a03535ec5ca6ce2d39e4369a1096ae47"
+                "reference": "48035d186798d27d375d95aad37db8fe097e4048"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/5ab3a3e1a03535ec5ca6ce2d39e4369a1096ae47",
-                "reference": "5ab3a3e1a03535ec5ca6ce2d39e4369a1096ae47",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/48035d186798d27d375d95aad37db8fe097e4048",
+                "reference": "48035d186798d27d375d95aad37db8fe097e4048",
                 "shasum": ""
             },
             "require": {
@@ -13212,7 +12972,7 @@
                 "url"
             ],
             "support": {
-                "source": "https://github.com/symfony/routing/tree/v6.4.34"
+                "source": "https://github.com/symfony/routing/tree/v6.4.37"
             },
             "funding": [
                 {
@@ -13232,20 +12992,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-24T17:34:50+00:00"
+            "time": "2026-04-18T13:45:55+00:00"
         },
         {
             "name": "symfony/serializer",
-            "version": "v6.4.36",
+            "version": "v6.4.37",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/serializer.git",
-                "reference": "90e4e0187dca57331ea301506545aa26895b7787"
+                "reference": "53a31b1a3baa209862237bcbe50b0ab789b158dc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/serializer/zipball/90e4e0187dca57331ea301506545aa26895b7787",
-                "reference": "90e4e0187dca57331ea301506545aa26895b7787",
+                "url": "https://api.github.com/repos/symfony/serializer/zipball/53a31b1a3baa209862237bcbe50b0ab789b158dc",
+                "reference": "53a31b1a3baa209862237bcbe50b0ab789b158dc",
                 "shasum": ""
             },
             "require": {
@@ -13314,7 +13074,7 @@
             "description": "Handles serializing and deserializing data structures, including object graphs, into array structures or other formats like XML and JSON.",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/serializer/tree/v6.4.36"
+                "source": "https://github.com/symfony/serializer/tree/v6.4.37"
             },
             "funding": [
                 {
@@ -13334,7 +13094,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-30T15:37:17+00:00"
+            "time": "2026-04-29T12:54:08+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -13709,16 +13469,16 @@
         },
         {
             "name": "symfony/validator",
-            "version": "v6.4.36",
+            "version": "v6.4.37",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/validator.git",
-                "reference": "14921e87b2bd69dfbd9757cdb1c6974a1316aac5"
+                "reference": "72cfcf7925746d9950bbdab1362f6bda3b4046cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/validator/zipball/14921e87b2bd69dfbd9757cdb1c6974a1316aac5",
-                "reference": "14921e87b2bd69dfbd9757cdb1c6974a1316aac5",
+                "url": "https://api.github.com/repos/symfony/validator/zipball/72cfcf7925746d9950bbdab1362f6bda3b4046cf",
+                "reference": "72cfcf7925746d9950bbdab1362f6bda3b4046cf",
                 "shasum": ""
             },
             "require": {
@@ -13786,7 +13546,7 @@
             "description": "Provides tools to validate values",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/validator/tree/v6.4.36"
+                "source": "https://github.com/symfony/validator/tree/v6.4.37"
             },
             "funding": [
                 {
@@ -13806,7 +13566,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-26T15:58:46+00:00"
+            "time": "2026-04-29T06:33:37+00:00"
         },
         {
             "name": "symfony/var-dumper",
@@ -13898,16 +13658,16 @@
         },
         {
             "name": "symfony/var-exporter",
-            "version": "v6.4.36",
+            "version": "v6.4.37",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-exporter.git",
-                "reference": "f9c4a9695a9e2bbc65c920e147d8d7ae28f8d79a"
+                "reference": "34f6957deffacabd1b1c579a312daa481e3e99ca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/f9c4a9695a9e2bbc65c920e147d8d7ae28f8d79a",
-                "reference": "f9c4a9695a9e2bbc65c920e147d8d7ae28f8d79a",
+                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/34f6957deffacabd1b1c579a312daa481e3e99ca",
+                "reference": "34f6957deffacabd1b1c579a312daa481e3e99ca",
                 "shasum": ""
             },
             "require": {
@@ -13955,7 +13715,7 @@
                 "serialize"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-exporter/tree/v6.4.36"
+                "source": "https://github.com/symfony/var-exporter/tree/v6.4.37"
             },
             "funding": [
                 {
@@ -13975,7 +13735,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-10T15:06:19+00:00"
+            "time": "2026-04-14T12:12:40+00:00"
         },
         {
             "name": "symfony/yaml",
@@ -17553,7 +17313,7 @@
         },
         {
             "name": "symfony/polyfill-php73",
-            "version": "v1.36.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php73.git",
@@ -17609,7 +17369,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php73/tree/v1.36.0"
+                "source": "https://github.com/symfony/polyfill-php73/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -17633,7 +17393,7 @@
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.36.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
@@ -17693,7 +17453,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.36.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.37.0"
             },
             "funding": [
                 {

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_application_page/cgov_application_page.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_application_page/cgov_application_page.info.yml
@@ -4,6 +4,7 @@ package: 'CGov Digital Platform'
 description: 'The Application Page content type'
 core_version_requirement: '^9.4 || ^10'
 dependencies:
+  - 'features:features'
   - 'app_module:app_module'
   - 'cgov_core:cgov_core'
   - 'cgov_image:cgov_image'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/cgov_article.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/cgov_article.info.yml
@@ -4,6 +4,7 @@ package: 'CGov Digital Platform'
 description: 'The Article content type'
 core_version_requirement: '^9.4 || ^10'
 dependencies:
+  - 'features:features'
   - 'cgov_core:cgov_core'
   - 'cgov_image:cgov_image'
   - 'cgov_list:cgov_list'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_biography/cgov_biography.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_biography/cgov_biography.info.yml
@@ -4,6 +4,7 @@ package: 'CGov Digital Platform'
 description: 'The Biography content type'
 core_version_requirement: '^9.4 || ^10'
 dependencies:
+  - 'features:features'
   - 'cgov_biography:cgov_biography'
   - 'cgov_core:cgov_core'
   - 'cgov_image:cgov_image'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/cgov_blog.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/cgov_blog.info.yml
@@ -4,6 +4,7 @@ package: 'CGov Digital Platform'
 description: 'Blog Post and Blog Series item functionality for CGov Digital Platform Sites'
 core_version_requirement: '^10 || ^11'
 dependencies:
+  - 'features:features'
   - 'cgov_blog:cgov_blog'
   - 'cgov_core:cgov_core'
   - 'cgov_image:cgov_image'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_center/cgov_cancer_center.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_center/cgov_cancer_center.info.yml
@@ -4,6 +4,7 @@ package: 'CGov Digital Platform'
 description: 'The Cancer Center content type'
 core_version_requirement: '^9.4 || ^10'
 dependencies:
+  - 'features:features'
   - 'address:address'
   - 'cgov_cancer_center:cgov_cancer_center'
   - 'cgov_core:cgov_core'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_research/cgov_cancer_research.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_research/cgov_cancer_research.info.yml
@@ -4,6 +4,7 @@ package: 'CGov Digital Platform'
 description: 'The Cancer Research List Page content type'
 core_version_requirement: '^9.4 || ^10'
 dependencies:
+  - 'features:features'
   - 'cgov_core:cgov_core'
   - 'cgov_image:cgov_image'
   - 'cgov_list:cgov_list'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_content_block/cgov_content_block.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_content_block/cgov_content_block.info.yml
@@ -4,6 +4,7 @@ package: 'CGov Digital Platform'
 description: 'The Content Block content type'
 core_version_requirement: '^9.4 || ^10'
 dependencies:
+  - 'features:features'
   - 'cgov_core:cgov_core'
   - 'drupal:block_content'
   - 'drupal:content_moderation'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/cgov_cthp.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/cgov_cthp.info.yml
@@ -4,6 +4,7 @@ package: 'CGov Digital Platform'
 description: 'The Cancer Type Home Page content type'
 core_version_requirement: '^9.4 || ^10'
 dependencies:
+  - 'features:features'
   - 'cgov_cancer_research:cgov_cancer_research'
   - 'cgov_core:cgov_core'
   - 'cgov_home_landing:cgov_home_landing'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_embedded_block/cgov_embedded_block.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_embedded_block/cgov_embedded_block.info.yml
@@ -4,6 +4,7 @@ package: 'CGov Digital Platform'
 description: 'Embeddable block content support'
 core_version_requirement: '^9.4 || ^10'
 dependencies:
+  - 'features:features'
   - 'cgov_content_block:cgov_content_block'
   - 'cgov_core:cgov_core'
   - 'drupal:block_content'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_event/cgov_event.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_event/cgov_event.info.yml
@@ -4,6 +4,7 @@ package: 'CGov Digital Platform'
 description: 'The Event content type'
 core_version_requirement: '^9.4 || ^10'
 dependencies:
+  - 'features:features'
   - 'cgov_core:cgov_core'
   - 'cgov_event:cgov_event'
   - 'cgov_image:cgov_image'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_external_link_block/cgov_external_link_block.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_external_link_block/cgov_external_link_block.info.yml
@@ -4,6 +4,7 @@ package: 'CGov Digital Platform'
 description: 'Allows External Links to be featured in content'
 core_version_requirement: '^9.4 || ^10'
 dependencies:
+  - 'features:features'
   - 'cgov_content_block:cgov_content_block'
   - 'cgov_core:cgov_core'
   - 'cgov_embedded_block:cgov_embedded_block'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_file/cgov_file.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_file/cgov_file.info.yml
@@ -4,6 +4,7 @@ description: 'Cancer.gov File module.'
 package: 'CGov Digital Platform'
 core_version_requirement: '^9.4 || ^10'
 dependencies:
+  - 'features:features'
   - 'cgov_core:cgov_core'
   - 'cgov_image:cgov_image'
   - 'cgov_site_section:cgov_site_section'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/cgov_home_landing.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/cgov_home_landing.info.yml
@@ -4,6 +4,7 @@ package: 'CGov Digital Platform'
 description: 'The home and landing page content type'
 core_version_requirement: '^9.4 || ^10'
 dependencies:
+  - 'features:features'
   - 'cgov_core:cgov_core'
   - 'cgov_image:cgov_image'
   - 'cgov_list:cgov_list'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_https_config/cgov_https_config.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_https_config/cgov_https_config.info.yml
@@ -4,4 +4,5 @@ package: 'CGov HTTPS Enforcement Configuration'
 description: 'Configures enforcement of HTTPS'
 core_version_requirement: '^9.4 || ^10'
 dependencies:
+  - 'features:features'
   - seckit

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_image/cgov_image.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_image/cgov_image.info.yml
@@ -4,6 +4,7 @@ package: 'CGov Digital Platform'
 description: 'CGov Image Media Type'
 core_version_requirement: '^9.4 || ^10'
 dependencies:
+  - 'features:features'
   - 'cgov_core:cgov_core'
   - 'crop:crop'
   - 'drupal:block_content'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_infographic/cgov_infographic.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_infographic/cgov_infographic.info.yml
@@ -4,6 +4,7 @@ package: 'CGov Digital Platform'
 description: 'The infographic content type'
 core_version_requirement: '^9.4 || ^10'
 dependencies:
+  - 'features:features'
   - 'cgov_core:cgov_core'
   - 'cgov_image:cgov_image'
   - 'cgov_site_section:cgov_site_section'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_list/cgov_list.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_list/cgov_list.info.yml
@@ -4,6 +4,7 @@ package: 'CGov Digital Platform'
 description: 'CGov Core List Components used by most content types for content listings.'
 core_version_requirement: '^9.4 || ^10'
 dependencies:
+  - 'features:features'
   - 'cgov_core:cgov_core'
   - 'cgov_image:cgov_image'
   - 'drupal:field'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/cgov_press_release.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/cgov_press_release.info.yml
@@ -4,6 +4,7 @@ package: 'CGov Digital Platform'
 description: 'The Press Release content type'
 core_version_requirement: '^9.4 || ^10'
 dependencies:
+  - 'features:features'
   - 'cgov_core:cgov_core'
   - 'cgov_image:cgov_image'
   - 'cgov_list:cgov_list'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_promo/cgov_promo.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_promo/cgov_promo.info.yml
@@ -4,6 +4,7 @@ package: 'CGov Digital Platform'
 description: 'Promo item functionality for CGov Digital Platform Sites'
 core_version_requirement: '^10 || ^11'
 dependencies:
+  - 'features:features'
   - 'cgov_core:cgov_core'
   - 'cgov_image:cgov_image'
   - 'cgov_list:cgov_list'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_saml_auth_config/cgov_saml_auth_config.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_saml_auth_config/cgov_saml_auth_config.info.yml
@@ -4,5 +4,6 @@ package: 'CGov Single Sign-on Configuration'
 description: 'Configures SAML Auth Settings'
 core_version_requirement: '^9.4 || ^10'
 dependencies:
+  - 'features:features'
   - 'autologout:autologout'
   - 'samlauth:samlauth'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_schema_org/cgov_schema_org.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_schema_org/cgov_schema_org.info.yml
@@ -4,6 +4,7 @@ package: 'CGov Digital Platform'
 description: 'Support for schema.org markup in NCI content'
 core_version_requirement: '^9.4 || ^10'
 dependencies:
+  - 'features:features'
   - cgov_schema_org
   - field
   - node

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_site_section/cgov_site_section.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_site_section/cgov_site_section.info.yml
@@ -4,6 +4,7 @@ description: 'Cancer.gov Site Section module.'
 package: 'CGov Digital Platform'
 core_version_requirement: '^9.4 || ^10'
 dependencies:
+  - 'features:features'
   - 'cgov_content_block:cgov_content_block'
   - 'cgov_core:cgov_core'
   - 'cgov_site_section:cgov_site_section'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_syndication/cgov_syndication.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_syndication/cgov_syndication.info.yml
@@ -4,6 +4,7 @@ package: 'CGov Digital Platform'
 description: 'Support for exporting NCI content via HHS Syndication'
 core_version_requirement: '^9.4 || ^10'
 dependencies:
+  - 'features:features'
   - cgov_syndication
   - field
   - node

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/cgov_video.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/cgov_video.info.yml
@@ -4,6 +4,7 @@ description: 'Cancer.gov Video module.'
 package: 'CGov Digital Platform'
 core_version_requirement: '^9.4 || ^10'
 dependencies:
+  - 'features:features'
   - 'cgov_content_block:cgov_content_block'
   - 'cgov_core:cgov_core'
   - 'cgov_image:cgov_image'

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/pdq_cancer_information_summary.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/pdq_cancer_information_summary.info.yml
@@ -4,6 +4,7 @@ package: 'CGov Digital Platform'
 description: 'The PDQ Cancer Information Summary content type'
 core_version_requirement: '^9.4 || ^10'
 dependencies:
+  - 'features:features'
   - 'cgov_core:cgov_core'
   - 'cgov_syndication:cgov_syndication'
   - 'drupal:basic_auth'

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_core/pdq_core.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_core/pdq_core.info.yml
@@ -4,6 +4,7 @@ description: 'Common tools used by the imported PDQ content'
 package: 'CGov Digital Platform'
 core_version_requirement: '^9.4 || ^10'
 dependencies:
+  - 'features:features'
   - basic_auth
   - block
   - cgov_core

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_drug_information_summary/pdq_drug_information_summary.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_drug_information_summary/pdq_drug_information_summary.info.yml
@@ -4,6 +4,7 @@ package: 'CGov Digital Platform'
 description: 'The PDQ Drug Information Summary content type'
 core_version_requirement: '^9.4 || ^10'
 dependencies:
+  - 'features:features'
   - 'cgov_core:cgov_core'
   - 'drupal:basic_auth'
   - 'drupal:content_moderation'

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_glossifier/pdq_glossifier.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_glossifier/pdq_glossifier.info.yml
@@ -4,6 +4,7 @@ description: 'Service to identify candidate links to PDQ dictionaries'
 package: 'CGov Digital Platform'
 core_version_requirement: '^9.4 || ^10'
 dependencies:
+  - 'features:features'
   - 'drupal:basic_auth'
   - 'drupal:rest'
   - 'drupal:serialization'


### PR DESCRIPTION
Removes `drupal/acsf` from composer.json and composer.lock. Removes acsf from module toggle uninstall lists in blt.blt.yml for follow environments.

- local
- meodev
- meostage
- meoprod

Closes #5208 #5223