### PR TITLE
(#4876) Replace deprecated file_validate_extensions validator

### DIFF
--- a/docroot/modules/custom/json_data_field/src/Plugin/Field/FieldType/JsonDataFieldItem.php
+++ b/docroot/modules/custom/json_data_field/src/Plugin/Field/FieldType/JsonDataFieldItem.php
@@ -78,7 +78,7 @@ class JsonDataFieldItem extends FieldItemBase {
       '#title' => $this->t('JSON Schema File'),
       '#upload_location' => $upload_location,
       '#upload_validators' => [
-        'file_validate_extensions' => ['json'],
+        'FileExtension' => ['extensions' => 'json'],
       /* @todo some day validate this as JSONSchema */
       ],
     ];

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Plugin/Block/NcidsHeader.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/src/Plugin/Block/NcidsHeader.php
@@ -703,7 +703,7 @@ class NcidsHeader extends BlockBase implements ContainerFactoryPluginInterface {
       '#title' => $this->t('Upload desktop logo image'),
       '#description' => $this->t("Use this field to upload your desktop logo."),
       '#upload_validators' => [
-        'file_validate_extensions' => ['svg'],
+        'FileExtension' => ['extensions' => 'svg'],
       ],
       '#upload_location' => 'public://ncids_header/logos/',
     ];
@@ -716,7 +716,7 @@ class NcidsHeader extends BlockBase implements ContainerFactoryPluginInterface {
       '#title' => $this->t('Upload mobile logo image'),
       '#description' => $this->t("Use this field to upload your mobile logo."),
       '#upload_validators' => [
-        'file_validate_extensions' => ['svg'],
+        'FileExtension' => ['extensions' => 'svg'],
       ],
       '#upload_location' => 'public://ncids_header/logos/',
     ];

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_redirect_manager/src/Form/RedirectImport.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_redirect_manager/src/Form/RedirectImport.php
@@ -69,7 +69,7 @@ class RedirectImport extends FormBase {
       '#title' => $this->t('CSV Redirect File'),
       '#description' => $this->t('Please upload a CSV redirect file.'),
       '#upload_validators' => [
-        'file_validate_extensions' => ['csv'],
+        'FileExtension' => ['extensions' => 'csv'],
       ],
       '#prefix' => '<p id="redirect-import">Upload a new CSV file.</p>',
       '#suffix' => '<p>CSV file should be formatted:<ul>

--- a/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/theme-settings.php
+++ b/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/theme-settings.php
@@ -16,7 +16,7 @@ function ncids_trans_form_system_theme_settings_alter(&$form) {
   // So while the Drupal community argues if SVGs *can* be used, we will
   // *only* allow them. (SVGs scale better and use less bandwith)
   $form['logo']['settings']['logo_upload']['#upload_validators'] = [
-    'file_validate_extensions' => ['svg'],
+    'FileExtension' => ['extensions' => 'svg'],
   ];
 
   /* ------------ 'Has Translations' button ----------- */


### PR DESCRIPTION
Replace deprecated `file_validate_extensions` validator with `FileExtension` constraint

`file_validate_extensions` is deprecated in Drupal 10.2.0 and removed in Drupal 11.0.0. Updated all five #upload_validators call sites to use the `FileExtension` constraint key instead, which Drupal core processes via the file.validator service.

Closes #4876