### PR TITLE
(#4447) Fix Spanish media images linking to broken /espanol/ URL

### DIFF
--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_image/src/Plugin/PathProcessor/ImageRedirectProcessor.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_image/src/Plugin/PathProcessor/ImageRedirectProcessor.php
@@ -82,7 +82,7 @@ class ImageRedirectProcessor implements OutboundPathProcessorInterface {
       return $this->getEditingPath($entity);
     }
     else {
-      return $this->getEntityFilepath($entity);
+      return $this->getEntityFilepath($entity, $options);
     }
 
   }
@@ -92,13 +92,17 @@ class ImageRedirectProcessor implements OutboundPathProcessorInterface {
    *
    * @param mixed $entity
    *   The media item to find the path of.
+   * @param array $options
+   *   The path options, passed by reference so that overriding the
+   *   language here also affects the outbound path processors that run
+   *   after this one (e.g. the language path processor's /espanol prefix).
    *
    * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
    *
    * @return string
    *   The path to where the physical file is located.
    */
-  private function getEntityFilepath($entity) {
+  private function getEntityFilepath($entity, array &$options) {
     // We don't want '/espanol' getting tacked on
     // to a file path. We'll create a language object for
     // english to prevent any language processors using


### PR DESCRIPTION
The code was trying to force the file path to English so it would not get an `/espanol/` prefix, but it was setting that on a local variable instead of the $options array Drupal actually uses, so it never took effect. Passing $options through by reference fixes it.

Closes #4447