### PR TITLE
(#5209) Fix admin UI language negotiation to always display in English

### DIFF
--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.module
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.module
@@ -18,6 +18,7 @@ use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Language\Language;
+use Drupal\Core\Language\LanguageInterface;
 use Drupal\Core\Render\Element;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Site\Settings;
@@ -58,6 +59,12 @@ function cgov_core_block_build_alter(array &$build, BlockPluginInterface $block)
     else {
       $build['#cache']['max_age'] = 0;
     }
+  }
+
+  // Language switcher blocks must vary by content language so the correct
+  // link is removed when interface language is decoupled from content language.
+  if (str_starts_with($block->getPluginId(), 'language_block:')) {
+    $build['#cache']['contexts'][] = 'languages:language_content';
   }
 }
 
@@ -402,7 +409,7 @@ function cgov_core_theme_suggestions_entity_embed_container(array $variables) {
  * We fix this, but still leverage the OOB language block.
  */
 function cgov_core_language_switch_links_alter(array &$links, $type, Url $url) {
-  $language_interface = \Drupal::languageManager()->getCurrentLanguage();
+  $language_interface = \Drupal::languageManager()->getCurrentLanguage(LanguageInterface::TYPE_CONTENT);
 
   // First remove the current language no matter what. This applies to all
   // links.

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/CgovCoreTools.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/CgovCoreTools.php
@@ -92,11 +92,12 @@ class CgovCoreTools {
   private $cgovLangTypes = [
     'language_interface' => [
       'enabled' => [
-        'language-user-admin' => "-10",
+        'cgov-admin-english' => "-12",
         'language-url' => "-8",
         'language-selected' => "12",
       ],
       'method_weights' => [
+        'cgov-admin-english' => "-12",
         'language-user-admin' => "-10",
         'language-url' => "-8",
         'language-session' => "-4",

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Plugin/LanguageNegotiation/LanguageNegotiationAdminEnglish.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Plugin/LanguageNegotiation/LanguageNegotiationAdminEnglish.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Drupal\cgov_core\Plugin\LanguageNegotiation;
+
+use Drupal\language\LanguageNegotiationMethodBase;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Language negotiation plugin that keeps the admin UI in English.
+ *
+ * Runs before URL-based negotiation so that authenticated users always receive
+ * English for the interface language, keeping the admin menu in English
+ * regardless of content language. Anonymous visitors on /espanol/ pages fall
+ * through to URL-based detection so .po translations load correctly.
+ *
+ * @LanguageNegotiation(
+ *   id = \Drupal\cgov_core\Plugin\LanguageNegotiation\LanguageNegotiationAdminEnglish::METHOD_ID,
+ *   weight = -12,
+ *   name = @Translation("Admin English"),
+ *   description = @Translation("The admin UI always uses English regardless of URL or user preference."),
+ * )
+ */
+final class LanguageNegotiationAdminEnglish extends LanguageNegotiationMethodBase {
+
+  const METHOD_ID = 'cgov-admin-english';
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getLangcode(?Request $request = NULL): ?string {
+    if ($this->currentUser && $this->currentUser->isAuthenticated()) {
+      return 'en';
+    }
+    return NULL;
+  }
+
+}

--- a/docroot/profiles/custom/cgov_site/tests/src/Functional/CgovSiteTest.php
+++ b/docroot/profiles/custom/cgov_site/tests/src/Functional/CgovSiteTest.php
@@ -88,7 +88,7 @@ class CgovSiteTest extends BrowserTestBase {
     // Test that the language negotiations are correct.
     $ifaceNegs = \Drupal::config('language.types')->get('negotiation.language_interface.enabled');
     $this->assertCount(3, array_keys($ifaceNegs), 'Only 3 interface negotiations set.');
-    $this->assertArrayHasKey('language-user-admin', $ifaceNegs, 'User admin interface negotiation set.');
+    $this->assertArrayHasKey('cgov-admin-english', $ifaceNegs, 'Admin English interface negotiation set.');
     $this->assertArrayHasKey('language-url', $ifaceNegs, 'Language URL interface negotiation set.');
     $this->assertArrayHasKey('language-selected', $ifaceNegs, 'Selected language interface negotiation set.');
 


### PR DESCRIPTION
Adds a custom `LanguageNegotiationAdminEnglish` plugin that returns English for authenticated users, keeping admin menu in English regardless of content language. Anonymous visitors on `/espanol/ `pages still receive URL-based interface detection so `.po` translations (e.g. por/by) load correctly. Removes language-user-admin from the enabled interface negotiation methods.

Closes #5209