### PR TITLE
(#4817) Remove dcterms.coverage from meta data across sites

### DIFF
--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_application_page/config/install/metatag.metatag_defaults.node__cgov_application_page.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_application_page/config/install/metatag.metatag_defaults.node__cgov_application_page.yml
@@ -6,7 +6,6 @@ label: 'Content: Application Page'
 tags:
   canonical_url: '[node:url]'
   cgdp_template: '[node:field_app_module_page_template:value]'
-  dcterms_coverage: 'nciglobal,ncienterprise'
   dcterms_is_part_of: '[cgov_tokens:cgov-analytics-group]'
   dcterms_is_referenced_by: event1
   dcterms_issued: '[node:field_date_posted:date:html_date]'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/metatag.metatag_defaults.node__cgov_article.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_article/config/install/metatag.metatag_defaults.node__cgov_article.yml
@@ -5,7 +5,6 @@ id: node__cgov_article
 label: 'Content: Article'
 tags:
   canonical_url: '[node:url]'
-  dcterms_coverage: 'nciglobal,ncienterprise'
   dcterms_is_part_of: '[cgov_tokens:cgov-analytics-group]'
   dcterms_is_referenced_by: event1
   dcterms_issued: '[node:field_date_posted:date:html_date]'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_biography/config/install/metatag.metatag_defaults.node__cgov_biography.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_biography/config/install/metatag.metatag_defaults.node__cgov_biography.yml
@@ -5,7 +5,6 @@ id: node__cgov_biography
 label: 'Content: Biography'
 tags:
   canonical_url: '[node:url]'
-  dcterms_coverage: 'nciglobal,ncienterprise'
   dcterms_is_part_of: '[cgov_tokens:cgov-analytics-group]'
   dcterms_is_referenced_by: event1
   dcterms_issued: '[node:field_date_posted:date:html_date]'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/config/install/metatag.metatag_defaults.node__cgov_blog_post.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/config/install/metatag.metatag_defaults.node__cgov_blog_post.yml
@@ -5,7 +5,6 @@ id: node__cgov_blog_post
 label: 'Content: Blog Post'
 tags:
   canonical_url: '[node:url]'
-  dcterms_coverage: 'nciglobal,ncienterprise'
   dcterms_is_part_of: '[cgov_tokens:cgov-analytics-group]'
   dcterms_is_referenced_by: 'event1,event53'
   dcterms_issued: '[node:field_date_posted:date:html_date]'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/config/install/metatag.metatag_defaults.node__cgov_blog_series.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/config/install/metatag.metatag_defaults.node__cgov_blog_series.yml
@@ -5,7 +5,6 @@ id: node__cgov_blog_series
 label: 'Content: Blog Series'
 tags:
   canonical_url: '[node:url]'
-  dcterms_coverage: 'nciglobal,ncienterprise'
   dcterms_is_part_of: '[cgov_tokens:cgov-analytics-group]'
   dcterms_is_referenced_by: event1
   dcterms_issued: '[node:field_date_posted:date:html_date]'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_center/config/install/metatag.metatag_defaults.node__cgov_cancer_center.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_center/config/install/metatag.metatag_defaults.node__cgov_cancer_center.yml
@@ -5,7 +5,6 @@ id: node__cgov_cancer_center
 label: 'Content: Cancer Center'
 tags:
   canonical_url: '[node:url]'
-  dcterms_coverage: 'nciglobal,ncienterprise'
   dcterms_is_part_of: '[cgov_tokens:cgov-analytics-group]'
   dcterms_is_referenced_by: event1
   dcterms_issued: '[node:field_date_posted:date:html_date]'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_research/config/install/metatag.metatag_defaults.node__cgov_cancer_research.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_research/config/install/metatag.metatag_defaults.node__cgov_cancer_research.yml
@@ -5,7 +5,6 @@ id: node__cgov_cancer_research
 label: 'Content: Cancer Research List Page'
 tags:
   canonical_url: '[node:url]'
-  dcterms_coverage: 'nciglobal,ncienterprise'
   dcterms_is_part_of: '[cgov_tokens:cgov-analytics-group]'
   dcterms_is_referenced_by: event1
   dcterms_issued: '[node:field_date_posted:date:html_date]'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/config/install/metatag.metatag_defaults.global.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/config/install/metatag.metatag_defaults.global.yml
@@ -6,7 +6,6 @@ label: Global
 tags:
   canonical_url: '[current-page:url]'
   cgdp_domain: '[cgov_tokens:cgdp-domain]'
-  dcterms_coverage: 'nciglobal,ncienterprise'
   dcterms_is_part_of: '[cgov_tokens:cgov-analytics-group]'
   dcterms_subject: '[cgov_tokens:cgov-analytics-channel]'
   og_image: '[cgov_tokens:cgov-og-image]'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/metatag.metatag_defaults.node__cgov_cthp.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/metatag.metatag_defaults.node__cgov_cthp.yml
@@ -6,7 +6,6 @@ label: 'Content: Cancer Type Homepage'
 tags:
   canonical_url: '[node:url]'
   dcterms_audience: '[node:field_audience:value]'
-  dcterms_coverage: 'nciglobal,ncienterprise'
   dcterms_is_part_of: '[cgov_tokens:cgov-analytics-group]'
   dcterms_is_referenced_by: event1
   dcterms_issued: '[node:field_date_posted:date:html_date]'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_event/config/install/metatag.metatag_defaults.node__cgov_event.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_event/config/install/metatag.metatag_defaults.node__cgov_event.yml
@@ -5,7 +5,6 @@ id: node__cgov_event
 label: 'Content: Event'
 tags:
   canonical_url: '[node:url]'
-  dcterms_coverage: 'nciglobal,ncienterprise'
   dcterms_is_part_of: '[cgov_tokens:cgov-analytics-group]'
   dcterms_is_referenced_by: event1
   dcterms_issued: '[node:field_date_posted:date:html_date]'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/config/install/metatag.metatag_defaults.node__cgov_home_landing.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/config/install/metatag.metatag_defaults.node__cgov_home_landing.yml
@@ -6,7 +6,6 @@ label: 'Content: Home and Landing'
 tags:
   canonical_url: '[node:url]'
   cgdp_template: '[node:field_page_style:value]'
-  dcterms_coverage: 'nciglobal,ncienterprise'
   dcterms_is_part_of: '[cgov_tokens:cgov-analytics-group]'
   dcterms_is_referenced_by: event1
   dcterms_issued: '[node:field_date_posted:date:html_date]'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/config/install/metatag.metatag_defaults.node__cgov_mini_landing.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/config/install/metatag.metatag_defaults.node__cgov_mini_landing.yml
@@ -6,7 +6,6 @@ label: 'Content: Mini Landing Page'
 tags:
   canonical_url: '[node:url]'
   cgdp_template: '[node:field_mlp_page_style:value]'
-  dcterms_coverage: 'nciglobal,ncienterprise'
   dcterms_is_part_of: '[cgov_tokens:cgov-analytics-group]'
   dcterms_is_referenced_by: event1
   dcterms_issued: '[node:field_date_posted:date:html_date]'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_infographic/config/install/metatag.metatag_defaults.media__cgov_infographic.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_infographic/config/install/metatag.metatag_defaults.media__cgov_infographic.yml
@@ -6,7 +6,6 @@ label: 'Media: Infographic'
 tags:
   canonical_url: '[media:url]'
   cgdp_template: default
-  dcterms_coverage: 'nciglobal,ncienterprise'
   dcterms_is_part_of: '[cgov_tokens:cgov-analytics-group]'
   dcterms_subject: '[cgov_tokens:cgov-analytics-channel]'
   dcterms_type: cgvInfographic

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/metatag.metatag_defaults.node__cgov_press_release.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/config/install/metatag.metatag_defaults.node__cgov_press_release.yml
@@ -5,7 +5,6 @@ id: node__cgov_press_release
 label: 'Content: Press Release'
 tags:
   canonical_url: '[node:url]'
-  dcterms_coverage: 'nciglobal,ncienterprise'
   dcterms_is_part_of: '[cgov_tokens:cgov-analytics-group]'
   dcterms_is_referenced_by: event1
   dcterms_issued: '[node:field_date_posted:date:html_date]'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/metatag.metatag_defaults.media__cgov_video.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/metatag.metatag_defaults.media__cgov_video.yml
@@ -6,7 +6,6 @@ label: 'Media: Video'
 tags:
   canonical_url: '[media:url]'
   cgdp_template: default
-  dcterms_coverage: 'nciglobal,ncienterprise'
   dcterms_is_part_of: '[cgov_tokens:cgov-analytics-group]'
   dcterms_subject: '[cgov_tokens:cgov-analytics-channel]'
   dcterms_type: cgvVideo

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/metatag.metatag_defaults.node__cgov_video.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/config/install/metatag.metatag_defaults.node__cgov_video.yml
@@ -5,7 +5,6 @@ id: node__cgov_video
 label: 'Content: Video'
 tags:
   canonical_url: '[node:url]'
-  dcterms_coverage: 'nciglobal,ncienterprise'
   dcterms_is_part_of: '[cgov_tokens:cgov-analytics-group]'
   dcterms_is_referenced_by: event1
   dcterms_issued: '[node:field_date_posted:date:html_date]'

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/metatag.metatag_defaults.node__pdq_cancer_information_summary.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/metatag.metatag_defaults.node__pdq_cancer_information_summary.yml
@@ -7,7 +7,6 @@ tags:
   canonical_url: '[node:url]'
   cgdp_template: '[cgov_tokens:cgdp-field-pdq-is-svpc]'
   dcterms_audience: '[node:field_pdq_audience:value]'
-  dcterms_coverage: 'nciglobal,ncienterprise'
   dcterms_is_part_of: '[cgov_tokens:cgov-analytics-group]'
   dcterms_is_referenced_by: event1
   dcterms_issued: '[node:field_date_posted:date:html_date]'

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_drug_information_summary/config/install/metatag.metatag_defaults.node__pdq_drug_information_summary.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_drug_information_summary/config/install/metatag.metatag_defaults.node__pdq_drug_information_summary.yml
@@ -5,7 +5,6 @@ id: node__pdq_drug_information_summary
 label: 'Content: PDQ Drug Information Summary'
 tags:
   canonical_url: '[node:url]'
-  dcterms_coverage: 'nciglobal,ncienterprise'
   dcterms_is_part_of: '[cgov_tokens:cgov-analytics-group]'
   dcterms_is_referenced_by: event1
   dcterms_issued: '[node:field_date_posted:date:html_date]'


### PR DESCRIPTION
`dcterms.coverage `was used to control the Adobe Analytics report suite per page/site. That's no longer in use, so it's removed from the global and content-type metatag defaults.

Verified no existing PHPUnit or Cypress tests reference `dcterms_coverage/dcterms.coverage`

Closes #4817