### PR TITLE
(#5211) Disable Admin Toolbar Links Access Filter module

### DIFF
--- a/docroot/profiles/custom/cgov_site/cgov_site.info.yml
+++ b/docroot/profiles/custom/cgov_site/cgov_site.info.yml
@@ -44,7 +44,6 @@ install:
   - content_translation
   - admin_toolbar
   - admin_toolbar_tools
-  - admin_toolbar_links_access_filter
   # other
   - features
   - features_ui

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.install
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.install
@@ -345,3 +345,13 @@ function cgov_core_update_10017(): void {
     $installer->install(['mysql']);
   }
 }
+
+/**
+ * Uninstall admin_toolbar_links_access_filter (duplicated by Drupal 10.3 core).
+ */
+function cgov_core_update_10018(): void {
+  $installer = \Drupal::service('module_installer');
+  if (\Drupal::moduleHandler()->moduleExists('admin_toolbar_links_access_filter')) {
+    $installer->uninstall(['admin_toolbar_links_access_filter']);
+  }
+}


### PR DESCRIPTION
The `admin_toolbar_links_access_filter` module's functionality was duplicated by Drupal core in 10.3. This removes it.

Closes #5211