### PR TITLE
(#5315) Bump core_version_requirement across all custom modules

### DIFF
--- a/docroot/modules/custom/app_module/app_module.info.yml
+++ b/docroot/modules/custom/app_module/app_module.info.yml
@@ -2,6 +2,6 @@ name: 'Application Module'
 type: module
 package: 'Application Support'
 description: 'Support for embedding applications on nodes and other routable entities'
-core_version_requirement: '^9.4 || ^10'
+core_version_requirement: '^10 || ^11'
 dependencies:
   - drupal:toolbar

--- a/docroot/modules/custom/app_module/tests/modules/app_module_test/app_module_test.info.yml
+++ b/docroot/modules/custom/app_module/tests/modules/app_module_test/app_module_test.info.yml
@@ -2,6 +2,6 @@ name: 'Application Module Tests'
 type: module
 package: Testing
 description: 'Testing for embedding applications on nodes and other routable entities'
-core_version_requirement: '^9.4 || ^10'
+core_version_requirement: '^10 || ^11'
 dependencies:
 - app_module

--- a/docroot/modules/custom/app_module/tests/modules/app_node_test/app_node_test.info.yml
+++ b/docroot/modules/custom/app_module/tests/modules/app_node_test/app_node_test.info.yml
@@ -2,7 +2,7 @@ name: 'Application Node Tests'
 type: module
 package: Testing
 description: 'Integration testing for app modules & nodes'
-core_version_requirement: '^9.4 || ^10'
+core_version_requirement: '^10 || ^11'
 dependencies:
   - app_module
   - datetime

--- a/docroot/modules/custom/cgov_adobe/cgov_adobe.info.yml
+++ b/docroot/modules/custom/cgov_adobe/cgov_adobe.info.yml
@@ -2,6 +2,6 @@ name: 'Application Module'
 type: module
 package: 'Application Support'
 description: 'Support for embedding applications on nodes and other routable entities'
-core_version_requirement: '^9.4 || ^10'
+core_version_requirement: '^10 || ^11'
 # dependencies:
 #  - drupal:toolbar

--- a/docroot/modules/custom/cgov_cts/cgov_cts.info.yml
+++ b/docroot/modules/custom/cgov_cts/cgov_cts.info.yml
@@ -2,7 +2,7 @@ name: 'CGov CTS'
 type: module
 package: 'CGov Digital Platform'
 description: 'Support for Clinical Trials Search in CGov'
-core_version_requirement: '^9.4 || ^10'
+core_version_requirement: '^10 || ^11'
 dependencies:
   - app_module
   - field

--- a/docroot/modules/custom/cgov_js_app_module/cgov_js_app_module.info.yml
+++ b/docroot/modules/custom/cgov_js_app_module/cgov_js_app_module.info.yml
@@ -2,7 +2,7 @@ name: 'CGov JS App Module'
 type: module
 package: 'CGov Digital Platform'
 description: 'Support for Hosting any JS-only App Module'
-core_version_requirement: '^9.4 || ^10'
+core_version_requirement: '^10 || ^11'
 dependencies:
   - app_module
   - field

--- a/docroot/modules/custom/cgov_r4r/cgov_r4r.info.yml
+++ b/docroot/modules/custom/cgov_r4r/cgov_r4r.info.yml
@@ -2,7 +2,7 @@ name: 'CGov R5R'
 type: module
 package: 'CGov Digital Platform'
 description: 'Support for R4R app in CGov'
-core_version_requirement: '^9.4 || ^10'
+core_version_requirement: '^10 || ^11'
 dependencies:
   - app_module
   - field

--- a/docroot/modules/custom/json_data_field/json_data_field.info.yml
+++ b/docroot/modules/custom/json_data_field/json_data_field.info.yml
@@ -2,4 +2,4 @@ name: 'JSON Data Field'
 type: module
 package: 'Application Support'
 description: 'Support for JSON Field for Storing and Validating Data'
-core_version_requirement: '^9.4 || ^10'
+core_version_requirement: '^10 || ^11'

--- a/docroot/modules/custom/nci_ckeditor5_cleanup/nci_ckeditor5_cleanup.info.yml
+++ b/docroot/modules/custom/nci_ckeditor5_cleanup/nci_ckeditor5_cleanup.info.yml
@@ -2,7 +2,7 @@ name: 'NCI CKeditor 5 Cleanup'
 type: module
 description: 'Adds options to further cleanup HTML allowed or pasted into unconstrained CKEditor5 fields'
 package: 'CGov Digital Platform'
-core_version_requirement: '^9.4 || ^10'
+core_version_requirement: '^10 || ^11'
 dependencies:
   - 'drupal:ckeditor5'
   - 'drupal:editor'

--- a/docroot/modules/custom/nci_ckeditor5_enhancements/nci_ckeditor5_enhancements.info.yml
+++ b/docroot/modules/custom/nci_ckeditor5_enhancements/nci_ckeditor5_enhancements.info.yml
@@ -1,7 +1,7 @@
 name: 'NCI CKEditor 5 Enhancements'
 type: module
 description: 'Provides a collection of small ckeditor5 plugins.'
-core_version_requirement: ^10
+core_version_requirement: ^10 || ^11
 package: 'CGov Digital Platform'
 dependencies:
   - 'drupal:ckeditor5'

--- a/docroot/modules/custom/nci_definition/nci_definition.info.yml
+++ b/docroot/modules/custom/nci_definition/nci_definition.info.yml
@@ -2,7 +2,7 @@ name: 'NCI Definition'
 type: module
 description: 'Service to identify candidate links to PDQ dictionaries'
 package: 'CGov Digital Platform'
-core_version_requirement: '^9.4 || ^10'
+core_version_requirement: '^10 || ^11'
 dependencies:
   - 'drupal:ckeditor5'
   - 'drupal:editor'

--- a/docroot/modules/custom/ncids_html_transformer/ncids_html_transformer.info.yml
+++ b/docroot/modules/custom/ncids_html_transformer/ncids_html_transformer.info.yml
@@ -2,6 +2,6 @@ name: 'NCIDS HTML Transformer'
 type: module
 package: 'CGov Digital Platform'
 description: 'The NCIDS HTML Transformer for migration'
-core_version_requirement: '^9.4 || ^10'
+core_version_requirement: '^10 || ^11'
 dependencies:
   - 'drupal:system'

--- a/docroot/profiles/custom/cgov_site/cgov_site.info.yml
+++ b/docroot/profiles/custom/cgov_site/cgov_site.info.yml
@@ -3,7 +3,7 @@ type: profile
 description: 'Minimal CGov site configuration.'
 package: 'CGov Digital Platform'
 version: 1.0.1
-core_version_requirement: '^9.4 || ^10'
+core_version_requirement: '^10 || ^11'
 install:
   # from Minimal
   - node

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_antivirus/cgov_antivirus.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_antivirus/cgov_antivirus.info.yml
@@ -2,6 +2,6 @@ name: 'CGov Antivirus'
 type: module
 package: 'CGov Digital Platform'
 description: 'Enables ClamAV virus scanning for file uploads on MEO environments.'
-core_version_requirement: '^10'
+core_version_requirement: '^10 || ^11'
 dependencies:
   - 'clamav:clamav'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_caching_cdn/cgov_caching_cdn.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_caching_cdn/cgov_caching_cdn.info.yml
@@ -2,7 +2,7 @@ name: 'CGov Caching with CDN'
 type: module
 package: 'CGov Digital Platform'
 description: 'Caching Module for ACSF Environments and ACE Environments protected by CDN'
-core_version_requirement: '^9.4 || ^10'
+core_version_requirement: '^10 || ^11'
 dependencies:
   - acquia_purge
   - akamai

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_caching_nocdn/cgov_caching_nocdn.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_caching_nocdn/cgov_caching_nocdn.info.yml
@@ -2,7 +2,7 @@ name: 'CGov Caching with no CDN'
 type: module
 package: 'CGov Digital Platform'
 description: 'Caching Module for ACE Environments when not protected by a CDN'
-core_version_requirement: '^9.4 || ^10'
+core_version_requirement: '^10 || ^11'
 dependencies:
   - acquia_purge
   - features

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_content_block/cgov_content_block.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_content_block/cgov_content_block.info.yml
@@ -2,7 +2,7 @@ name: 'CGov Content Block'
 type: module
 package: 'CGov Digital Platform'
 description: 'The Content Block content type'
-core_version_requirement: '^9.4 || ^10'
+core_version_requirement: '^10 || ^11'
 dependencies:
   - 'features:features'
   - 'cgov_core:cgov_core'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_embedded_block/cgov_embedded_block.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_embedded_block/cgov_embedded_block.info.yml
@@ -2,7 +2,7 @@ name: 'CGov Embedded Block'
 type: module
 package: 'CGov Digital Platform'
 description: 'Embeddable block content support'
-core_version_requirement: '^9.4 || ^10'
+core_version_requirement: '^10 || ^11'
 dependencies:
   - 'features:features'
   - 'cgov_content_block:cgov_content_block'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_external_link_block/cgov_external_link_block.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_external_link_block/cgov_external_link_block.info.yml
@@ -2,7 +2,7 @@ name: 'CGov External Link Block'
 type: module
 package: 'CGov Digital Platform'
 description: 'Allows External Links to be featured in content'
-core_version_requirement: '^9.4 || ^10'
+core_version_requirement: '^10 || ^11'
 dependencies:
   - 'features:features'
   - 'cgov_content_block:cgov_content_block'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_https_config/cgov_https_config.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_https_config/cgov_https_config.info.yml
@@ -2,7 +2,7 @@ name: 'CGov HTTPS Enforcement Configuration'
 type: module
 package: 'CGov HTTPS Enforcement Configuration'
 description: 'Configures enforcement of HTTPS'
-core_version_requirement: '^9.4 || ^10'
+core_version_requirement: '^10 || ^11'
 dependencies:
   - 'features:features'
   - seckit

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_image/cgov_image.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_image/cgov_image.info.yml
@@ -2,7 +2,7 @@ name: 'CGov Image'
 type: module
 package: 'CGov Digital Platform'
 description: 'CGov Image Media Type'
-core_version_requirement: '^9.4 || ^10'
+core_version_requirement: '^10 || ^11'
 dependencies:
   - 'features:features'
   - 'cgov_core:cgov_core'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_list/cgov_list.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_list/cgov_list.info.yml
@@ -2,7 +2,7 @@ name: 'CGov Lists'
 type: module
 package: 'CGov Digital Platform'
 description: 'CGov Core List Components used by most content types for content listings.'
-core_version_requirement: '^9.4 || ^10'
+core_version_requirement: '^10 || ^11'
 dependencies:
   - 'features:features'
   - 'cgov_core:cgov_core'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_mail/cgov_mail.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_mail/cgov_mail.info.yml
@@ -1,6 +1,6 @@
 name: 'Cgov Mail'
 type: module
 description: 'Mail backend and configuration for Cancer.gov'
-core_version_requirement: '^9.4 || ^10'
+core_version_requirement: '^10 || ^11'
 package: 'CGov Digital Platform'
 configure: cgov_mail.email_settings.form

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_metatag/cgov_metatag.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_metatag/cgov_metatag.info.yml
@@ -2,5 +2,5 @@ name: 'Cgov Metatag'
 type: module
 description: 'Cancer.gov Metatag module.'
 package: 'CGov Digital Platform'
-core_version_requirement: '^9.4 || ^10'
+core_version_requirement: '^10 || ^11'
 hidden: false

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_redirect_manager/cgov_redirect_manager.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_redirect_manager/cgov_redirect_manager.info.yml
@@ -1,6 +1,6 @@
 name: CGov Redirect Manager
 type: module
 description: Manages redirects for the CGov Platform.
-core_version_requirement: '^9.4 || ^10'
+core_version_requirement: '^10 || ^11'
 dependencies:
   - redirect

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_saml_auth_config/cgov_saml_auth_config.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_saml_auth_config/cgov_saml_auth_config.info.yml
@@ -2,7 +2,7 @@ name: 'CGov Single Sign-on Configuration'
 type: module
 package: 'CGov Single Sign-on Configuration'
 description: 'Configures SAML Auth Settings'
-core_version_requirement: '^9.4 || ^10'
+core_version_requirement: '^10 || ^11'
 dependencies:
   - 'features:features'
   - 'autologout:autologout'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_schema_org/cgov_schema_org.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_schema_org/cgov_schema_org.info.yml
@@ -2,7 +2,7 @@ name: 'Schema.org Implementation'
 type: module
 package: 'CGov Digital Platform'
 description: 'Support for schema.org markup in NCI content'
-core_version_requirement: '^9.4 || ^10'
+core_version_requirement: '^10 || ^11'
 dependencies:
   - 'features:features'
   - cgov_schema_org

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_site_section/cgov_site_section.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_site_section/cgov_site_section.info.yml
@@ -2,7 +2,7 @@ name: 'CGov Site Sections'
 type: module
 description: 'Cancer.gov Site Section module.'
 package: 'CGov Digital Platform'
-core_version_requirement: '^9.4 || ^10'
+core_version_requirement: '^10 || ^11'
 dependencies:
   - 'features:features'
   - 'cgov_content_block:cgov_content_block'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_syndication/cgov_syndication.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_syndication/cgov_syndication.info.yml
@@ -2,7 +2,7 @@ name: 'HHS Syndication of NCI content'
 type: module
 package: 'CGov Digital Platform'
 description: 'Support for exporting NCI content via HHS Syndication'
-core_version_requirement: '^9.4 || ^10'
+core_version_requirement: '^10 || ^11'
 dependencies:
   - 'features:features'
   - cgov_syndication

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_syslog/cgov_syslog.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_syslog/cgov_syslog.info.yml
@@ -2,6 +2,6 @@ name: 'CGov Syslog configuration.'
 type: module
 package: 'CGov Syslog configuration.'
 description: 'CGov specific settings for the Syslog module.'
-core_version_requirement: ^9.4 || ^10
+core_version_requirement: ^10 || ^11
 dependencies:
   - syslog

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_vocab_manager/cgov_vocab_manager.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_vocab_manager/cgov_vocab_manager.info.yml
@@ -2,4 +2,4 @@ type: module
 name: CGov Vocab Manager
 description: 'Various improvements on Vocab Management UI.'
 package: Taxonomy
-core_version_requirement: '^9.4 || ^10'
+core_version_requirement: '^10 || ^11'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/cgov_yaml_content.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/cgov_yaml_content.info.yml
@@ -2,7 +2,7 @@ name: 'Cgov YAML Content '
 type: module
 package: 'Cgov Digital Platform'
 description: 'Cgov YAML content importer '
-core_version_requirement: '^9.4 || ^10'
+core_version_requirement: '^10 || ^11'
 dependencies:
   - yaml_content
   - cgov_core

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_core/pdq_core.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_core/pdq_core.info.yml
@@ -2,7 +2,7 @@ name: 'PDQ Core'
 type: module
 description: 'Common tools used by the imported PDQ content'
 package: 'CGov Digital Platform'
-core_version_requirement: '^9.4 || ^10'
+core_version_requirement: '^10 || ^11'
 dependencies:
   - 'features:features'
   - basic_auth

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_glossifier/pdq_glossifier.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_glossifier/pdq_glossifier.info.yml
@@ -2,7 +2,7 @@ name: 'PDQ Glossifier'
 type: module
 description: 'Service to identify candidate links to PDQ dictionaries'
 package: 'CGov Digital Platform'
-core_version_requirement: '^9.4 || ^10'
+core_version_requirement: '^10 || ^11'
 dependencies:
   - 'features:features'
   - 'drupal:basic_auth'

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov_admin/cgov_admin.info.yml
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov_admin/cgov_admin.info.yml
@@ -3,7 +3,7 @@ description: 'CGov Admin Theme'
 type: theme
 base theme: claro
 package: CGov Digital Platform
-core_version_requirement: '^9.4 || ^10'
+core_version_requirement: '^10 || ^11'
 libraries:
   - cgov_admin/global-styling
 

--- a/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/ncids_trans.info.yml
+++ b/docroot/profiles/custom/cgov_site/themes/custom/ncids_trans/ncids_trans.info.yml
@@ -2,7 +2,7 @@ name: NCIDS Transitional Theme
 type: theme
 description: 'Cgov Digital Platform theme for incremental NCIDS rollout'
 package: CGov Digital Platform
-core_version_requirement: '^9.4 || ^10'
+core_version_requirement: '^10 || ^11'
 base theme: stark
 ## NOTE: Our Theme has no Global Libraries. See the various page templates.
 ckeditor5-stylesheets:


### PR DESCRIPTION
`drush features:export` automatically rewrites `core_version_requirement` from `^9.4 || ^10` to `^10 || ^11` based on the installed core version, which was showing up as incidental noise in unrelated feature-export PRs. This consolidates the remaining `^9.4 || ^10` declarations into one dedicated commit.

Closes #5315