### PR TITLE
(#5225) Add cgdp-definition styles to blogs

### DIFF
--- a/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/front-end/src/entrypoints/blogs/blogs.scss
+++ b/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/front-end/src/entrypoints/blogs/blogs.scss
@@ -16,6 +16,11 @@
 @forward '../../lib/components/wysiwyg/common/cgdp-embed-video';
 @forward '../../lib/components/wysiwyg/common/cgdp-embed-card/';
 
+// CGDP Definition link styles
+// We would include this file in NCIDS full html except that it is
+// used in the CKEditor as well and we don't want the modal CSS included there.
+@forward '../../lib/components/cgdp-definition';
+
 @use 'uswds-core' as *;
 
 .cgdp-article-footer-citation {


### PR DESCRIPTION
Adds an import for "cgdp-definition" styles in blogs. Previously it was coming from "ncids-common" which was getting overridden due to import order / specificity. 

Closes #5225