### PR TITLE
(#4032) Validate pretty URL uniqueness per blog series on blog posts

### DIFF
--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/cgov_blog.module
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/cgov_blog.module
@@ -17,6 +17,13 @@ use Drupal\taxonomy\TermInterface;
 use Drupal\views\ViewExecutable;
 
 /**
+ * Implements hook_entity_type_build().
+ */
+function cgov_blog_entity_type_build(array &$entity_types) {
+  $entity_types['node']->addConstraint('UniqueBlogPostUrl');
+}
+
+/**
  * Implements hook_form_alter().
  */
 function cgov_blog_form_alter(&$form, FormStateInterface $form_state, $form_id) {

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/src/Plugin/Validation/Constraint/UniqueBlogPostUrlConstraint.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/src/Plugin/Validation/Constraint/UniqueBlogPostUrlConstraint.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Drupal\cgov_blog\Plugin\Validation\Constraint;
+
+use Drupal\Core\Entity\Plugin\Validation\Constraint\CompositeConstraintBase;
+
+/**
+ * No two blog posts in the same series may share a pretty URL.
+ *
+ * @Constraint(
+ *   id = "UniqueBlogPostUrl",
+ *   label = @Translation("Blog post pretty URL is unique within its series.", context="Validation"),
+ *   type = "entity:node"
+ * )
+ */
+final class UniqueBlogPostUrlConstraint extends CompositeConstraintBase {
+
+  /**
+   * Shown when an editor picks a pretty URL already in use in this series.
+   *
+   * @var string
+   */
+  public $prettyUrlInUse = 'The Pretty URL is already in use for this blog series.';
+
+  /**
+   * {@inheritdoc}
+   */
+  public function coversFields() {
+    return ['field_blog_series', 'field_pretty_url'];
+  }
+
+}

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/src/Plugin/Validation/Constraint/UniqueBlogPostUrlConstraintValidator.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/src/Plugin/Validation/Constraint/UniqueBlogPostUrlConstraintValidator.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Drupal\cgov_blog\Plugin\Validation\Constraint;
+
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+/**
+ * Checks that no two blog posts in the same series share a pretty URL.
+ */
+final class UniqueBlogPostUrlConstraintValidator extends ConstraintValidator implements ContainerInjectionInterface {
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  private EntityTypeManagerInterface $entityTypeManager;
+
+  public function __construct(EntityTypeManagerInterface $entityTypeManager) {
+    $this->entityTypeManager = $entityTypeManager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static($container->get('entity_type.manager'));
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validate($entity, Constraint $constraint) {
+    if (!($constraint instanceof UniqueBlogPostUrlConstraint)) {
+      return;
+    }
+
+    if ($entity->bundle() !== 'cgov_blog_post') {
+      return;
+    }
+
+    $is_populated_series = $entity->hasField('field_blog_series') && !$entity->get('field_blog_series')->isEmpty();
+    $is_populated_pretty_url = $entity->hasField('field_pretty_url') && !$entity->get('field_pretty_url')->isEmpty();
+
+    if (!$is_populated_series || !$is_populated_pretty_url) {
+      return;
+    }
+
+    $series_id = $entity->get('field_blog_series')->first()->getValue()['target_id'];
+    $pretty_url = $entity->get('field_pretty_url')->value;
+    $id_key = $entity->getEntityType()->getKey('id');
+
+    $value_taken = (bool) $this->entityTypeManager
+      ->getStorage('node')
+      ->getQuery()
+      ->accessCheck(FALSE)
+      ->condition($id_key, (int) $entity->id(), '<>')
+      ->condition('field_blog_series', $series_id)
+      ->condition('field_pretty_url', $pretty_url)
+      ->range(0, 1)
+      ->count()
+      ->execute();
+
+    if ($value_taken) {
+      $this->context->buildViolation($constraint->prettyUrlInUse)
+        ->atPath('field_pretty_url')
+        ->addViolation();
+    }
+  }
+
+}


### PR DESCRIPTION
Adds a new UniqueBlogPostUrl constraint to the cgov_blog module that blocks saving a blog post when another post in the same series already holds the same pretty URL.

Closes #4032