### PR TITLE
(#5318) Fix enlarge button text on Spanish pages

### DIFF
--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/src/libraries/enlarge/enlarge.js
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/src/libraries/enlarge/enlarge.js
@@ -269,8 +269,8 @@ $.fn.overflowEnlarge = function( options ) {
     var settings = $.extend({
         text: "Default Text",
         color: null,
-        enlargeTxt : ($('meta[name="content-language"]').attr('content') == 'es') ? "Ampliar" : "Enlarge",
-        collapseTxt : ($('meta[name="content-language"]').attr('content') == 'es') ? "Cerrar" : "Close",
+        enlargeTxt : (document.documentElement.lang === 'es') ? "Ampliar" : "Enlarge",
+        collapseTxt : (document.documentElement.lang === 'es') ? "Cerrar" : "Close",
         thresholdForEnlarge : 1024,
         xlThreshold: 1440, //This is when the browser goes into XL mode and the body is wider.
         dialogLRMargin : 20,

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/src/utilities/domManipulation.js
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/src/utilities/domManipulation.js
@@ -91,21 +91,11 @@ export const getMetaData = (metaTags, document) => {
 
 /**
  * TODO: Extend with extra checks, this is very specific to CGOV.
- * @param {HTMLElement} [document=window.document]
+ * @param {Document} [document=window.document]
  * @return {string}
  */
 export const getDocumentLanguage = (document = window.document) => {
-  // MIGRATION NOTE:
-  // The fallback values were added during migration because a content-language attribute was not available
-  // at the time this file was ported.
-  const language = document.querySelector('meta[name="content-language"]')
-    ? document
-        .querySelector('meta[name="content-language"]')
-        .getAttribute("content")
-    : document.documentElement.lang
-    ? document.documentElement.lang
-    : "en";
-  return language;
+  return document.documentElement.lang || "en";
 };
 
 /**


### PR DESCRIPTION
After the Metatag 2.x upgrade, the content-language meta tag is no longer output. `enlarge.js` relied on this tag to render "Ampliar"/"Cerrar" on Spanish pages. With the tag gone, Spanish pages always show "Enlarge"/"Close" instead

`domManipulation.js` had the same content-language dependency with an unnecessary fallback - simplified to use `document.documentElement.lang` directly.

Closes #5318