### PR TITLE
(#4870) Remove deprecated CacheDecoratorInterface from AppPathManager

### DIFF
--- a/docroot/modules/custom/app_module/src/AppPathManager.php
+++ b/docroot/modules/custom/app_module/src/AppPathManager.php
@@ -4,7 +4,6 @@ namespace Drupal\app_module;
 
 use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\Cache\CacheBackendInterface;
-use Drupal\Core\CacheDecorator\CacheDecoratorInterface;
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityMalformedException;
@@ -19,7 +18,7 @@ use Drupal\path_alias\PathAliasInterface;
 /**
  * The default app path manager implementation.
  */
-class AppPathManager implements AppPathManagerInterface, CacheDecoratorInterface {
+class AppPathManager implements AppPathManagerInterface {
 
   /**
    * The alias manager service.
@@ -250,7 +249,10 @@ class AppPathManager implements AppPathManagerInterface, CacheDecoratorInterface
   }
 
   /**
-   * {@inheritdoc}
+   * Specify the key to use when writing the cache.
+   *
+   * @param string $key
+   *   The cache key.
    */
   public function setCacheKey($key) {
     // Prefix the cache key to avoid clashes with other caches.
@@ -516,7 +518,7 @@ class AppPathManager implements AppPathManagerInterface, CacheDecoratorInterface
   }
 
   /**
-   * {@inheritdoc}
+   * Write the cache.
    *
    * Cache an array of the paths available on each page. We assume that aliases
    * will be needed for the majority of these paths during subsequent requests,


### PR DESCRIPTION
CacheDecoratorInterface is deprecated as of Drupal 10.2.0 and removed in Drupal 11.0.0 with no replacement (see
https://www.drupal.org/node/3398182). 

Updated the now orphaned `@inheritdoc` docblocks to describe them directly.

Closes #4870