### PR TITLE
Replace content-language meta tag with document.documentElement.lang

### DIFF
--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/src/libraries/enlarge/enlarge.js
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/src/libraries/enlarge/enlarge.js
@@ -269,8 +269,8 @@ $.fn.overflowEnlarge = function( options ) {
     var settings = $.extend({
         text: "Default Text",
         color: null,
-        enlargeTxt : ($('meta[name="content-language"]').attr('content') == 'es') ? "Ampliar" : "Enlarge",
-        collapseTxt : ($('meta[name="content-language"]').attr('content') == 'es') ? "Cerrar" : "Close",
+        enlargeTxt : (document.documentElement.lang === 'es') ? "Ampliar" : "Enlarge",
+        collapseTxt : (document.documentElement.lang === 'es') ? "Cerrar" : "Close",
         thresholdForEnlarge : 1024,
         xlThreshold: 1440, //This is when the browser goes into XL mode and the body is wider.
         dialogLRMargin : 20,

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/src/utilities/domManipulation.js
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/src/utilities/domManipulation.js
@@ -95,17 +95,7 @@ export const getMetaData = (metaTags, document) => {
  * @return {string}
  */
 export const getDocumentLanguage = (document = window.document) => {
-  // MIGRATION NOTE:
-  // The fallback values were added during migration because a content-language attribute was not available
-  // at the time this file was ported.
-  const language = document.querySelector('meta[name="content-language"]')
-    ? document
-        .querySelector('meta[name="content-language"]')
-        .getAttribute("content")
-    : document.documentElement.lang
-    ? document.documentElement.lang
-    : "en";
-  return language;
+  return document.documentElement.lang || "en";
 };
 
 /**


### PR DESCRIPTION
The `content-language` meta tag was removed in the Metatag 2.x upgrade. `enlarge.js `was being called on pages with tables. Both files updated to use `document.documentElement.lang` which Drupal always sets correctly.